### PR TITLE
OCPBUGS-33390: Add checks for OPENSHIFT_PIPELINE flag on Pipelines nav

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -11,6 +11,17 @@
     }
   },
   {
+    "type": "console.flag/model",
+    "properties": {
+      "model": {
+        "group": "tekton.dev",
+        "version": "v1",
+        "kind": "Pipeline"
+      },
+      "flag": "OPENSHIFT_PIPELINE"
+    }
+  },
+  {
     "type": "console.model-metadata",
     "properties": {
       "model": {
@@ -157,7 +168,7 @@
       "namespaced": true
     },
     "flags": {
-      "required": ["PIPELINE_TEKTON_RESULT_INSTALLED"]
+      "required": ["OPENSHIFT_PIPELINE", "PIPELINE_TEKTON_RESULT_INSTALLED"]
     }
   },
   {
@@ -239,7 +250,10 @@
       "namespaced": true
     },
     "flags": {
-      "required": ["HIDE_STATIC_PIPELINE_PLUGIN_TASKS_NAV_OPTION"]
+      "required": [
+        "OPENSHIFT_PIPELINE",
+        "HIDE_STATIC_PIPELINE_PLUGIN_TASKS_NAV_OPTION"
+      ]
     }
   },
   {
@@ -723,7 +737,10 @@
       "namespaced": true
     },
     "flags": {
-      "required": ["HIDE_STATIC_PIPELINE_PLUGIN_TRIGGERS_NAV_OPTION"]
+      "required": [
+        "OPENSHIFT_PIPELINE",
+        "HIDE_STATIC_PIPELINE_PLUGIN_TRIGGERS_NAV_OPTION"
+      ]
     }
   },
   {
@@ -833,7 +850,10 @@
       }
     },
     "flags": {
-      "required": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_NAV_OPTION"]
+      "required": [
+        "OPENSHIFT_PIPELINE",
+        "HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_NAV_OPTION"
+      ]
     }
   },
   {
@@ -852,7 +872,10 @@
       }
     },
     "flags": {
-      "required": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_NAV_OPTION"]
+      "required": [
+        "OPENSHIFT_PIPELINE",
+        "HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_NAV_OPTION"
+      ]
     }
   },
   {


### PR DESCRIPTION
Issue: The Pipelines nav option is present without the Pipelines operator installed.