### PR TITLE
OCPBUGS-35948: Corrected typo Namespace in list page

### DIFF
--- a/locales/en/plugin__pipelines-console-plugin.json
+++ b/locales/en/plugin__pipelines-console-plugin.json
@@ -202,7 +202,6 @@
   "Metrics": "Metrics",
   "More info": "More info",
   "Name": "Name",
-  "Namesapce": "Namesapce",
   "Namespace": "Namespace",
   "Namespaces": "Namespaces",
   "No {{resourceName}} results available due to failure": "No {{resourceName}} results available due to failure",

--- a/src/components/list-pages/default-resources.tsx
+++ b/src/components/list-pages/default-resources.tsx
@@ -18,7 +18,7 @@ export const useDefaultColumns = () => {
     {
       id: 'namespace',
       sort: 'metadata.namespace',
-      title: t('Namesapce'),
+      title: t('Namespace'),
       transforms: [sortable],
     },
     {

--- a/src/components/pipelines-tasks/TaskRunsList.tsx
+++ b/src/components/pipelines-tasks/TaskRunsList.tsx
@@ -43,7 +43,7 @@ const useTaskColumns = () => {
     {
       id: 'namespace',
       sort: 'metadata.namespace',
-      title: t('Namesapce'),
+      title: t('Namespace'),
       transforms: [sortable],
     },
     {


### PR DESCRIPTION
----Belore----
<img width="1175" alt="Screenshot 2024-06-24 at 12 48 06 PM" src="https://github.com/openshift-pipelines/console-plugin/assets/102503482/bc427889-7312-4d74-b45c-613458985fbc">


----After----
<img width="1175" alt="Screenshot 2024-06-24 at 12 47 24 PM" src="https://github.com/openshift-pipelines/console-plugin/assets/102503482/29b0f2e7-1b07-4739-9505-f638d9899338">

