### PR TITLE
OCPBUGS-28978: Remove 'react-router-dom-v5-compat' package and use of useActiveNamespace from the sdk

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -8,9 +8,37 @@
         "kind": "TektonResult"
       },
       "color": "#38812f",
-      "label": "%TektonResult%",
-      "labelPlural": "%TektonResults%",
+      "label": "%plugin__pipeline-console-plugin~TektonResult%",
+      "labelPlural": "%plugin__pipeline-console-plugin~TektonResults%",
       "abbr": "TR"
+    }
+  },
+  {
+    "type": "console.model-metadata",
+    "properties": {
+      "model": {
+        "group": "tekton.dev",
+        "version": "v1beta1",
+        "kind": "Pipeline"
+      },
+      "color": "#38812f",
+      "label": "%plugin__pipeline-console-plugin~Pipeline%",
+      "labelPlural": "%plugin__pipeline-console-plugin~Pipelines%",
+      "abbr": "PL"
+    }
+  },
+  {
+    "type": "console.model-metadata",
+    "properties": {
+      "model": {
+        "group": "tekton.dev",
+        "version": "v1",
+        "kind": "Pipeline"
+      },
+      "color": "#38812f",
+      "label": "%plugin__pipeline-console-plugin~Pipeline%",
+      "labelPlural": "%plugin__pipeline-console-plugin~Pipelines%",
+      "abbr": "PL"
     }
   },
   {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.15.5",
-    "@openshift-console/dynamic-plugin-sdk": "0.0.21",
-    "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.11",
+    "@openshift-console/dynamic-plugin-sdk": "0.0.18",
+    "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.9",
     "@patternfly/react-charts": "6.94.19",
     "@patternfly/react-core": "4.276.8",
     "@patternfly/react-table": "4.113.0",
@@ -37,6 +37,7 @@
     "@types/node": "^18.0.0",
     "@types/react": "^17.0.37",
     "@types/react-helmet": "^6.1.4",
+    "@types/react-redux": "6.0.2",
     "@types/react-router-dom": "^5.3.2",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.14.0",
@@ -66,7 +67,6 @@
     "react-i18next": "^11.7.3",
     "react-router": "5.3.x",
     "react-router-dom": "5.3.x",
-    "react-router-dom-v5-compat": "^6.11.2",
     "resolve-url-loader": "2.x",
     "sass": "^1.42.1",
     "sass-loader": "^10.1.1",
@@ -100,6 +100,9 @@
     "@types/express": "^4.17.18",
     "classnames": "^2.3.2",
     "lodash-es": "^4.17.21",
+    "react-redux": "7.2.2",
+    "redux": "4.0.1",
+    "typesafe-actions": "^4.2.1",
     "victory-core": "^36.6.11"
   }
 }

--- a/src/components/hooks/useActiveNamespace.ts
+++ b/src/components/hooks/useActiveNamespace.ts
@@ -1,0 +1,43 @@
+import { useLocation } from 'react-router-dom';
+import { ALL_NAMESPACES_KEY } from '../../consts';
+
+const basePathPattern = new RegExp(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  `^/?${(window as any).SERVER_FLAGS.basePath}`,
+);
+const stripBasePath = (path: string): string =>
+  path.replace(basePathPattern, '/');
+export const legalNamePattern = /[a-z0-9](?:[-a-z0-9]*[a-z0-9])?/;
+
+const getNamespace = (path: string): string => {
+  path = stripBasePath(path);
+  const split = path.split('/').filter((x) => x);
+
+  if (split[1] === 'all-namespaces') {
+    return ALL_NAMESPACES_KEY;
+  }
+
+  let ns: string;
+  if (
+    split[1] === 'cluster' &&
+    ['namespaces', 'projects'].includes(split[2]) &&
+    split[3]
+  ) {
+    ns = split[3];
+  } else if (split[1] === 'ns' && split[2]) {
+    ns = split[2];
+  } else {
+    return;
+  }
+
+  const match = ns.match(legalNamePattern);
+  return match && match.length > 0 && match[0];
+};
+
+export const useActiveNamespace = (): [string] => {
+  const { pathname } = useLocation();
+  const activeNamespace = getNamespace(pathname);
+  return [activeNamespace];
+};
+
+export default useActiveNamespace;

