### PR TITLE
SRVKP-7594: PLR details page borken due to loading issue

### DIFF
--- a/src/components/hooks/useTaskRuns.ts
+++ b/src/components/hooks/useTaskRuns.ts
@@ -285,7 +285,7 @@ export const useRuns = <Kind extends K8sResourceCommon>(
         : runs || trResources;
     return [
       rResources,
-      !!rResources?.[0] || loaded || trLoaded,
+      !!rResources?.[0] || (loaded && trLoaded),
       namespace
         ? queryTr
           ? isList


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/SRVKP-7594

**Description:**

Reverted loading logic change done in PR - https://github.com/openshift-pipelines/console-plugin/pull/421