### PR TITLE
ODC-7674: Configure CI and enable create-from-add-options.feature test file

### DIFF
--- a/integration-tests/cypress/support/commands/app.ts
+++ b/integration-tests/cypress/support/commands/app.ts
@@ -153,6 +153,7 @@ Cypress.Commands.add('checkErrors', () => {
 
 Cypress.Commands.add(
   'waitUntilEnabled',
+  // eslint-disable-next-line @typescript-eslint/no-inferrable-types
   (selector: string, timeout: number = 20000): any => {
     const start = new Date().getTime();
 

--- a/integration-tests/cypress/support/commands/hooks.ts
+++ b/integration-tests/cypress/support/commands/hooks.ts
@@ -12,7 +12,7 @@ after(() => {
   cy.log(`Deleting "${namespaces}" namespace`);
   cy.exec(`oc delete namespace ${namespaces}`, {
     failOnNonZeroExit: false,
-    timeout: 180000,
+    timeout: 200000,
   });
 });
 

--- a/integration-tests/cypress/support/page-objects/operators-po.ts
+++ b/integration-tests/cypress/support/page-objects/operators-po.ts
@@ -28,7 +28,7 @@ export const operatorsPO = {
   },
   installOperators: {
     title: 'h1.co-m-pane__heading',
-    noOperatorsFound: '[data-test="msg-box-title"]',
+    noOperatorsFound: '[data-test="console-empty-state-title"]',
     noOperatorsDetails: '[data-test="msg-box-detail"]',
     search: 'input[data-test-id="item-filter"]',
     noOperatorFoundMessage: 'div.cos-status-box__title',

--- a/integration-tests/cypress/support/pages/operators-page.ts
+++ b/integration-tests/cypress/support/pages/operators-page.ts
@@ -54,8 +54,11 @@ export const operatorsPage = {
       if (
         $body.find(operatorsPO.installOperators.noOperatorsDetails).length === 0
       ) {
+        cy.get(operatorsPO.installOperators.search).clear();
         /* eslint-disable-next-line cypress/unsafe-to-chain-command */
-        cy.get(operatorsPO.installOperators.search).clear().type(operatorName);
+        cy.get(operatorsPO.installOperators.search)
+          .should('be.enabled')
+          .type(operatorName);
       } else {
         cy.log(
           `${operatorName} operator is not installed in this cluster, so lets install it from operator Hub`,

--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -21,12 +21,12 @@ trap copyArtifacts EXIT
 
 
 # don't log kubeadmin-password
-# set +x
-# BRIDGE_KUBEADMIN_PASSWORD="$(cat "${KUBEADMIN_PASSWORD_FILE:-${INSTALLER_DIR}/auth/kubeadmin-password}")"
-# export BRIDGE_KUBEADMIN_PASSWORD
-# set -x
-# BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}')"
-# export BRIDGE_BASE_ADDRESS
+set +x
+BRIDGE_KUBEADMIN_PASSWORD="$(cat "${KUBEADMIN_PASSWORD_FILE:-${INSTALLER_DIR}/auth/kubeadmin-password}")"
+export BRIDGE_KUBEADMIN_PASSWORD
+set -x
+BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}')"
+export BRIDGE_BASE_ADDRESS
 
 if [ ! -d node_modules ]; then
   yarn install

--- a/tests/support/admin.ts
+++ b/tests/support/admin.ts
@@ -2,6 +2,7 @@ import { guidedTour } from '../views/guided-tour';
 import { nav } from '../views/nav';
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Cypress {
     interface Chainable {
       initAdmin(): Chainable<Element>;
@@ -23,10 +24,10 @@ Cypress.Commands.add('initAdmin', () => {
 
 Cypress.Commands.add('initDeveloper', () => {
   cy.log('redirect to home');
+  nav.sidenav.switcher.changePerspectiveTo('Developer');
+  nav.sidenav.switcher.shouldHaveText('Developer');
   cy.visit('/add');
   cy.byTestID('loading-indicator').should('not.exist');
   cy.log('ensure perspective switcher is set to Developer');
-  nav.sidenav.switcher.changePerspectiveTo('Developer');
-  nav.sidenav.switcher.shouldHaveText('Developer');
   guidedTour.close();
 });

--- a/tests/views/nav.ts
+++ b/tests/views/nav.ts
@@ -2,17 +2,17 @@ export const nav = {
   sidenav: {
     switcher: {
       shouldHaveText: (text: string) =>
-        /* eslint-disable-next-line cypress/unsafe-to-chain-command */
+        /* eslint-disable-next-line */
         cy
           .byLegacyTestID('perspective-switcher-toggle')
           .scrollIntoView()
           .contains(text),
       changePerspectiveTo: (newPerspective: string) =>
-        /* eslint-disable-next-line cypress/unsafe-to-chain-command */
+        /* eslint-disable-next-line */
         cy
           .byLegacyTestID('perspective-switcher-toggle')
           .click()
-          .byLegacyTestID('perspective-switcher-menu-option')
+          .byLegacyTestID('perspective-switcher-menu')
           .contains(newPerspective)
           .click(),
     },
@@ -20,7 +20,7 @@ export const nav = {
       shouldHaveText: (text: string) =>
         cy.byLegacyTestID('cluster-dropdown-toggle').contains(text),
       changeClusterTo: (newCluster: string) =>
-        /* eslint-disable-next-line cypress/unsafe-to-chain-command */
+        /* eslint-disable-next-line */
         cy
           .byLegacyTestID('cluster-dropdown-toggle')
           .click()


### PR DESCRIPTION
Story:[ODC-7674](https://issues.redhat.com/browse/ODC-7674)

Description:
CI should be running create-from-add-optiuons.feature file successfully 

Command to execute:

export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.13-042801.devcluster.openshift.com/
export BRIDGE_KUBEADMIN_PASSWORD
export BRIDGE_BASE_ADDRESS
oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
oc apply -f ./tests/utils/htpasswd-secret.yaml
oc patch oauths cluster --patch "$(cat ./tests/utils/patch-htpasswd.yaml)" --type=merge
./test-prow-e2e.sh
Run create-from-add-options.feature
Browser
Chrome 125
![Screenshot from 2024-10-25 19-08-22](https://github.com/user-attachments/assets/93c06e61-90f6-47c5-84b5-0164f2979efe)
