### PR TITLE
[console-plugin] OCPBUGS-33333: In PipelineList page PipelineRuns not fetched from tekton results

### DIFF
--- a/src/components/pipelines-list/PipelinesList.tsx
+++ b/src/components/pipelines-list/PipelinesList.tsx
@@ -11,10 +11,9 @@ import * as React from 'react';
 import usePipelinesColumns from './usePipelinesColumns';
 import { usePipelinesFilters } from './usePipelinesFilters';
 import PipelineRow from './PipelineRow';
-import { useGetTaskRuns } from '../hooks/useTektonResult';
-import { PipelineModel, PipelineRunModel } from '../../models';
+import { useGetPipelineRuns, useGetTaskRuns } from '../hooks/useTektonResult';
+import { PipelineModel } from '../../models';
 import { PropPipelineData, augmentRunsToData } from '../utils/pipeline-augment';
-import { PipelineRunKind } from '../../types';
 import { useParams } from 'react-router-dom-v5-compat';
 import { useTranslation } from 'react-i18next';
 
@@ -41,12 +40,7 @@ const PipelinesList: React.FC<PipelineListProps> = ({
     optional: true,
   });
   const [pipelineRuns, pipelineRunsLoaded, pipelineRunsLoadError] =
-    useK8sWatchResource<PipelineRunKind[]>({
-      isList: true,
-      groupVersionKind: getGroupVersionKindForModel(PipelineRunModel),
-      namespace,
-      optional: true,
-    });
+    useGetPipelineRuns(namespace);
   const pipelinesData = augmentRunsToData(pipelines, pipelineRuns);
   const [data, filteredData, onFilterChange] = useListPageFilter(
     pipelinesData,


### PR DESCRIPTION
**Issue:**
https://issues.redhat.com/browse/OCPBUGS-33333

**Screenshots:**
----Before----
<img width="1439" alt="Screenshot 2024-05-07 at 11 31 50 AM" src="https://github.com/openshift-pipelines/console-plugin/assets/102503482/af0fbab5-0069-48d9-af9c-1796f9895908">


----After----
<img width="1728" alt="Screenshot 2024-05-07 at 11 50 33 AM" src="https://github.com/openshift-pipelines/console-plugin/assets/102503482/9cf0f069-af3e-4eba-97a9-bbbb8c133141">

**Steps to reproduce:**

    1. Install Pipelines operator
    2. Install tekton results
    3. Create some Pipeline and PipelineRuns
    4. Delete PipelineRun and see Pipeline list page, Task Status and Last Run Status is '-'     