### PR TITLE
ODC-7462: Hide standalone PipelineRuns by req. spec.pipelineRef.name for Pipeline PLRs

### DIFF
--- a/src/components/pipelines-overview/PipelineRunsTotalCard.tsx
+++ b/src/components/pipelines-overview/PipelineRunsTotalCard.tsx
@@ -67,25 +67,25 @@ const PipelinesRunsTotalCard: React.FC<PipelinesRunsDurationProps> = ({
       });
   };
 
-  const filter = `data.metadata.labels.contains("pipelinesascode.tekton.dev/repository")&&data.status.startTime>timestamp("${date}")`;
+  const pipelineFilter = `data.spec.pipelineRef.contains("name") && data.status.startTime>timestamp("${date}")`;
   useInterval(
-    () => getSummaryData(filter, setRepoRun),
+    () => getSummaryData(pipelineFilter, setPlrRun),
     interval,
     namespace,
     date,
   );
 
-  const filter2 = `!data.metadata.labels.contains("pipelinesascode.tekton.dev/repository")&&data.status.startTime>timestamp("${date}")`;
+  const pacFilter = `data.metadata.labels.contains("pipelinesascode.tekton.dev/repository") && data.status.startTime>timestamp("${date}")`;
   useInterval(
-    () => getSummaryData(filter2, setPlrRun),
+    () => getSummaryData(pacFilter, setRepoRun),
     interval,
     namespace,
     date,
   );
 
-  const filter3 = `data.status.startTime>timestamp("${date}")`;
+  const allFilter = `data.status.startTime>timestamp("${date}")`;
   useInterval(
-    () => getSummaryData(filter3, setTotalRun),
+    () => getSummaryData(allFilter, setTotalRun),
     interval,
     namespace,
     date,

--- a/src/components/pipelines-overview/list-pages/PipelineRunsListPage.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsListPage.tsx
@@ -52,13 +52,13 @@ const PipelineRunsListPage: React.FC<PipelineRunsForPipelinesListProps> = ({
             summary: 'total_duration,avg_duration,total,succeeded,last_runtime',
             data_type: DataType.PipelineRun,
             groupBy: 'pipeline',
-            filter: `data.status.startTime>timestamp("${date}")&&!data.metadata.labels.contains('pipelinesascode.tekton.dev/repository')`,
+            filter: `data.status.startTime>timestamp("${date}") && data.spec.pipelineRef.contains("name")`,
           }
         : {
             summary: 'total_duration,avg_duration,total,succeeded,last_runtime',
             data_type: DataType.PipelineRun,
             groupBy: 'repository',
-            filter: `data.status.startTime>timestamp("${date}")&&data.metadata.labels.contains('pipelinesascode.tekton.dev/repository')`,
+            filter: `data.status.startTime>timestamp("${date}") && data.metadata.labels.contains('pipelinesascode.tekton.dev/repository')`,
           },
     )
       .then((response) => {

--- a/src/components/pipelines-overview/utils.ts
+++ b/src/components/pipelines-overview/utils.ts
@@ -205,15 +205,24 @@ export const useInterval = (
 };
 
 export const getFilter = (date, parentName, kind): string => {
-  let filter = `data.status.startTime>timestamp("${date}")`;
-  if (parentName) {
-    if (kind === 'Repository') {
-      filter = `data.status.startTime>timestamp("${date}")&&data.metadata.labels['pipelinesascode.tekton.dev/repository']=="${parentName}"`;
-    } else {
-      filter = `data.status.startTime>timestamp("${date}")&&!data.metadata.labels.contains('pipelinesascode.tekton.dev/repository')&&data.metadata.labels['tekton.dev/pipeline']=="${parentName}"`;
-    }
-  } else {
-    filter = `data.status.startTime>timestamp("${date}")`;
+  const filter = [`data.status.startTime>timestamp("${date}")`];
+  if (kind === 'Pipeline') {
+    filter.push(`data.spec.pipelineRef.contains("name")`);
+  } else if (kind === 'Repository') {
+    filter.push(
+      `data.metadata.labels.contains('pipelinesascode.tekton.dev/repository')`,
+    );
   }
-  return filter;
+  if (parentName) {
+    if (kind === 'Pipeline') {
+      filter.push(
+        `data.metadata.labels['tekton.dev/pipeline']=="${parentName}"`,
+      );
+    } else if (kind === 'Repository') {
+      filter.push(
+        `data.metadata.labels['pipelinesascode.tekton.dev/repository']=="${parentName}"`,
+      );
+    }
+  }
+  return filter.join(' && ');
 };


### PR DESCRIPTION
This ignores change to the filter ignores PipelineRuns that are started individually.

Solves also a bug that the PipelineRun name was used as Pipeline name in the Pipeline list page. But the click on the Pipeline shows 404.

**Demo PipelineRun:**

```yaml
apiVersion: tekton.dev/v1
kind: PipelineRun
metadata:
  generateName: independent-pipeline-
spec:
  params:
    - name: NAME
      value: world
  pipelineSpec:
    tasks:
      - name: echo-hello
        taskSpec:
          metadata: {}
          spec: null
          steps:
            - computeResources: {}
              image: ubuntu
              name: echo
              script: |
                #!/usr/bin/env bash
                echo "Hello"
      - name: echo-name
        runAfter:
          - echo-hello
        taskSpec:
          metadata: {}
          spec: null
          steps:
            - computeResources: {}
              image: ubuntu
              name: echo
              script: |
                #!/usr/bin/env bash
                echo "$(params.NAME)"
      - name: echo-bye
        taskSpec:
          metadata: {}
          spec: null
          steps:
            - computeResources: {}
              image: ubuntu
              name: echo
              script: |
                #!/usr/bin/env bash
                sleep 3
                echo "Goodbye!"
  taskRunTemplate:
    serviceAccountName: pipeline
  timeouts:
    pipeline: 1h0m0s
```


**Without this PR:**

![image](https://github.com/openshift-pipelines/console-plugin/assets/139310/23dd3281-697c-4335-9fa8-258ebf2fdf83)

**With this PR:**

![image](https://github.com/openshift-pipelines/console-plugin/assets/139310/b7bb025b-b34b-48db-ad59-5e38c409086f)
