### PR TITLE
OCPBUGS-33344: Fix details page Actions in dark mode

### DIFF
--- a/src/components/details-page/DetailsPage.scss
+++ b/src/components/details-page/DetailsPage.scss
@@ -17,6 +17,6 @@
 .action-menu-dropdown {
   inset-inline-end: 0;
   position: absolute;
-  background: #fff;
-  box-shadow: 0 0.25rem 0.5rem 0rem rgba(3, 3, 3, 0.12), 0 0 0.25rem 0 rgba(3, 3, 3, 0.06);
+  background: var(--pf-v5-global--BackgroundColor--light-100);
+  box-shadow: var(--pf-v5-global--BoxShadow--md);
 }

--- a/src/components/details-page/DetailsPage.tsx
+++ b/src/components/details-page/DetailsPage.tsx
@@ -141,7 +141,7 @@ const DetailsPage: React.FC<React.PropsWithChildren<DetailsPageProps>> = ({
                 )}
                 isOpen={isOpen}
               >
-                <DropdownList className={'action-menu-dropdown'}>
+                <DropdownList className="action-menu-dropdown">
                   {dropdownItems}
                 </DropdownList>
               </Dropdown>


### PR DESCRIPTION
Before:

![image](https://github.com/openshift-pipelines/console-plugin/assets/2561818/f4772958-3c36-40e9-9f6b-f58c383f198e)


After:

![image](https://github.com/openshift-pipelines/console-plugin/assets/2561818/07e992d7-e9fe-4942-b97e-88f467af094f)
