### PR TITLE
fix: For 1st plr show - for last runtime until it is completed

### DIFF
--- a/src/components/pipelines-overview/dateTime.ts
+++ b/src/components/pipelines-overview/dateTime.ts
@@ -98,29 +98,32 @@ export const formatTime = (time: string): string => {
 };
 
 export const formatTimeLastRunTime = (time: number): string => {
+  if (!time) {
+    return '-';
+  }
   const currentTimestamp = Math.floor(Date.now() / 1000); // Current timestamp in seconds
-    const timeDifference = currentTimestamp - time;
+  const timeDifference = currentTimestamp - time;
 
-    // Convert the time difference into seconds, minutes, hours, etc.
-    const minutes = Math.floor(timeDifference / 60);
-    const hours = Math.floor(minutes / 60);
-    const days = Math.floor(hours / 24);
-    const months = Math.floor(days / 30); // Approximate months (30 days)
-    const years = Math.floor(months / 12); // Approximate years (12 months)
+  // Convert the time difference into seconds, minutes, hours, etc.
+  const minutes = Math.floor(timeDifference / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  const months = Math.floor(days / 30); // Approximate months (30 days)
+  const years = Math.floor(months / 12); // Approximate years (12 months)
 
-    // Determine the output based on the time difference
-    if (years > 0) {
-        return `${years} year${years > 1 ? 's' : ''} ago`;
-    } else if (months > 0) {
-        return `${months} month${months > 1 ? 's' : ''} ago`;
-    } else if (days > 0) {
-        return `${days} day${days > 1 ? 's' : ''} ago`;
-    } else if (hours > 0) {
-        return `${hours} hour${hours > 1 ? 's' : ''} ago`;
-    } else if (minutes > 0) {
-        return `${minutes} minute${minutes > 1 ? 's' : ''} ago`;
-    } else {
-      return `${timeDifference} second${timeDifference !== 1 ? 's' : ''} ago`;
+  // Determine the output based on the time difference
+  if (years > 0) {
+    return `${years} year${years > 1 ? 's' : ''} ago`;
+  } else if (months > 0) {
+    return `${months} month${months > 1 ? 's' : ''} ago`;
+  } else if (days > 0) {
+    return `${days} day${days > 1 ? 's' : ''} ago`;
+  } else if (hours > 0) {
+    return `${hours} hour${hours > 1 ? 's' : ''} ago`;
+  } else if (minutes > 0) {
+    return `${minutes} minute${minutes > 1 ? 's' : ''} ago`;
+  } else {
+    return `${timeDifference} second${timeDifference !== 1 ? 's' : ''} ago`;
   }
 };
 


### PR DESCRIPTION
Description:

If it is 1st PLR for pipeline and repository, last run time will be shown as '-'. From API last run time is passed as completed timestamp, so show '-' till it gets completed