### PR TITLE
SRVKP-4088: sync docker login and buildx gh action

### DIFF
--- a/.github/workflows/publish_container_image.yaml
+++ b/.github/workflows/publish_container_image.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: '16'
 
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-buildx-action@v3
 
       - name: Login in to ghcr.io registry
         uses: docker/login-action@v3


### PR DESCRIPTION
Fixes the following issue by syncing the docker login and buildx GH action versions,
```
docker/setup-buildx-action@v1 is not allowed to be used in openshift-pipelines/console-plugin. Actions in this workflow must be: within a repository owned by openshift-pipelines, created by GitHub, or matching the following: docker/login-action@*.
```