--- a/src/components/pipelines-metrics/PipelinesMetricsPage.tsx
+++ b/src/components/pipelines-metrics/PipelinesMetricsPage.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useParams } from 'react-router-dom-v5-compat';
 import PipelineRunsStatusCard from '../pipelines-overview/PipelineRunsStatusCard';
 import { Flex, FlexItem } from '@patternfly/react-core';
 import PipelinesRunsDurationCard from '../pipelines-overview/PipelineRunsDurationCard';
@@ -11,21 +10,22 @@ import {
 import TimeRangeDropdown from '../pipelines-overview/TimeRangeDropdown';
 import RefreshDropdown from '../pipelines-overview/RefreshDropdown';
 import PipelinesAverageDuration from './PipelinesAverageDuration';
-import { K8sResourceKind } from '@openshift-console/dynamic-plugin-sdk';
-import './PipelinesMetrics.scss';
 import {
   IntervalOptions,
   TimeRangeOptions,
   useQueryParams,
 } from '../pipelines-overview/utils';
+import { PipelineKind } from '../../types';
+import './PipelinesMetrics.scss';
 
 type PipelinesMetricsPageProps = {
-  obj: K8sResourceKind;
+  obj: PipelineKind;
 };
 
 const PipelinesMetricsPage: React.FC<PipelinesMetricsPageProps> = ({ obj }) => {
-  const params = useParams();
-  const { ns: namespace, name: parentName } = params;
+  const {
+    metadata: { namespace, name: parentName },
+  } = obj;
   const [timespan, setTimespan] = React.useState(parsePrometheusDuration('1d'));
   const [interval, setInterval] = React.useState(
     parsePrometheusDuration('30s'),

--- a/src/components/pipelines-overview/__tests__/PipelinesOverview.spec.tsx
+++ b/src/components/pipelines-overview/__tests__/PipelinesOverview.spec.tsx
@@ -1,23 +1,28 @@
 import * as React from 'react';
+// FIXME upgrading redux types is causing many errors at this time
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import * as redux from 'react-redux';
 import { render, screen, waitFor } from '@testing-library/react';
 import {
   VirtualizedTable,
-  useActiveNamespace,
   useK8sWatchResource,
   useActiveColumns,
 } from '@openshift-console/dynamic-plugin-sdk';
 import PipelinesOverviewPage from '../PipelinesOverviewPage';
 import { getResultsSummary } from '../../utils/summary-api';
 import * as utils from '../utils';
+import * as namespaceHooks from '../../hooks/useActiveNamespace';
 
 const virtualizedTableRenderProps = jest.fn();
-const setActiveNamespace = jest.fn();
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  useActiveNamespace: jest.fn(),
   useK8sWatchResource: jest.fn(),
   useActiveColumns: jest.fn(),
   VirtualizedTable: jest.fn(),
   k8sGet: jest.fn(),
+}));
+jest.mock('../../hooks/useActiveNamespace', () => ({
+  useActiveNamespace: jest.fn(),
 }));
 jest.mock('../../utils/tekton-results', () => ({
   createTektonResultsSummaryUrl: jest.fn(),
@@ -31,9 +36,22 @@ jest.mock('../../utils/summary-api', () => ({
 });
 
 jest.spyOn(utils, 'useQueryParams').mockReturnValue(null);
+jest.spyOn(namespaceHooks, 'useActiveNamespace').mockReturnValue(['active']);
+// FIXME upgrading redux types is causing many errors at this time
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+jest.spyOn(redux, 'useDispatch').mockReturnValue(() => {});
+const mockHistoryPush = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useHistory: () => ({
+    push: mockHistoryPush,
+  }),
+}));
+jest.spyOn(namespaceHooks, 'useActiveNamespace').mockReturnValue(['active']);
 
 const virtualizedTableMock = VirtualizedTable as jest.Mock;
-const useActiveNamespaceMock = useActiveNamespace as jest.Mock;
 const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
 const useActiveColumnsMock = useActiveColumns as jest.Mock;
 const getResultsSummaryMock = getResultsSummary as jest.Mock;
@@ -41,10 +59,6 @@ const getResultsSummaryMock = getResultsSummary as jest.Mock;
 describe('Pipeline Overview page', () => {
   beforeEach(() => {
     virtualizedTableMock.mockReturnValue(<></>);
-    useActiveNamespaceMock.mockReturnValue([
-      'active-namespace',
-      setActiveNamespace,
-    ]);
     useK8sWatchResourceMock.mockReturnValue([[], true]);
     useActiveColumnsMock.mockReturnValue([[]]);
     getResultsSummaryMock.mockReturnValue(Promise.resolve({}));

--- a/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesRow.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router-dom';
 import {
   SummaryProps,
   getReferenceForModel,
@@ -8,11 +8,12 @@ import {
 import {
   ResourceLink,
   RowProps,
-  useActiveNamespace,
+  getGroupVersionKindForModel,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { formatTime, formatTimeLastRunTime } from '../dateTime';
 import { ALL_NAMESPACES_KEY } from '../../../consts';
 import { PipelineModel } from '../../../models';
+import { useActiveNamespace } from '../../hooks/useActiveNamespace';
 
 const pipelineReference = getReferenceForModel(PipelineModel);
 
@@ -26,7 +27,7 @@ const PipelineRunsForPipelinesRow: React.FC<RowProps<SummaryProps>> = ({
     <>
       <td className={tableColumnClasses[0]}>
         <ResourceLink
-          kind={pipelineReference}
+          groupVersionKind={getGroupVersionKindForModel(PipelineModel)}
           name={name}
           namespace={namespace}
         />

--- a/src/components/pipelines-overview/list-pages/PipelineRunsForRepositoriesRow.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsForRepositoriesRow.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom-v5-compat';
-import {
-  ResourceLink,
-  RowProps,
-  useActiveNamespace,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { Link } from 'react-router-dom';
+import { ResourceLink, RowProps } from '@openshift-console/dynamic-plugin-sdk';
 import {
   SummaryProps,
   getReferenceForModel,
@@ -13,6 +9,7 @@ import {
 import { formatTime, formatTimeLastRunTime } from '../dateTime';
 import { ALL_NAMESPACES_KEY } from '../../../consts';
 import { RepositoryModel } from '../../../models';
+import { useActiveNamespace } from '../../hooks/useActiveNamespace';
 
 const repositoryReference = getReferenceForModel(RepositoryModel);
 

--- a/src/components/utils/tekton-results.ts
+++ b/src/components/utils/tekton-results.ts
@@ -1,14 +1,14 @@
 import {
   K8sResourceCommon,
-  K8sResourceKind,
   MatchExpression,
   MatchLabels,
   Selector,
   k8sGet,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { RouteModel, TektonResultModel } from '../../models';
-import { consoleProxyFetchJSON } from './proxy';
 import { PipelineRunKind, TaskRunKind } from '../../types';
+import { K8sResourceKind } from '../../types/openshift';
+import { consoleProxyFetchJSON } from './proxy';
 
 // REST API spec
 // https://github.com/tektoncd/results/blob/main/docs/api/rest-api-spec.md

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,10 +14,11 @@ export type Status = components['schemas']['Status'];
 
 export type RecordType = components['schemas']['RecordType'];
 
+export * from './computedStatus';
 export * from './coreTekton';
+export * from './openshift';
 export * from './pipeline';
-export * from './pipelineRun';
 export * from './pipelineResource';
+export * from './pipelineRun';
 export * from './task';
 export * from './taskRun';
-export * from './computedStatus';

--- a/src/types/openshift.ts
+++ b/src/types/openshift.ts
@@ -1,3 +1,12 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 export type Project = K8sResourceCommon;
+
+export type K8sResourceKind = K8sResourceCommon & {
+  spec?: {
+    [key: string]: any;
+  };
+  status?: { [key: string]: any };
+  data?: { [key: string]: any };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -263,6 +263,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.9.2":
+  version "7.23.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
+  integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.22.15", "@babel/template@^7.3.3":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
@@ -716,10 +723,10 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@openshift-console/dynamic-plugin-sdk-webpack@0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-0.0.11.tgz#1b9f10fc4f4f6e6214576cc90b52ce8e6e8dc281"
-  integrity sha512-LtaNSKsBmeO+cJuTbOGgAucji8sF9SzZrPjyxee1tX/IiSXGGQAYcf/fwqZTS58FX3QSWQgkk8qrWpWdwTbbKA==
+"@openshift-console/dynamic-plugin-sdk-webpack@0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-0.0.9.tgz#46cbd97a304c20ba951fa2dc8c69f6ac60e8181f"
+  integrity sha512-ElbD6T7Z7s8zF3ulUU2aKkxVQ4GNqgxeKNvXv8lE9a0T+iFHcB6uzv6nfwHdLDWpCtuozvL1sTen+sQ+qvdfag==
   dependencies:
     ajv "^6.12.3"
     chalk "2.4.x"
@@ -730,14 +737,14 @@
     semver "6.x"
     webpack "^5.73.0"
 
-"@openshift-console/dynamic-plugin-sdk@0.0.21":
-  version "0.0.21"
-  resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-0.0.21.tgz#6e8db3dfe7cda2b8d9b3ab2cc72dbe6125fe92fc"
-  integrity sha512-6ztwhvQRP31casfTPeIf+7x4TuM27rZMHG6oMTYIlxjTpssYTzuCRTdzeSeOw3UUXzCJH25HFj2KXSh3krzAJg==
+"@openshift-console/dynamic-plugin-sdk@0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-0.0.18.tgz#c58fd4056ef2469d080857f79e8c771392d57c27"
+  integrity sha512-1aNdM4RVdWAcIChHulHdK4PuJofiN/aHsd1r9HIfdwd9sc8TcWVPHK3o1ppVysxFqhiyLABVpmG/tc1Gg+bwCg==
   dependencies:
-    "@patternfly/quickstarts" "2.4.0"
-    "@patternfly/react-core" "4.276.8"
-    "@patternfly/react-table" "4.113.0"
+    "@patternfly/quickstarts" "2.0.1"
+    "@patternfly/react-core" "4.239.0"
+    "@patternfly/react-table" "4.108.0"
     classnames "2.x"
     immutable "3.x"
     lodash "^4.17.21"
@@ -745,32 +752,38 @@
     react-helmet "^6.1.0"
     react-i18next "^11.7.3"
     react-redux "7.2.2"
-    react-router "5.3.x"
-    react-router-dom "5.3.x"
-    react-router-dom-v5-compat "^6.11.2"
+    react-router "5.2.0"
+    react-router-dom "5.2.0"
     redux "4.0.1"
     redux-thunk "2.4.0"
     reselect "4.x"
     typesafe-actions "^4.2.1"
     whatwg-fetch "2.x"
 
-"@patternfly/quickstarts@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-2.4.0.tgz#2244fc93fe72d9936609ffa1dff25fcd1efc28b3"
-  integrity sha512-dlGtAX8iQarFvmflEvZ7rHaJb1aaBrcqkbzwx0wy2QLL/BID7Y+UQ9ht7k+TBNfnxhPOljM2YTp0rugG5S9q4g==
+"@patternfly/patternfly@4.122.2":
+  version "4.122.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.122.2.tgz#3e774d78996c7027b8c528edb2e90990676458a5"
+  integrity sha512-kSoW8mt9eEJcAZX2lX4r/SYvFd44GGb8PUSDjMrpKDZqgn9/9VFh1rSChG4v5kCK6cpS99/gdTapZc3ylf8Rpw==
+
+"@patternfly/quickstarts@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-2.0.1.tgz#8e8270782eae0e2476ccf4cdbbaa22c7c095097e"
+  integrity sha512-tbF1sqlkVb9rEriiHPnKAN5SercMxP27ty+PB87uZ/aF9YkvDD5BUuCbU3JR0e2qe189WksvLrgrAEaamh3gig==
   dependencies:
-    "@patternfly/react-catalog-view-extension" "^4.93.15"
+    "@patternfly/react-catalog-view-extension" "4.12.15"
     dompurify "^2.2.6"
     history "^5.0.0"
     showdown "1.8.6"
 
-"@patternfly/react-catalog-view-extension@^4.93.15":
-  version "4.96.1"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-4.96.1.tgz#09ff8a00f0bc1f51aa9806c79aad09b14d5b3583"
-  integrity sha512-zM7Jg7CS0YL8deRwphExM6ueGYTt4PsALmBqDzZ5h0YE/k9gWWfSMurB2lm1lxYghNXInuCOZQ9SBD26i/NXUw==
+"@patternfly/react-catalog-view-extension@4.12.15":
+  version "4.12.15"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-4.12.15.tgz#edb0d6b97b3adf060129fdd1e0c1edc25c31d22e"
+  integrity sha512-1mp+Ogi7fJfgh5wV9q+PolmplbMj3Tcias8xs0eeD5GCirdzOQxG+wihEM5k6CAGhBAr7jHg5fRSgO8QLTt3UQ==
   dependencies:
-    "@patternfly/react-core" "^4.276.11"
-    "@patternfly/react-styles" "^4.92.8"
+    "@patternfly/patternfly" "4.122.2"
+    "@patternfly/react-core" "^4.135.15"
+    "@patternfly/react-styles" "^4.11.4"
+    classnames "^2.2.5"
 
 "@patternfly/react-charts@6.94.19":
   version "6.94.19"
@@ -799,6 +812,19 @@
     victory-voronoi-container "^36.6.7"
     victory-zoom-container "^36.6.7"
 
+"@patternfly/react-core@4.239.0":
+  version "4.239.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.239.0.tgz#ae310a0c07155a46ab3a0e6aa32fdcf2faef4dd7"
+  integrity sha512-6CmYABCJLUXTlzCk6C3WouMNZpS0BCT+aHU8CvYpFQ/NrpYp3MJaDsYbqgCRWV42rmIO5iXun/4WhXBJzJEoQg==
+  dependencies:
+    "@patternfly/react-icons" "^4.90.0"
+    "@patternfly/react-styles" "^4.89.0"
+    "@patternfly/react-tokens" "^4.91.0"
+    focus-trap "6.9.2"
+    react-dropzone "9.0.0"
+    tippy.js "5.1.2"
+    tslib "^2.0.0"
+
 "@patternfly/react-core@4.276.8":
   version "4.276.8"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.276.8.tgz#7ef52830dcdda954bd5bec40132da6eef49aba6f"
@@ -812,7 +838,7 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
-"@patternfly/react-core@^4.276.11", "@patternfly/react-core@^4.276.8":
+"@patternfly/react-core@^4.135.15", "@patternfly/react-core@^4.239.0", "@patternfly/react-core@^4.276.8":
   version "4.278.1"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.278.1.tgz#65a4578eb5502d8f4c81a5c218d4fdb3c1141135"
   integrity sha512-BZ+A0r/xLWXLxE5/b8FTVxRI/KokDlTQOS0ub49ts7nv++vmZS7kU4tn2bfuh7RVw/BfW4CNtoMzeJkM8GpaWw==
@@ -837,7 +863,7 @@
     react-dropzone "^14.2.3"
     tslib "^2.5.0"
 
-"@patternfly/react-icons@^4.93.6", "@patternfly/react-icons@^4.93.7":
+"@patternfly/react-icons@^4.90.0", "@patternfly/react-icons@^4.93.6", "@patternfly/react-icons@^4.93.7":
   version "4.93.7"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.93.7.tgz#130acbcda4835cf0f26802aaddbb75664709ad4b"
   integrity sha512-3kr35dgba7Qz5CSzmfH0rIjSvBC5xkmiknf3SvVUVxaiVA7KRowID8viYHeZlf3v/Oa3sEewaH830Q0t+nWsZQ==
@@ -847,7 +873,7 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-5.1.2.tgz#c5c1a733230261a4747cd5fc88c946d4f290526c"
   integrity sha512-hgf3OchvNyCcxqDrRJCkxauFdxENtVX2d6uTkMfOQWP3hs8hqYGHR5S0pe2teJ1SwAs2Rgtf7ezzmzKAouAjkw==
 
-"@patternfly/react-styles@^4.92.6", "@patternfly/react-styles@^4.92.8":
+"@patternfly/react-styles@^4.11.4", "@patternfly/react-styles@^4.89.0", "@patternfly/react-styles@^4.92.6", "@patternfly/react-styles@^4.92.8":
   version "4.92.8"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.92.8.tgz#2f05455dfe8095a16df27c0d185a7f46f9451d74"
   integrity sha512-K4lUU8O4HiCX9NeuNUIrPgN3wlGERCxJVio+PAjd8hpJD/PKnjFfOJ9u6/Cii3qLy/5ZviWPRNHbGiwA/+YUhg==
@@ -856,6 +882,18 @@
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-5.1.2.tgz#89fa082f728e2724f89455a7049b3a9f6e48c4e0"
   integrity sha512-rGNo8MstZG2r3yDS1tWwYDctK1qWW5RT1UwKF1DrQfhZ8ruEEL6m2ZXXM0u62hmM3qq4Q8h5lgn/bVHBnOHSLA==
+
+"@patternfly/react-table@4.108.0":
+  version "4.108.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.108.0.tgz#82956d4a64e0581b569acdc89f2a6d7d330840d3"
+  integrity sha512-EUvd3rlkE1UXobAm7L6JHgNE3TW8IYTaVwwH/px4Mkn5mBayDO6f+w6QM3OeoDQVZcXK6IYFe7QQaYd/vWIJCQ==
+  dependencies:
+    "@patternfly/react-core" "^4.239.0"
+    "@patternfly/react-icons" "^4.90.0"
+    "@patternfly/react-styles" "^4.89.0"
+    "@patternfly/react-tokens" "^4.91.0"
+    lodash "^4.17.19"
+    tslib "^2.0.0"
 
 "@patternfly/react-table@4.113.0":
   version "4.113.0"
@@ -874,7 +912,7 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.94.6.tgz#47c715721ad3dd315a523f352ba1a0de2b03f0bc"
   integrity sha512-tm7C6nat+uKMr1hrapis7hS3rN9cr41tpcCKhx6cod6FLU8KwF2Yt5KUxakhIOCEcE/M/EhXhAw/qejp8w0r7Q==
 
-"@patternfly/react-tokens@^4.94.6", "@patternfly/react-tokens@^4.94.7":
+"@patternfly/react-tokens@^4.91.0", "@patternfly/react-tokens@^4.94.6", "@patternfly/react-tokens@^4.94.7":
   version "4.94.7"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.94.7.tgz#4453b9abe91a4ffa38e3ebec28927d9b91e3320c"
   integrity sha512-h+ducOLDMSxcuec3+YY3x+stM5ZUSnrl/lC/eVmjypil2El08NuE2MNEPMQWdhrod6VRRZFMNqZw/m82iv6U1A==
@@ -906,11 +944,6 @@
     react-measure "^2.3.0"
     tslib "^2.0.0"
     webcola "3.4.0"
-
-"@remix-run/router@1.14.0":
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.14.0.tgz#9bc39a5a3a71b81bdb310eba6def5bc3966695b7"
-  integrity sha512-WOHih+ClN7N8oHk9N4JUiMxQJmRVaOxcg8w7F/oHUXzJt920ekASLI/7cYX8XkntDWRhLZtsk6LbGrkgOAvi5A==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.6"
@@ -1467,6 +1500,14 @@
   integrity sha512-Y6V11CH6bU7RhqrIdENPwEUZlPXhfXNGylMNnGwq5TAEs2wDoBA3kSVVM/EQ8u72sz5r9ja+7W8M8PIVcS841Q==
   dependencies:
     "@types/react" "*"
+
+"@types/react-redux@6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-6.0.2.tgz#10069b53db8e0920fd8656e068dcf10c53c9ad2a"
+  integrity sha512-rNf/oxhVDPoRLpxP1d8NvdYHJe6LtyLp0ha8a/RLnsgMVBrbmPaQUznwcmAHlgCdAYFBFqntxe8OqmixHIVI5Q==
+  dependencies:
+    "@types/react" "*"
+    redux "^4.0.0"
 
 "@types/react-router-dom@^5.3.2":
   version "5.3.3"
@@ -2829,6 +2870,11 @@ classnames@2.x, classnames@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
+classnames@^2.2.5:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -5393,7 +5439,7 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
-history@^5.0.0, history@^5.3.0:
+history@^5.0.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
   integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
@@ -7566,6 +7612,14 @@ min-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
+mini-create-react-context@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
+  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    tiny-warning "^1.0.3"
+
 minimalistic-assert@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -8853,13 +8907,18 @@ react-redux@7.2.2:
     prop-types "^15.7.2"
     react-is "^16.13.1"
 
-react-router-dom-v5-compat@^6.11.2:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.21.0.tgz#b5a12bd921e628716bc3aed6db8f71fc9f4aea19"
-  integrity sha512-+rHaX2rndq6/FFgRU1Clqni1hSVhEeYScEqewXaBfBZcqBCrv7Khxhxzac7MtbQyQmBeAcgPr+qekVdrr7eozw==
+react-router-dom@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
+  integrity sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==
   dependencies:
-    history "^5.3.0"
-    react-router "6.21.0"
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.2.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-router-dom@5.3.x:
   version "5.3.4"
@@ -8871,6 +8930,22 @@ react-router-dom@5.3.x:
     loose-envify "^1.3.1"
     prop-types "^15.6.2"
     react-router "5.3.4"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"
+  integrity sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.4.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
@@ -8888,13 +8963,6 @@ react-router@5.3.4, react-router@5.3.x:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
-
-react-router@6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.21.0.tgz#6fe3e59877aca3dccceec1801d26991ddf42d12b"
-  integrity sha512-hGZ0HXbwz3zw52pLZV3j3+ec+m/PQ9cTpBvqjFQmy2XVUWGn5MD+31oXHb6dVTxYzmAeaiUBYjkoNz66n3RGCg==
-  dependencies:
-    "@remix-run/router" "1.14.0"
 
 react-side-effect@^2.1.0:
   version "2.1.2"
@@ -9044,6 +9112,13 @@ redux@4.0.1:
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"
+
+redux@^4.0.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
+  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 reflect.getprototypeof@^1.0.4:
   version "1.0.4"
@@ -10495,7 +10570,7 @@ tiny-invariant@^1.0.2:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
   integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
 
-tiny-warning@^1.0.0:
+tiny-warning@^1.0.0, tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==


### PR DESCRIPTION
Fix: [OCPBUGS-28978](https://issues.redhat.com/browse/OCPBUGS-28978)

Descriptions: Remove 'react-router-dom-v5-compat' package and use of useActiveNamespace from the sdk and downgrade the `@openshift-console/dynamic-plugin-sdk` and `@openshift-console/dynamic-plugin-sdk-webpack` to support OCP 4.12 and 4.13. 

as per https://github.com/openshift/console/tree/master/frontend/packages/console-dynamic-plugin-sdk#openshift-console-versions-vs-sdk-versions
