### PR TITLE
SRVKP-7041: Empty message in Pipeline, PipelineRun and Repositories list page is not aligned properly

### DIFF
--- a/src/components/pipelineRuns-list/PipelineRunsList.tsx
+++ b/src/components/pipelineRuns-list/PipelineRunsList.tsx
@@ -78,11 +78,10 @@ const PipelineRunsList: React.FC<PipelineRunsListProps> = ({
       <VirtualizedTable<PipelineRunKind>
         key={sortColumnIndex}
         EmptyMsg={() => (
-          <div
-            className="pf-u-text-align-center virtualized-table-empty-msg"
-            id="no-templates-msg"
-          >
-            {t('No PipelineRuns found')}
+          <div className="cos-status-box">
+            <div className="pf-v5-u-text-align-center">
+              {t('No PipelineRuns found')}
+            </div>
           </div>
         )}
         columns={columns}

--- a/src/components/pipelines-list/PipelinesList.tsx
+++ b/src/components/pipelines-list/PipelinesList.tsx
@@ -67,11 +67,10 @@ const PipelinesList: React.FC<PipelineListProps> = ({
       <VirtualizedTable<K8sResourceCommon>
         key={sortColumnIndex}
         EmptyMsg={() => (
-          <div
-            className="pf-u-text-align-center virtualized-table-empty-msg"
-            id="no-templates-msg"
-          >
-            {t('No Pipelines found')}
+          <div className="cos-status-box">
+            <div className="pf-v5-u-text-align-center">
+              {t('No Pipelines found')}
+            </div>
           </div>
         )}
         columns={columns}

--- a/src/components/repositories-list/RepositoriesList.tsx
+++ b/src/components/repositories-list/RepositoriesList.tsx
@@ -57,11 +57,10 @@ const RepositoriesList: React.FC<RepositoriesListProps> = ({
       />
       <VirtualizedTable
         EmptyMsg={() => (
-          <div
-            className="pf-u-text-align-center virtualized-table-empty-msg"
-            id="no-templates-msg"
-          >
-            {t('No Repositories found')}
+          <div className="cos-status-box">
+            <div className="pf-v5-u-text-align-center">
+              {t('No Repositories found')}
+            </div>
           </div>
         )}
         columns={columns}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/SRVKP-7041

**Analysis / Root cause**: 
Global css was not defined

**Solution Description**: 
Updated the css
  
**Screen shots / Gifs for design review**: 

**----BEFORE---**

https://github.com/user-attachments/assets/c24f5fa5-abf3-455c-b2ef-7402f2bee9b3
-----

**---AFTER----**


https://github.com/user-attachments/assets/914a5957-58ee-4976-941d-e33f49c17ad6


-----



**Unit test coverage report**: 
NA

**Test setup:**

1. Install Pipelines Operator
2. Enable Dynamic plugin
3. Go to Pipelines list page

    

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

