### PR TITLE
SRVKP-5836: In metrics overview page of tekton results, Average duration chart y-axis is always set to 5m

### DIFF
--- a/src/components/pipelines-metrics/PipelinesAverageDuration.tsx
+++ b/src/components/pipelines-metrics/PipelinesAverageDuration.tsx
@@ -145,6 +145,15 @@ const PipelinesAverageDuration: React.FC<PipelinesAverageDurationProps> = ({
       break;
   }
 
+  const max = Math.max(...chartData.map((yVal) => yVal.y));
+  const roundUp = (value, nearest) => {
+    return Math.ceil(value / nearest) * nearest;
+  };
+  const nearest = max > 10 ? 10 : 5;
+  const roundedMax = roundUp(max, nearest);
+  domainValue.y =
+    !isNaN(roundedMax) && roundedMax > 5 ? [0, roundedMax] : [0, 5];
+
   if (!domainY) {
     let minY: number = _.minBy(chartData, 'y')?.y ?? 0;
     let maxY: number = _.maxBy(chartData, 'y')?.y ?? 0;


### PR DESCRIPTION
**Issue:**
https://issues.redhat.com/browse/SRVKP-5836

**Description:**
In Metrics tab of Pipelines/Repository details page, the y-axis of average duration chat is fixed to max of 5 minutes. In this PR, based on the max y axis value, y-axis is set.

**Screenshots:**
<img width="1439" alt="Screenshot 2024-07-22 at 2 38 41 PM" src="https://github.com/user-attachments/assets/c0542b19-086c-4ed5-a972-f1f20a4ddd29">
<img width="1442" alt="Screenshot 2024-07-22 at 2 39 21 PM" src="https://github.com/user-attachments/assets/4f7d992d-7e04-40f0-94e6-041f485fd643">
<img width="1438" alt="Screenshot 2024-07-22 at 2 42 09 PM" src="https://github.com/user-attachments/assets/b8f982ad-e8f3-48c5-bae2-71cf346786c8">
