### PR TITLE
SRVKP-6733: ReRun of Resolver based PipelineRuns fails from UI

### DIFF
--- a/src/components/pipelineRuns-details/PipelineRunDetailsPage.tsx
+++ b/src/components/pipelineRuns-details/PipelineRunDetailsPage.tsx
@@ -68,7 +68,10 @@ const PipelineRunDetailsPage: React.FC<PipelineRunDetailsPageProps> = ({
   const PLRTasks = getTaskRunsOfPipelineRun(taskRuns, name);
   const reRunAction = () => {
     const { pipelineRef, pipelineSpec } = pipelineRun.spec;
-    if (namespace && (pipelineRef?.name || pipelineSpec)) {
+    if (
+      namespace &&
+      (pipelineRef?.name || pipelineSpec || pipelineRef?.resolver)
+    ) {
       k8sCreate({
         model: returnValidPipelineRunModel(pipelineRun),
         data: getPipelineRunData(null, pipelineRun),

--- a/src/components/pipelineRuns-list/PipelineRunsKebab.tsx
+++ b/src/components/pipelineRuns-list/PipelineRunsKebab.tsx
@@ -99,7 +99,10 @@ const PipelineRunsKebab: React.FC<PipelineRunsKebabProps> = ({
 
   const reRunAction = () => {
     const { pipelineRef, pipelineSpec } = obj.spec;
-    if (namespace && (pipelineRef?.name || pipelineSpec)) {
+    if (
+      namespace &&
+      (pipelineRef?.name || pipelineSpec || pipelineRef?.resolver)
+    ) {
       k8sCreate({
         model: returnValidPipelineRunModel(obj),
         data: getPipelineRunData(null, obj),

--- a/src/components/utils/utils.ts
+++ b/src/components/utils/utils.ts
@@ -214,9 +214,14 @@ export const getPipelineRunData = (
     spec: {
       ...(latestRun?.spec || {}),
       ...((latestRun?.spec.pipelineRef || pipeline) && {
-        pipelineRef: {
-          name: pipelineName,
-        },
+        pipelineRef: latestRun?.spec.pipelineRef?.resolver
+          ? {
+              resolver: latestRun.spec.pipelineRef?.resolver,
+              params: latestRun.spec.pipelineRef?.params,
+            }
+          : {
+              name: pipelineName,
+            },
       }),
       ...(params && { params }),
       workspaces,

--- a/src/types/pipelineRun.ts
+++ b/src/types/pipelineRun.ts
@@ -3,7 +3,7 @@ import {
   ObjectMetadata,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { TektonResultsRun, TektonTaskSpec } from './coreTekton';
-import { PipelineKind, PipelineSpec } from './pipeline';
+import { PipelineKind, PipelineSpec, PipelineTaskParam } from './pipeline';
 
 export type PLRTaskRunStep = {
   container: string;
@@ -158,7 +158,11 @@ export type PipelineRunStatus = {
 
 export type PipelineRunKind = K8sResourceCommon & {
   spec: {
-    pipelineRef?: { name: string };
+    pipelineRef?: {
+      name?: string;
+      resolver?: string;
+      params?: PipelineTaskParam[];
+    };
     pipelineSpec?: PipelineSpec;
     params?: PipelineRunParam[];
     workspaces?: PipelineRunWorkspace[];


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/SRVKP-6733

**Analysis / Root cause:**
PipelineRun with Resolver case was not handled. Only Pipeline name was sent at the time of rerun under pipelineRef.

**Solution Description:**
If PLR is using resolver, instead of sending pipeline name in pipelineRef, resolver and params values are used.

**Screen shots / Gifs for design review:**

**-----BEFORE-----**

----Rerun in PLR details page---
https://github.com/user-attachments/assets/5cb4a51b-4ef5-4c1c-aa46-131ab9f04bfd

----

----Rerun in PLR list page---

https://github.com/user-attachments/assets/f8ac7137-8723-42bd-a0fd-6e3c8b870d0a

----

**-----AFTER-----**

----Rerun in PLR details page---

https://github.com/user-attachments/assets/48a74912-cf12-48ca-ab3a-90c9f1030508

----

----Rerun in PLR list page---

https://github.com/user-attachments/assets/ee44e07c-e92c-4e51-a875-3ac80a9f14c0

**Test setup:**

1. Create a resolver based pipelinerun using https://tekton.dev/docs/pipelines/resolution-getting-started/ or use the below provided yaml directly.
2. Attempt to "ReRun" the same from Console  

```
kind: PipelineRun
apiVersion: tekton.dev/v1
metadata:
  name: run-basic-pipeline-from-git
spec:
  pipelineRef:
    resolver: git
    params:
    - name: url
      value: https://github.com/lokanandaprabhu/pipelines-testing
    - name: revision
      value: main
    - name: pathInRepo
      value: pipeline.yaml
  params:
  - name: username
    value: admin
```