### PR TITLE
SRVKP-5936: Close modal button is not working in dynamic plugin list pages

### DIFF
--- a/src/components/modals/LoadingModal.tsx
+++ b/src/components/modals/LoadingModal.tsx
@@ -11,7 +11,7 @@ type LoadingModalProps = {
 const LoadingModal: React.FC<LoadingModalProps> = ({ onClose }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
   return (
-    <ModalWrapper>
+    <ModalWrapper onClose={onClose}>
       <LoadingBox />
       <ModalFooter inProgress={false}>
         <ActionGroup className="pf-v5-c-form pf-v5-c-form__actions--right pf-v5-c-form__group--no-top-margin">

--- a/src/components/modals/modal.tsx
+++ b/src/components/modals/modal.tsx
@@ -165,9 +165,14 @@ export const createModal: CreateModal = (getModalElement) => {
 export const ModalWrapper: React.FC<ModalWrapperProps> = ({
   className,
   children,
+  onClose,
 }) => {
   return (
-    <Modal className={classNames('modal-dialog', className)} isOpen>
+    <Modal
+      className={classNames('modal-dialog', className)}
+      isOpen
+      onClose={() => onClose()}
+    >
       {children}
     </Modal>
   );


### PR DESCRIPTION
**Issue:**
https://issues.redhat.com/browse/SRVKP-5936

**Analysis / Root cause**: 
onClose function was not submitted to Modal component.

**Solution Description**: 
Added onClose function to Modal component. 


**Screen shots / Gifs for design review**: 
----BEFORE---


https://github.com/user-attachments/assets/211ff1b6-d73a-47b9-b649-f5b9beb19e26

---AFTER---


https://github.com/user-attachments/assets/401d9b34-3637-4b7e-864b-1308dd1074b2


**Unit test coverage report**: 
NA

**Test setup:**

1. Install Pipelines operator and enable dynamic plugin
2. Create a pipeline and click on start in kebab menu
3. Click on X button to close the start pipeline modal

    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge