### PR TITLE
SRVKP-6363: use TaskRuns `results.tekton.dev/record` annotation to get the logs

### DIFF
--- a/src/components/hooks/useTektonResult.ts
+++ b/src/components/hooks/useTektonResult.ts
@@ -199,6 +199,7 @@ export const useGetTaskRuns = (
 export const useTRTaskRunLog = (
   namespace: string,
   taskRunName: string,
+  taskRunPath: string,
 ): [string, boolean, unknown] => {
   const [result, setResult] = React.useState<[string, boolean, unknown]>([
     null,
@@ -210,7 +211,7 @@ export const useTRTaskRunLog = (
     if (namespace && taskRunName) {
       (async () => {
         try {
-          const log = await getTaskRunLog(namespace, taskRunName);
+          const log = await getTaskRunLog(taskRunPath);
           if (!disposed) {
             setResult([log, true, undefined]);
           }

--- a/src/components/logs/TektonTaskRunLog.tsx
+++ b/src/components/logs/TektonTaskRunLog.tsx
@@ -22,6 +22,7 @@ export const TektonTaskRunLog: React.FC<TektonTaskRunLogProps> = ({
   const [trResults, trLoaded, trError] = useTRTaskRunLog(
     taskRun.metadata.namespace,
     taskRun.metadata.name,
+    taskRun.metadata?.annotations?.['results.tekton.dev/record'],
   );
 
   React.useEffect(() => {

--- a/src/components/logs/logs-utils.ts
+++ b/src/components/logs/logs-utils.ts
@@ -79,6 +79,7 @@ type StepsWatchUrl = {
   [key: string]: {
     name: string;
     steps: { [step: string]: WatchURLStatus };
+    taskRunPath: string;
   };
 };
 
@@ -133,6 +134,8 @@ export const getDownloadAllLogsCallback = (
       acc[currTask] = {
         name: pipelineTaskName,
         steps: { ...allStepUrls },
+        taskRunPath:
+          taskRun.metadata?.annotations?.['results.tekton.dev/record'],
       };
       return acc;
     }, {});
@@ -167,7 +170,7 @@ export const getDownloadAllLogsCallback = (
         }
       } else {
         // eslint-disable-next-line no-await-in-loop
-        allLogs += await getTaskRunLog(namespace, currTask).then(
+        allLogs += await getTaskRunLog(task.taskRunPath).then(
           (log) => `${tasks[currTask].name.toUpperCase()}\n\n${log}\n\n`,
         );
       }


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/SRVKP-6363

**Description:**
`results.tekton.dev/record` annotation is used to get the Logs for the TaskRuns.