### PR TITLE
SRVKP-5880: Switch to use annotations as labels from PipelineRuns created through Pipelines as Code is deprecated

### DIFF
--- a/src/components/pipelineRuns-details/RepositoryLinkList.tsx
+++ b/src/components/pipelineRuns-details/RepositoryLinkList.tsx
@@ -39,6 +39,9 @@ const RepositoryLinkList: React.FC<RepositoryLinkListProps> = ({
     plrAnnotations?.[RepositoryAnnotations[RepoAnnotationFields.REPO_URL]];
   const shaURL =
     plrAnnotations?.[RepositoryAnnotations[RepoAnnotationFields.SHA_URL]];
+  const branchName =
+    plrLabels?.[RepositoryAnnotations[RepoAnnotationFields.BRANCH]] ||
+    plrAnnotations?.[RepositoryAnnotations[RepoAnnotationFields.BRANCH]];
 
   if (!repoName) return null;
 
@@ -66,20 +69,11 @@ const RepositoryLinkList: React.FC<RepositoryLinkListProps> = ({
           </ExternalLink>
         )}
       </dd>
-      {plrLabels?.[RepositoryLabels[RepositoryFields.BRANCH]] && (
+      {branchName && (
         <>
-          <dt>
-            {t(
-              getLabelValue(
-                plrLabels[RepositoryLabels[RepositoryFields.BRANCH]],
-                t,
-              ),
-            )}
-          </dt>
+          <dt>{t(getLabelValue(branchName, t))}</dt>
           <dd data-test="pl-repository-branch">
-            {sanitizeBranchName(
-              plrLabels[RepositoryLabels[RepositoryFields.BRANCH]],
-            )}
+            {sanitizeBranchName(branchName)}
           </dd>
         </>
       )}

--- a/src/components/pipelineRuns-list/PipelineRunsRow.tsx
+++ b/src/components/pipelineRuns-list/PipelineRunsRow.tsx
@@ -95,6 +95,9 @@ const PipelineRunRowTable = ({
   const { t } = useTranslation('plugin__pipelines-console-plugin');
   const plrLabels = obj.metadata.labels;
   const plrAnnotations = obj.metadata.annotations;
+  const branchName =
+    plrLabels?.[RepositoryAnnotations[RepoAnnotationFields.BRANCH]] ||
+    plrAnnotations?.[RepositoryAnnotations[RepoAnnotationFields.BRANCH]];
   return (
     <>
       <TableData
@@ -222,9 +225,7 @@ const PipelineRunRowTable = ({
           className={tableColumnClasses.branch}
           activeColumnIDs={activeColumnIDs}
         >
-          {sanitizeBranchName(
-            plrLabels?.[RepositoryLabels[RepositoryFields.BRANCH]],
-          )}
+          {sanitizeBranchName(branchName)}
         </TableData>
       )}
       <TableData

--- a/src/components/pipelineRuns-list/usePipelineRunsColumns.ts
+++ b/src/components/pipelineRuns-list/usePipelineRunsColumns.ts
@@ -1,7 +1,12 @@
 import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
-import { RepositoryFields, RepositoryLabels } from '../../consts';
+import {
+  RepoAnnotationFields,
+  RepositoryAnnotations,
+  RepositoryFields,
+  RepositoryLabels,
+} from '../../consts';
 import { PipelineRunKind } from '../../types';
 import { tableColumnClasses } from './PipelineRunsRow';
 
@@ -80,8 +85,8 @@ const usePipelineRunsColumns = (
           {
             id: 'branch-tag',
             title: t('Branch/Tag'),
-            sort: `metadata.labels.${
-              RepositoryLabels[RepositoryFields.BRANCH]
+            sort: `metadata.annotations.${
+              RepositoryAnnotations[RepoAnnotationFields.BRANCH]
             }`,
             transforms: [sortable],
             props: { className: tableColumnClasses.branch },

--- a/src/components/repositories-list/RepositoriesRow.tsx
+++ b/src/components/repositories-list/RepositoriesRow.tsx
@@ -12,7 +12,6 @@ import { Link } from 'react-router-dom';
 import { PipelineRunModel, RepositoryModel } from '../../models';
 import { getLatestRun } from '../utils/pipeline-augment';
 import { getTaskRunsOfPipelineRun } from '../hooks/useTaskRuns';
-import { RepositoryFields, RepositoryLabels } from '../../consts';
 import { pipelineRunDuration } from '../utils/pipeline-utils';
 import PipelineRunStatus from '../pipelines-list/status/PipelineRunStatus';
 import {
@@ -22,6 +21,7 @@ import {
 import { getReferenceForModel } from '../pipelines-overview/utils';
 import LinkedPipelineRunTaskStatus from '../pipelines-list/status/LinkedPipelineRunTaskStatus';
 import RepositoriesKebab from './RepositoriesKebab';
+import { RepositoryFields, RepositoryLabels } from '../../consts';
 
 export const repositoriesTableColumnClasses = [
   'pf-v5-u-w-16-on-xl pf-v5-u-w-25-on-lg pf-v5-u-w-33-on-xs', // name
@@ -62,7 +62,9 @@ const RepositoriesRow: React.FC<
 
   const latestPLREventType =
     latestRun &&
-    latestRun?.metadata?.labels[RepositoryLabels[RepositoryFields.EVENT_TYPE]];
+    latestRun?.metadata?.labels?.[
+      RepositoryLabels[RepositoryFields.EVENT_TYPE]
+    ];
 
   const PLRTaskRuns = getTaskRunsOfPipelineRun(
     taskRuns,

--- a/src/components/utils/repository-utils.tsx
+++ b/src/components/utils/repository-utils.tsx
@@ -61,19 +61,19 @@ export const getGitProviderIcon = (url: string) => {
 };
 
 export const sanitizeBranchName = (branchName: string): string => {
-  if (branchName.startsWith('refs/heads/')) {
+  if (branchName?.startsWith('refs/heads/')) {
     return branchName.replace('refs/heads/', '');
   }
 
-  if (branchName.startsWith('refs-heads-')) {
+  if (branchName?.startsWith('refs-heads-')) {
     return branchName.replace('refs-heads-', '');
   }
 
-  if (branchName.startsWith('refs/tags/')) {
+  if (branchName?.startsWith('refs/tags/')) {
     return branchName.replace('refs/tags/', '');
   }
 
-  if (branchName.startsWith('refs-tags-')) {
+  if (branchName?.startsWith('refs-tags-')) {
     return branchName.replace('refs-tags-', '');
   }
   return branchName;
@@ -81,15 +81,15 @@ export const sanitizeBranchName = (branchName: string): string => {
 
 export const getLabelValue = (branchName: string, t): string => {
   if (
-    branchName.startsWith('refs/heads/') ||
-    branchName.startsWith('refs-heads-')
+    branchName?.startsWith('refs/heads/') ||
+    branchName?.startsWith('refs-heads-')
   ) {
     return t('Branch');
   }
 
   if (
-    branchName.startsWith('refs/tags/') ||
-    branchName.startsWith('refs-tags-')
+    branchName?.startsWith('refs/tags/') ||
+    branchName?.startsWith('refs-tags-')
   ) {
     return t('Tag');
   }

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -87,9 +87,8 @@ export enum TektonResourceLabel {
 
 export enum RepositoryFields {
   REPOSITORY = 'Repository',
-  BRANCH = 'Branch',
-  URL_REPO = 'RepoUrl',
   URL_ORG = 'RepoOrg',
+  URL_REPO = 'RepoUrl',
   SHA = 'sha',
   EVENT_TYPE = 'EventType',
 }
@@ -98,11 +97,11 @@ export enum RepoAnnotationFields {
   SHA_MESSAGE = 'sha_message',
   SHA_URL = 'sha_url',
   REPO_URL = 'repo_url',
+  BRANCH = 'Branch',
 }
 
 export const RepositoryLabels: Record<RepositoryFields, string> = {
   [RepositoryFields.REPOSITORY]: 'pipelinesascode.tekton.dev/repository',
-  [RepositoryFields.BRANCH]: 'pipelinesascode.tekton.dev/branch',
   [RepositoryFields.URL_REPO]: 'pipelinesascode.tekton.dev/url-repository',
   [RepositoryFields.URL_ORG]: 'pipelinesascode.tekton.dev/url-org',
   [RepositoryFields.SHA]: 'pipelinesascode.tekton.dev/sha',
@@ -113,6 +112,7 @@ export const RepositoryAnnotations: Record<RepoAnnotationFields, string> = {
   [RepoAnnotationFields.SHA_MESSAGE]: 'pipelinesascode.tekton.dev/sha-title',
   [RepoAnnotationFields.SHA_URL]: 'pipelinesascode.tekton.dev/sha-url',
   [RepoAnnotationFields.REPO_URL]: 'pipelinesascode.tekton.dev/repo-url',
+  [RepoAnnotationFields.BRANCH]: 'pipelinesascode.tekton.dev/branch',
 };
 
 export enum ApprovalFields {

--- a/src/test-data/pipeline-data.ts
+++ b/src/test-data/pipeline-data.ts
@@ -3338,8 +3338,10 @@ export const PipeLineRunWithRepoMetadata: Record<string, PipelineRunKind> = {
     kind: 'PipelineRun',
     metadata: {
       name: 'pipeline-with-repo',
-      labels: {
+      annotations: {
         'pipelinesascode.tekton.dev/branch': 'main',
+      },
+      labels: {
         'pipelinesascode.tekton.dev/url-repository': 'demoapp',
       },
       namespace: 'test',
@@ -3365,6 +3367,8 @@ export const PipeLineRunWithRepoMetadata: Record<string, PipelineRunKind> = {
       name: 'pipeline-with-repo',
       labels: {
         'pipelinesascode.tekton.dev/repository': 'repo1',
+      },
+      annotations: {
         'pipelinesascode.tekton.dev/branch': 'main',
       },
       namespace: 'test',


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/SRVKP-5880

Descriptions:
The labels added by PAC have been deprecated and added to PLR annotations. So, use annotations to get the value in the repository list page, repository PLRs list page, and on the PLR details page.

Test steps:

Check Repository list page
PipelineRuns list page for repository
PipelineRun details page
Repository details page