### PR TITLE
ODC-7470: fix logic for quarterly week grouping

### DIFF
--- a/src/components/pipelines-metrics/PipelinesAverageDuration.tsx
+++ b/src/components/pipelines-metrics/PipelinesAverageDuration.tsx
@@ -48,17 +48,11 @@ const getChartData = (
       if (type == 'hour') {
         return new Date(d.group_value * 1000).getHours() === value;
       }
-      if (type == 'day') {
+      if (type == 'day' || type == 'week') {
         return (
           new Date(d.group_value * 1000).toDateString() ===
           new Date(value).toDateString()
         );
-      }
-      if (type == 'week') {
-        const wDate = new Date(d.group_value * 1000);
-        const weekend = new Date(value);
-        weekend.setDate(weekend.getDate() + 6);
-        return wDate >= new Date(value) && wDate <= weekend;
       }
       if (type == 'month') {
         return new Date(d.group_value * 1000).getMonth() === value.getMonth();

--- a/src/components/pipelines-overview/PipelineRunsNumbersChart.tsx
+++ b/src/components/pipelines-overview/PipelineRunsNumbersChart.tsx
@@ -48,17 +48,11 @@ const getChartData = (
       if (type == 'hour') {
         return new Date(d.group_value * 1000).getHours() === value;
       }
-      if (type == 'day') {
+      if (type == 'day' || type == 'week') {
         return (
           new Date(d.group_value * 1000).toDateString() ===
           new Date(value).toDateString()
         );
-      }
-      if (type == 'week') {
-        const wDate = new Date(d.group_value * 1000);
-        const weekend = new Date(value);
-        weekend.setDate(weekend.getDate() + 6);
-        return wDate >= new Date(value) && wDate <= weekend;
       }
       if (type == 'month') {
         return new Date(d.group_value * 1000).getMonth() === value.getMonth();

--- a/src/components/pipelines-overview/PipelineRunsStatusCard.tsx
+++ b/src/components/pipelines-overview/PipelineRunsStatusCard.tsx
@@ -69,17 +69,11 @@ const getChartData = (
       if (type == 'hour') {
         return new Date(d.group_value * 1000).getHours() === value;
       }
-      if (type == 'day') {
+      if (type == 'day' || type == 'week') {
         return (
           new Date(d.group_value * 1000).toDateString() ===
           new Date(value).toDateString()
         );
-      }
-      if (type == 'week') {
-        const wDate = new Date(d.group_value * 1000);
-        const weekend = new Date(value);
-        weekend.setDate(weekend.getDate() + 6);
-        return wDate >= new Date(value) && wDate <= weekend;
       }
       if (type == 'month') {
         return new Date(d.group_value * 1000).getMonth() === value.getMonth();


### PR DESCRIPTION
Fix logic for week group_by. The group_by API returns the Monday date of the week, which is also the value for the x-axis. Hence no need to add additional logic for checking if the date falls withing the week.