### PR TITLE
SRVKP-6101: Redirects to new PipelineRun logs URL from old PipelineRun logs URL

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -1173,5 +1173,16 @@
     "flags": {
       "required": ["HIDE_STATIC_PIPELINE_PLUGIN_PIPELINE_DETAILS"]
     }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
+      "path": [
+        "/k8s/ns/:ns/tekton.dev~v1~PipelineRun/:plrName/logs/:taskName",
+        "/k8s/ns/:ns/tekton.dev~v1beta1~PipelineRun/:plrName/logs/:taskName"
+      ],
+      "component": { "$codeRef": "pipelineRunDetails.LogURLRedirect" }
+    }
   }
 ]

--- a/src/components/pipelineRuns-details/LogURLRedirect.tsx
+++ b/src/components/pipelineRuns-details/LogURLRedirect.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Navigate, useLocation, useParams } from 'react-router-dom-v5-compat';
+
+const createLogURL = (pathname: string, taskName: string): string => {
+  const basePath = pathname.replace(/\/$/, '');
+  const detailsURL = basePath.split('/logs/');
+  return `${detailsURL[0]}/logs?taskName=${taskName}`;
+};
+
+export const LogURLRedirect: React.FC = () => {
+  const location = useLocation();
+  const { taskName } = useParams();
+  return <Navigate to={createLogURL(location.pathname, taskName)} replace />;
+};

--- a/src/components/pipelineRuns-details/index.ts
+++ b/src/components/pipelineRuns-details/index.ts
@@ -1,2 +1,3 @@
+export { LogURLRedirect } from './LogURLRedirect';
 export { default as PipelineRunDetails } from './PipelineRunDetails';
 export { default as PipelineRunDetailsPage } from './PipelineRunDetailsPage';


### PR DESCRIPTION
Descriptions: Logs URL has been changed after the react-router package upgrade because of this change log URL provided by PAC is broken now. This change redirects the old PLR logs URL to a new one.