### PR TITLE
OCPBUGS-31745: TaskRun status is not displayed near the name

### DIFF
--- a/src/components/pipelines-tasks/tasks-details-pages/TaskRunDetailsPage.tsx
+++ b/src/components/pipelines-tasks/tasks-details-pages/TaskRunDetailsPage.tsx
@@ -8,6 +8,7 @@ import { Link } from 'react-router-dom';
 import * as React from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 import { ArchiveIcon } from '@patternfly/react-icons';
+import { ResourceStatus } from '@openshift-console/dynamic-plugin-sdk';
 import DetailsPage from '../../details-page/DetailsPage';
 import { getReferenceForModel } from '../../pipelines-overview/utils';
 import { TaskRunModel } from '../../../models';
@@ -23,12 +24,18 @@ import {
   RESOURCE_LOADED_FROM_RESULTS_ANNOTATION,
 } from '../../../consts';
 import { LoadingBox } from '../../status/status-box';
+import { taskRunStatus } from '../../utils/pipeline-utils';
+import Status from '../../status/Status';
 
 const TaskRunDetailsPage = () => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
   const params = useParams();
   const { name, ns: namespace } = params;
   const [data, loaded] = useTaskRun(namespace, name);
+  const trStatus = React.useMemo(
+    () => loaded && data && taskRunStatus(data),
+    [loaded, data],
+  );
   const resourceTitleFunc = React.useMemo(() => {
     return (
       <div className="taskrun-details-page">
@@ -42,6 +49,9 @@ const TaskRunDetailsPage = () => {
             <ArchiveIcon className="pipelinerun-details-page__results-indicator" />
           </Tooltip>
         )}
+        <ResourceStatus>
+          <Status status={trStatus}></Status>
+        </ResourceStatus>
       </div>
     );
   }, [data]);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-31745

**Analysis / Root cause**: 
Status was not added for TaskRun details page heading

**Solution Description**: 
Added the status value in heading

**Screen shots / Gifs for design review**: 

---Before--
<img width="1439" alt="Screenshot 2024-04-10 at 12 16 18 PM" src="https://github.com/openshift/console/assets/102503482/9fd20c4c-49af-49a0-8d94-53fc3a466e82">



--After--
<img width="1440" alt="Screenshot 2024-04-10 at 12 09 12 PM" src="https://github.com/openshift/console/assets/102503482/350d9154-052c-46b4-a311-2ac78ced363e">


**Unit test coverage report**: 
NA

**Test setup:**

    1. Create a TaskRun and go to details page


     
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge