### PR TITLE
SRVKP-4210: Display a clear message populated on to the pipelinerun log snippet

### DIFF
--- a/src/components/logs/LogSnippetBlock.tsx
+++ b/src/components/logs/LogSnippetBlock.tsx
@@ -19,6 +19,7 @@ const LogSnippetBlock: React.FC<LogSnippetBlockProps> = ({
       namespace={namespace}
       podName={logDetails.podName}
       title={logDetails.title}
+      staticMessage={logDetails.staticMessage}
     >
       {children}
     </LogSnippetFromPod>

--- a/src/components/logs/LogSnippetFromPod.tsx
+++ b/src/components/logs/LogSnippetFromPod.tsx
@@ -12,6 +12,7 @@ type LogSnippetFromPodProps = {
   namespace: string;
   podName: string;
   title: string;
+  staticMessage?: string;
 };
 
 const LogSnippetFromPod: React.FC<LogSnippetFromPodProps> = ({
@@ -20,6 +21,7 @@ const LogSnippetFromPod: React.FC<LogSnippetFromPodProps> = ({
   namespace,
   podName,
   title,
+  staticMessage,
 }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
 
@@ -49,7 +51,7 @@ const LogSnippetFromPod: React.FC<LogSnippetFromPodProps> = ({
   if (logError) {
     return (
       <Alert isInline title={title} variant="danger">
-        {logError}
+        {staticMessage ? staticMessage : logError}
       </Alert>
     );
   }

--- a/src/components/logs/log-snippet-utils.ts
+++ b/src/components/logs/log-snippet-utils.ts
@@ -27,5 +27,6 @@ export const taskRunSnippetMessage = (
     title: t('Failure on task {{taskName}} - check logs for details.', {
       taskName,
     }),
+    staticMessage: joinConditions(taskRunStatus.conditions),
   };
 };

--- a/src/components/pipelines-tasks/taskRunLogSnippet.ts
+++ b/src/components/pipelines-tasks/taskRunLogSnippet.ts
@@ -26,7 +26,11 @@ export const getTRLogSnippet = (taskRun: TaskRunKind): CombinedErrorDetails => {
   }
   const isKnownReason = (reason: string): boolean => {
     // known reasons https://tekton.dev/vault/pipelines-v0.21.0/taskruns/#monitoring-execution-status
-    return ['TaskRunCancelled', 'TaskRunTimeout'].includes(reason);
+    return [
+      'TaskRunCancelled',
+      'TaskRunTimeout',
+      'TaskRunImagePullFailed',
+    ].includes(reason);
   };
 
   if (isKnownReason(succeededCondition?.reason)) {

--- a/src/types/log-snippet-types.ts
+++ b/src/types/log-snippet-types.ts
@@ -5,6 +5,7 @@ type ErrorDetails = {
 export type ErrorDetailsWithLogName = ErrorDetails & {
   containerName: string;
   podName: string;
+  staticMessage?: string;
 };
 export type ErrorDetailsWithStaticLog = ErrorDetails & {
   staticMessage: string;


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/SRVKP-4210

**Screenshots:**

------**Before:**-----

<img width="718" alt="image" src="https://github.com/user-attachments/assets/bb522e5e-c833-470f-b8d5-0b236496f717" />

--------------------------------------------

-----**After:**-----

<img width="704" alt="image" src="https://github.com/user-attachments/assets/d0c06a59-6264-4f53-933c-4f9176001f40" />

**Note:**

I will create a PR to handle styling issues in details page.
