### PR TITLE
SRVKP-4088: [main] tune multiarch container image build time

### DIFF
--- a/.github/workflows/publish_container_image.yaml
+++ b/.github/workflows/publish_container_image.yaml
@@ -1,12 +1,14 @@
 name: publish container images
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - release-v* # example: release-v1.14
     tags: ['v*']
 
 jobs:
   setup:
-    name: Setup
+    name: build container
     runs-on: ubuntu-latest
 
     steps:
@@ -26,8 +28,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: |
+            **/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+
       - name: Build and push Dynamic Console container image
-        run: ./build.sh
+        run: ./scripts/build_container.sh
         env:
           SUPPORT_MULTI_ARCH: "true"
           CONSOLE_PLUGIN_IMAGE_REPO: 'ghcr.io/${{ github.repository }}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
-FROM registry.access.redhat.com/ubi8/nodejs-16:latest AS build
+FROM registry.access.redhat.com/ubi8/nodejs-16:latest AS builder-ui
 USER root
 RUN command -v yarn || npm i -g yarn
 
 ADD . /usr/src/app
 WORKDIR /usr/src/app
-RUN yarn install && yarn build
+
+RUN yarn install --frozen-lockfile && \
+    yarn build
 
 FROM registry.access.redhat.com/ubi8/nginx-120:latest
 
-COPY --from=build /usr/src/app/dist /usr/share/nginx/html
+COPY --from=builder-ui /usr/src/app/dist /usr/share/nginx/html
 
 COPY ./nginx.conf /etc/nginx/nginx.conf
 

--- a/Dockerfile.without_builder
+++ b/Dockerfile.without_builder
@@ -1,0 +1,18 @@
+# used to generate multiarch container image
+
+# performing "yarn install" on multiarch with "docker buildx" takes a lot of time
+# to avoid this, "yarn install" and "yarn build" should be executed outside of docker
+# and only copy the "dist" to different platform/architecture runtime containers
+# WARNING: with this approach, if we use platform naive package may lead to a malfunction
+# however in this project, the code will be executed on a browser,
+# hence assuming no impact on this approach
+
+FROM registry.access.redhat.com/ubi8/nginx-120:latest
+
+COPY ./dist /usr/share/nginx/html
+
+COPY ./nginx.conf /etc/nginx/nginx.conf
+
+USER 1001
+
+ENTRYPOINT ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
 * performing `yarn install` on multiarch with `docker buildx` takes a lot of time (approx `2h30m`)
 to avoid this, `yarn install` and `yarn build` should be executed outside of docker (on a host platform)
 and only copy the `dist` to different platform/architecture runtime containers
**WARNING:** with this approach, if we use platform native package may lead to a malfunction
 however in this project, the code will be executed on a browser and assuming there is no platform specific implementations, hence assuming no impact on this approach


* and builds the container image for `release-v*` branches