### PR TITLE
SRVKP-6232: [main] bump node version and nginx image

### DIFF
--- a/.github/workflows/publish_container_image.yaml
+++ b/.github/workflows/publish_container_image.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
 
       - uses: docker/setup-buildx-action@v3
 
@@ -29,7 +29,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr/src/app
 RUN yarn install --frozen-lockfile && \
     yarn build
 
-FROM registry.access.redhat.com/ubi8/nginx-120:latest
+FROM registry.access.redhat.com/ubi8/nginx-124:latest
 
 COPY --from=builder-ui /usr/src/app/dist /usr/share/nginx/html
 

--- a/Dockerfile.without_builder
+++ b/Dockerfile.without_builder
@@ -7,7 +7,7 @@
 # however in this project, the code will be executed on a browser,
 # hence assuming no impact on this approach
 
-FROM registry.access.redhat.com/ubi8/nginx-120:latest
+FROM registry.access.redhat.com/ubi8/nginx-124:latest
 
 COPY ./dist /usr/share/nginx/html
 


### PR DESCRIPTION
* bumps node version to `1.18` on GitHub actions
* bumps cache module version in GitHub actions
* bumps ngnix image to supported version