### PR TITLE
ODC-7468: Add URL params for all filters available on the Pipeline Overview page

### DIFF
--- a/src/components/pipelines-metrics/PipelinesMetricsPage.tsx
+++ b/src/components/pipelines-metrics/PipelinesMetricsPage.tsx
@@ -4,12 +4,20 @@ import PipelineRunsStatusCard from '../pipelines-overview/PipelineRunsStatusCard
 import { Flex, FlexItem } from '@patternfly/react-core';
 import PipelinesRunsDurationCard from '../pipelines-overview/PipelineRunsDurationCard';
 import PipelinesRunsNumbersChart from '../pipelines-overview/PipelineRunsNumbersChart';
-import { parsePrometheusDuration } from '../pipelines-overview/dateTime';
+import {
+  formatPrometheusDuration,
+  parsePrometheusDuration,
+} from '../pipelines-overview/dateTime';
 import TimeRangeDropdown from '../pipelines-overview/TimeRangeDropdown';
 import RefreshDropdown from '../pipelines-overview/RefreshDropdown';
 import PipelinesAverageDuration from './PipelinesAverageDuration';
 import { K8sResourceKind } from '@openshift-console/dynamic-plugin-sdk';
 import './PipelinesMetrics.scss';
+import {
+  IntervalOptions,
+  TimeRangeOptions,
+  useQueryParams,
+} from '../pipelines-overview/utils';
 
 type PipelinesMetricsPageProps = {
   obj: K8sResourceKind;
@@ -22,6 +30,26 @@ const PipelinesMetricsPage: React.FC<PipelinesMetricsPageProps> = ({ obj }) => {
   const [interval, setInterval] = React.useState(
     parsePrometheusDuration('30s'),
   );
+
+  useQueryParams({
+    key: 'refreshinterval',
+    value: interval,
+    setValue: setInterval,
+    defaultValue: parsePrometheusDuration('30s'),
+    options: { ...IntervalOptions(), off: 'OFF_KEY' },
+    displayFormat: (v) => (v ? formatPrometheusDuration(v) : 'off'),
+    loadFormat: (v) => (v == 'off' ? null : parsePrometheusDuration(v)),
+  });
+
+  useQueryParams({
+    key: 'timerange',
+    value: timespan,
+    setValue: setTimespan,
+    defaultValue: parsePrometheusDuration('1w'),
+    options: TimeRangeOptions(),
+    displayFormat: formatPrometheusDuration,
+    loadFormat: parsePrometheusDuration,
+  });
 
   return (
     <>

--- a/src/components/pipelines-overview/PipelinesOverviewPage.tsx
+++ b/src/components/pipelines-overview/PipelinesOverviewPage.tsx
@@ -5,12 +5,13 @@ import { Flex, FlexItem } from '@patternfly/react-core';
 import PipelinesRunsDurationCard from './PipelineRunsDurationCard';
 import PipelinesRunsTotalCard from './PipelineRunsTotalCard';
 import PipelinesRunsNumbersChart from './PipelineRunsNumbersChart';
-import { parsePrometheusDuration } from './dateTime';
+import { formatPrometheusDuration, parsePrometheusDuration } from './dateTime';
 import NameSpaceDropdown from './NamespaceDropdown';
 import PipelineRunsListPage from './list-pages/PipelineRunsListPage';
 import TimeRangeDropdown from './TimeRangeDropdown';
 import RefreshDropdown from './RefreshDropdown';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import { IntervalOptions, TimeRangeOptions, useQueryParams } from './utils';
 
 const PipelinesOverviewPage: React.FC = () => {
   const { t } = useTranslation('plugin__pipeline-console-plugin');
@@ -25,6 +26,26 @@ const PipelinesOverviewPage: React.FC = () => {
   React.useEffect(() => {
     setActiveNamespace(namespace);
   }, [namespace]);
+
+  useQueryParams({
+    key: 'refreshinterval',
+    value: interval,
+    setValue: setInterval,
+    defaultValue: parsePrometheusDuration('30s'),
+    options: { ...IntervalOptions(), off: 'OFF_KEY' },
+    displayFormat: (v) => (v ? formatPrometheusDuration(v) : 'off'),
+    loadFormat: (v) => (v == 'off' ? null : parsePrometheusDuration(v)),
+  });
+
+  useQueryParams({
+    key: 'timerange',
+    value: timespan,
+    setValue: setTimespan,
+    defaultValue: parsePrometheusDuration('1w'),
+    options: TimeRangeOptions(),
+    displayFormat: formatPrometheusDuration,
+    loadFormat: parsePrometheusDuration,
+  });
 
   return (
     <>

--- a/src/components/pipelines-overview/RefreshIntervalDropdown.tsx
+++ b/src/components/pipelines-overview/RefreshIntervalDropdown.tsx
@@ -1,8 +1,7 @@
 import * as _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { Dropdown, DropdownToggle, DropdownItem } from '@patternfly/react-core';
-import { useBoolean } from './utils';
+import { IntervalOptions, useBoolean } from './utils';
 import { formatPrometheusDuration, parsePrometheusDuration } from './dateTime';
 
 import './PipelinesOverview.scss';
@@ -17,26 +16,13 @@ type Props = {
 
 const IntervalDropdown: React.FC<Props> = ({ id, interval, setInterval }) => {
   const [isOpen, toggleIsOpen, , setClosed] = useBoolean(false);
-  const { t } = useTranslation('plugin__pipeline-console-plugin');
+  const intervalOptions = IntervalOptions();
 
   const onChange = React.useCallback(
     (v: string) =>
       setInterval(v === OFF_KEY ? null : parsePrometheusDuration(v)),
     [setInterval],
   );
-
-  const intervalOptions = {
-    [OFF_KEY]: t('Refresh off'),
-    '15s': t('{{count}} second', { count: 15 }),
-    '30s': t('{{count}} second', { count: 30 }),
-    '1m': t('{{count}} minute', { count: 1 }),
-    '5m': t('{{count}} minute', { count: 5 }),
-    '15m': t('{{count}} minute', { count: 15 }),
-    '30m': t('{{count}} minute', { count: 30 }),
-    '1h': t('{{count}} hour', { count: 1 }),
-    '2h': t('{{count}} hour', { count: 2 }),
-    '1d': t('{{count}} day', { count: 1 }),
-  };
 
   const selectedKey =
     interval === null ? OFF_KEY : formatPrometheusDuration(interval);

--- a/src/components/pipelines-overview/SearchInput.tsx
+++ b/src/components/pipelines-overview/SearchInput.tsx
@@ -5,15 +5,18 @@ import { useTranslation } from 'react-i18next';
 type SearchInputProps = {
   pageFlag: number;
   handleNameChange: (searchKeyword: string) => void;
+  searchText: string;
 };
 
 const SearchInputField: React.FC<SearchInputProps> = ({
   pageFlag,
   handleNameChange,
+  searchText,
 }) => {
   const { t } = useTranslation('plugin__pipeline-console-plugin');
   return (
     <SearchInput
+      value={searchText}
       className="pipeline-overview__search-input"
       placeholder={
         pageFlag === 1

--- a/src/components/pipelines-overview/__tests__/PipelinesOverview.spec.tsx
+++ b/src/components/pipelines-overview/__tests__/PipelinesOverview.spec.tsx
@@ -8,6 +8,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import PipelinesOverviewPage from '../PipelinesOverviewPage';
 import { getResultsSummary } from '../../utils/summary-api';
+import * as utils from '../utils';
 
 const virtualizedTableRenderProps = jest.fn();
 const setActiveNamespace = jest.fn();
@@ -28,6 +29,8 @@ jest.mock('../../utils/summary-api', () => ({
   virtualizedTableRenderProps(props);
   return null;
 });
+
+jest.spyOn(utils, 'useQueryParams').mockReturnValue(null);
 
 const virtualizedTableMock = VirtualizedTable as jest.Mock;
 const useActiveNamespaceMock = useActiveNamespace as jest.Mock;

--- a/src/components/pipelines-overview/list-pages/PipelineRunsListPage.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsListPage.tsx
@@ -12,7 +12,7 @@ import {
 import PipelineRunsForRepositoriesList from './PipelineRunsForRepositoriesList';
 import PipelineRunsForPipelinesList from './PipelineRunsForPipelinesList';
 import SearchInputField from '../SearchInput';
-import { SummaryProps, useInterval } from '../utils';
+import { SummaryProps, useInterval, useQueryParams } from '../utils';
 import { getResultsSummary } from '../../../components/utils/summary-api';
 import { DataType } from '../../../components/utils/tekton-results';
 import { getDropDownDate } from '../dateTime';
@@ -35,6 +35,7 @@ const PipelineRunsListPage: React.FC<PipelineRunsListPageProps> = ({
   const [pageFlag, setPageFlag] = React.useState(1);
   const [loaded, setloaded] = React.useState(false);
   const [summaryData, setSummaryData] = React.useState<SummaryProps[]>([]);
+  const [searchText, setSearchText] = React.useState('');
   const [summaryDataFiltered, setSummaryDataFiltered] = React.useState<
     SummaryProps[]
   >([]);
@@ -78,6 +79,23 @@ const PipelineRunsListPage: React.FC<PipelineRunsListPageProps> = ({
     setSummaryDataFiltered([]);
   }, [namespace, timespan]);
 
+  useQueryParams({
+    key: 'search',
+    value: searchText,
+    setValue: setSearchText,
+    defaultValue: '',
+  });
+
+  useQueryParams({
+    key: 'list',
+    value: pageFlag,
+    setValue: setPageFlag,
+    defaultValue: 1,
+    options: { perpipeline: 1, perrepository: 2 },
+    displayFormat: (v) => (v == 1 ? 'perpipeline' : 'perrepository'),
+    loadFormat: (v) => (v == 'perrepository' ? 2 : 1),
+  });
+
   const handlePageChange = (pageNumber: number) => {
     setloaded(false);
     setSummaryData([]);
@@ -85,6 +103,7 @@ const PipelineRunsListPage: React.FC<PipelineRunsListPageProps> = ({
     setPageFlag(pageNumber);
   };
   const handleNameChange = (value: string) => {
+    setSearchText(value);
     const filteredData = summaryData.filter((summary) =>
       summary.group_value
         .split('/')[1]
@@ -105,6 +124,7 @@ const PipelineRunsListPage: React.FC<PipelineRunsListPageProps> = ({
             {/* Lastrun Status is not provided by API  */}
             {/* <StatusDropdown /> */}
             <SearchInputField
+              searchText={searchText}
               pageFlag={pageFlag}
               handleNameChange={handleNameChange}
             />


### PR DESCRIPTION
Added support for url params for filters mentioned in the [story](https://issues.redhat.com/browse/ODC-7468) i.e.
- added URL params on Time Range selection
- added URL params on Refresh interval selection
- added URL params on searching the Pipeline/Repository in the list
- added URL params on Per Pipeline/Per Repository selection 
- updated the filters based on params present in the URL.

WIP PR
Todo:
- add URL params on Filter by status in the list
- check issue with loading interval & range with search & pageFlag