### PR TITLE
OCPBUGS-28721: Enable metrics tab flag if TektonResults CR is present

### DIFF
--- a/src/components/hooks/flagHookProvider.ts
+++ b/src/components/hooks/flagHookProvider.ts
@@ -36,10 +36,6 @@ import {
 import { TektonResultModel } from '../../models';
 
 export const useFlagHookProvider = (setFeatureFlag: SetFeatureFlag) => {
-  setFeatureFlag(
-    FLAG_HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_DETAIL_METRICS_TAB,
-    true,
-  );
   setFeatureFlag(FLAG_HIDE_STATIC_PIPELINE_PLUGIN_PIPELINES_NAV_OPTION, false);
   setFeatureFlag(FLAG_HIDE_STATIC_PIPELINE_PLUGIN_TASKS_NAV_OPTION, false);
   setFeatureFlag(FLAG_HIDE_STATIC_PIPELINE_PLUGIN_TRIGGERS_NAV_OPTION, false);
@@ -98,4 +94,8 @@ export const useTektonResultInstallProvider = (
     fetch();
   }, []);
   setFeatureFlag(FLAG_PIPELINE_TEKTON_RESULT_INSTALLED, data ? true : false);
+  setFeatureFlag(
+    FLAG_HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_DETAIL_METRICS_TAB,
+    data ? true : false,
+  );
 };


### PR DESCRIPTION
Fix: [OCPBUGS-28721](https://issues.redhat.com/browse/OCPBUGS-28721)

Descriptions: Metrics tab on the Pipeline details page is not present if the Dynamic plugin is enabled but TektonResult CR is not present on the cluster. So, enable the `FLAG_HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_DETAIL_METRICS_TAB` flag only if TektonResults CR is present on the cluster.