### PR TITLE
SRVKP-6638: PipelineRuns List page doesn't fetch next page data on scroll

### DIFF
--- a/src/components/pipelineRuns-list/PipelineRunsList.tsx
+++ b/src/components/pipelineRuns-list/PipelineRunsList.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom-v5-compat';
 import { SortByDirection } from '@patternfly/react-table';
 import {
   ListPageBody,
@@ -11,8 +13,7 @@ import { usePipelineRunsFilters } from './usePipelineRunsFilters';
 import { PipelineRunKind } from '../../types';
 import { useGetPipelineRuns } from '../hooks/useTektonResult';
 import PipelineRunsRow from './PipelineRunsRow';
-import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom-v5-compat';
+import { useLoadMoreOnScroll } from '../utils/tekton-results';
 
 import './PipelineRunsList.scss';
 
@@ -56,23 +57,7 @@ const PipelineRunsList: React.FC<PipelineRunsListProps> = ({
     filters,
   );
 
-  // Once OCPBUGS-43538 ticket is closed, use onRowsRendered prop in VirtualizedTable for load more on scroll
-  React.useEffect(() => {
-    if (!loadMoreRef.current || !pipelineRunsLoaded) return;
-
-    const observer = new IntersectionObserver((entries) => {
-      const entry = entries[0];
-      if (entry.isIntersecting && nextPageToken) {
-        nextPageToken();
-      }
-    });
-
-    observer.observe(loadMoreRef.current);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [nextPageToken, pipelineRunsLoaded]);
+  useLoadMoreOnScroll(loadMoreRef, nextPageToken, pipelineRunsLoaded);
 
   return (
     <ListPageBody>

--- a/src/components/pipelines-tasks/TaskRunsList.tsx
+++ b/src/components/pipelines-tasks/TaskRunsList.tsx
@@ -19,6 +19,7 @@ import { TaskRunModel } from '../../models';
 import { ALL_NAMESPACES_KEY, TektonResourceLabel } from '../../consts';
 import { getReferenceForModel } from '../pipelines-overview/utils';
 import { useTaskRunsFilters } from './useTaskRunsFilters';
+import { useLoadMoreOnScroll } from '../utils/tekton-results';
 
 interface TaskRunsListPageProps {
   showTitle?: boolean;
@@ -123,23 +124,8 @@ const TaskRunsList: React.FC<TaskRunsListPageProps> = ({
     useTaskRunsFilters(),
   );
 
-  // Once OCPBUGS-43538 ticket is closed, use onRowsRendered prop in VirtualizedTable for load more on scroll
-  React.useEffect(() => {
-    if (!loadMoreRef.current || !loaded) return;
+  useLoadMoreOnScroll(loadMoreRef, nextPageToken, loaded);
 
-    const observer = new IntersectionObserver((entries) => {
-      const entry = entries[0];
-      if (entry.isIntersecting && nextPageToken) {
-        nextPageToken();
-      }
-    });
-
-    observer.observe(loadMoreRef.current);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [nextPageToken, loaded]);
   return (
     <>
       <ListPageBody>

--- a/src/components/utils/tekton-results.ts
+++ b/src/components/utils/tekton-results.ts
@@ -7,6 +7,7 @@ import {
   k8sGet,
 } from '@openshift-console/dynamic-plugin-sdk';
 import _ from 'lodash';
+import { RefObject, useEffect } from 'react';
 import {
   ALL_NAMESPACES_KEY,
   DELETED_RESOURCE_IN_K8S_ANNOTATION,
@@ -490,4 +491,25 @@ export const getTaskRunLog = async (taskRunPath: string): Promise<string> => {
     '/logs/',
   )}`;
   return consoleProxyFetchLog({ url, method: 'GET', allowInsecure: true });
+};
+
+export const useLoadMoreOnScroll = (
+  loadMoreRef: RefObject<HTMLElement>,
+  nextPageToken: (() => void) | null,
+  loaded: boolean,
+) => {
+  useEffect(() => {
+    if (!loadMoreRef.current || !loaded) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[0];
+      if (entry.isIntersecting && nextPageToken) {
+        nextPageToken();
+      }
+    });
+    observer.observe(loadMoreRef.current);
+    return () => {
+      observer.disconnect();
+    };
+  }, [nextPageToken, loaded, loadMoreRef]);
 };

--- a/src/components/utils/tekton-results.ts
+++ b/src/components/utils/tekton-results.ts
@@ -281,7 +281,7 @@ export const createTektonResultsUrl = async (
         MINIMUM_PAGE_SIZE,
         Math.min(
           MAXIMUM_PAGE_SIZE,
-          options?.limit >= 0 ? options.limit : options?.pageSize ?? 30,
+          options?.limit >= 0 ? options.limit : options?.pageSize ?? 50,
         ),
       )}`,
       ...(nextPageToken ? { page_token: nextPageToken } : {}),


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/SRVKP-6638

**Description:**
    `VirtualizedTable` which is exposed to dynamic plugin is missing `onRowsRendered` prop which is available in `VirtualTableBody` of PatternFly. 

Created https://issues.redhat.com/browse/OCPBUGS-43538 ticket for that. 

Once this ticket is closed, instead of the solution provided in this PR we have to use `onRowsRendered` prop in `VirtualizedTable` to call `nextPageToken`.
    
**Demo:**
----PipelineRun list page---

https://drive.google.com/file/d/1HO6V5AnMSRqVgTTf1hAIT-COVCH2Q701/view?usp=drive_link

------

----TaskRun list page---

https://drive.google.com/file/d/1FlOn6Zp3aEKxFlAmivy1IiFRWUUYrPyk/view?usp=drive_link
