### PR TITLE
ODC-7412: Fix e2e failues by having at least one working cypress test example

### DIFF
--- a/integration-tests/cypress.config.js
+++ b/integration-tests/cypress.config.js
@@ -11,7 +11,7 @@ module.exports = defineConfig({
     configFile: 'reporter-config.json',
   },
   fixturesFolder: 'fixtures',
-  defaultCommandTimeout: 30000,
+  defaultCommandTimeout: 5000,
   retries: {
     runMode: 1,
     openMode: 0,

--- a/integration-tests/tests/example.cy.ts
+++ b/integration-tests/tests/example.cy.ts
@@ -1,0 +1,28 @@
+import { checkErrors } from '../support';
+
+export const isLocalDevEnvironment =
+  Cypress.config('baseUrl').includes('localhost');
+
+describe('example', () => {
+  before(() => {
+    if (!isLocalDevEnvironment) {
+      cy.login();
+    }
+  });
+
+  afterEach(() => {
+    checkErrors();
+  });
+
+  after(() => {
+    if (!isLocalDevEnvironment) {
+      cy.logout();
+    }
+  });
+
+  it('Verify the example page title', () => {
+    cy.visit(`/`);
+    // For now, just check that the perspective switcher is visible
+    cy.get('[data-test-id="perspective-switcher-toggle"]').click();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "i18n": "./i18n-scripts/build-i18n.sh && node ./i18n-scripts/set-english-defaults.js",
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'",
     "lint": "eslint ./src ./integration-tests --fix &&  stylelint \"src/**/*.css\" --allow-empty-input --fix",
-    "test-cypress": "cd integration-tests s && cypress open --env openshift=true",
+    "test-cypress": "cd integration-tests && cypress open --env openshift=true",
     "test-cypress-headless": "cd integration-tests && node --max-old-space-size=4096 ../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome}",
     "cypress-merge": "mochawesome-merge ./integration-tests/screenshots/cypress_report*.json > ./integration-tests/screenshots/cypress.json",
     "cypress-generate": "marge -o ./integration-tests/screenshots/ -f cypress-report -t 'OpenShift Console Plugin Template Cypress Test Results' -p 'OpenShift Cypress Plugin Template Test Results' --showPassed false --assetsDir ./integration-tests/screenshots/cypress/assets ./integration-tests/screenshots/cypress.json",


### PR DESCRIPTION
Created one minimal cypress test (based on https://github.com/openshift/console-plugin-template/blob/main/integration-tests/tests/example-page.cy.ts), otherwise `yarn test-cypress-headless` fails with:

```
yarn run v1.22.19
$ cd integration-tests && node --max-old-space-size=4096 ../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome}

Can't run because no spec files were found.

We searched for specs matching this glob pattern:

  > /home/christoph/git/openshift-pipelines/console-plugin/integration-tests/tests/**/*.cy.{js,jsx,ts,tsx}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```