### PR TITLE
SRVKP-5546: Pipelines builder shows only some tasks from hubs

### DIFF
--- a/src/components/catalog/apis/artifactHub.ts
+++ b/src/components/catalog/apis/artifactHub.ts
@@ -182,3 +182,21 @@ export const updateArtifactHubTask = async (
     throw err;
   }
 };
+
+export const fetchArtifactHubTasks = async (
+  query: string,
+  limit: number = 20,
+): Promise<ArtifactHubTask[]> => {
+  try {
+    const response = await fetch(
+      `${ARTIFACTHUB_API_BASE_URL}/packages/search?ts_query_web=${encodeURIComponent(
+        query,
+      )}&facets=false&sort=relevance&limit=${limit}&offset=0`,
+    );
+    const data = await response.json();
+    return data.packages || [];
+  } catch (error) {
+    console.warn('Error searching Artifact Hub tasks:', error);
+    return [];
+  }
+};

--- a/src/components/catalog/providers/useArtifactHubTasksProvider.tsx
+++ b/src/components/catalog/providers/useArtifactHubTasksProvider.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { ARTIFACTHUB, useGetArtifactHubTasks } from '../apis/artifactHub';
+import * as _ from 'lodash';
+import {
+  ARTIFACTHUB,
+  createArtifactHubTask,
+  updateArtifactHubTask,
+  useGetArtifactHubTasks,
+} from '../apis/artifactHub';
 import { TektonHubTask } from '../apis/tektonHub';
 import {
   CatalogItem,
@@ -14,45 +20,101 @@ import { getReferenceForModel } from '../../pipelines-overview/utils';
 import { useTektonHubIntegration } from '../catalog-utils';
 import { t } from '../../utils/common-utils';
 import { ArtifactHubTask, FLAGS } from '../../../types';
+import useTasksProvider from './useTasksProvider';
 
 export const normalizeArtifactHubTasks = (
   artifactHubTasks: ArtifactHubTask[],
+  tektonTasks: CatalogItem[],
 ): CatalogItem<any>[] => {
-  const normalizedArtifactHubTasks: CatalogItem<ArtifactHubTask>[] =
-    artifactHubTasks.reduce((acc, task) => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { package_id, name, description } = task;
-      const provider = TaskProviders.artifactHub;
-      const normalizedArtifactHubTask: CatalogItem<any> = {
-        uid: package_id.toString(),
-        type: TaskProviders.community,
-        name,
-        description,
-        provider,
-        icon: {
-          node: <ResourceIcon kind={getReferenceForModel(TaskModel)} />,
+  return artifactHubTasks.map((task) => {
+    const { package_id, name, description, version } = task;
+    const installedTask = tektonTasks?.find(
+      (tektonTask) =>
+        tektonTask.provider === TaskProviders.artifactHub &&
+        tektonTask.name === name,
+    );
+    return {
+      uid: package_id.toString(),
+      type: TaskProviders.community,
+      name,
+      description,
+      provider: TaskProviders.artifactHub,
+      icon: {
+        node: <ResourceIcon kind={getReferenceForModel(TaskModel)} />,
+      },
+      attributes: {
+        installed: installedTask ? version : '',
+      },
+      cta: {
+        label: t('Add'),
+        callback: ({
+          selectedVersion,
+          selectedItem,
+          isDevConsoleProxyAvailable,
+          namespace,
+          callback,
+          setFailedTasks,
+        }) => {
+          return new Promise((resolve) => {
+            const selectedVersionUrl =
+              selectedItem?.attributes?.selectedVersionContentUrl;
+            if (installedTask) {
+              if (selectedVersion === selectedItem.attributes.installed) {
+                resolve(callback(installedTask.data));
+              } else {
+                resolve(
+                  callback({
+                    metadata: { name: selectedItem.data.task.name },
+                  }),
+                );
+                updateArtifactHubTask(
+                  selectedVersionUrl,
+                  installedTask,
+                  namespace,
+                  selectedItem.data.task.name,
+                  selectedVersion,
+                  isDevConsoleProxyAvailable,
+                ).catch((error) => {
+                  setFailedTasks((prev) => [
+                    ...prev,
+                    selectedItem.data.task.name,
+                  ]);
+                });
+              }
+            } else {
+              resolve(
+                callback({
+                  metadata: { name: selectedItem.data.task.name },
+                }),
+              );
+              createArtifactHubTask(
+                selectedVersionUrl,
+                namespace,
+                selectedVersion,
+                isDevConsoleProxyAvailable,
+              ).catch((error) => {
+                setFailedTasks((prev) => [
+                  ...prev,
+                  selectedItem.data.task.name,
+                ]);
+              });
+            }
+          });
         },
-        attributes: { installed: '' },
-        cta: {
-          label: t('Add'),
-        },
-        data: {
-          task,
-          source: ARTIFACTHUB,
-        },
-      };
-      acc.push(normalizedArtifactHubTask);
-
-      return acc;
-    }, []);
-
-  return normalizedArtifactHubTasks;
+      },
+      data: {
+        task,
+        source: ARTIFACTHUB,
+      },
+    };
+  });
 };
 
 const useArtifactHubTasksProvider: ExtensionHook<CatalogItem[]> = ({
   namespace,
 }): [CatalogItem[], boolean, string] => {
   const artifactHubIntegration = useTektonHubIntegration();
+  const [tektonTasks] = useTasksProvider({});
   const isDevConsoleProxyAvailable = useFlag(FLAGS.DEVCONSOLE_PROXY);
   const canCreateTask = useAccessReview({
     group: TaskModel.apiGroup,
@@ -74,7 +136,10 @@ const useArtifactHubTasksProvider: ExtensionHook<CatalogItem[]> = ({
   );
   const normalizedArtifactHubTasks = React.useMemo<
     CatalogItem<TektonHubTask>[]
-  >(() => normalizeArtifactHubTasks(artifactHubTasks), [artifactHubTasks]);
+  >(
+    () => normalizeArtifactHubTasks(artifactHubTasks, tektonTasks),
+    [artifactHubTasks, tektonTasks],
+  );
   return [normalizedArtifactHubTasks, tasksLoaded, tasksError];
 };
 

--- a/src/components/catalog/providers/useArtifactHubTasksProvider.tsx
+++ b/src/components/catalog/providers/useArtifactHubTasksProvider.tsx
@@ -15,7 +15,7 @@ import { useTektonHubIntegration } from '../catalog-utils';
 import { t } from '../../utils/common-utils';
 import { ArtifactHubTask, FLAGS } from '../../../types';
 
-const normalizeArtifactHubTasks = (
+export const normalizeArtifactHubTasks = (
   artifactHubTasks: ArtifactHubTask[],
 ): CatalogItem<any>[] => {
   const normalizedArtifactHubTasks: CatalogItem<ArtifactHubTask>[] =

--- a/src/components/quick-search/QuickSearchContent.tsx
+++ b/src/components/quick-search/QuickSearchContent.tsx
@@ -8,6 +8,7 @@ import QuickSearchDetails, {
 import QuickSearchList from './QuickSearchList';
 import { CatalogLinkData } from './utils/quick-search-types';
 import { CatalogType } from '../catalog/types';
+import { TaskSearchCallback } from '../pipeline-builder/types';
 import './QuickSearchContent.scss';
 
 interface QuickSearchContentProps {
@@ -23,6 +24,8 @@ interface QuickSearchContentProps {
   closeModal: () => void;
   detailsRenderer?: DetailsRendererFunction;
   onListChange?: (items: number) => void;
+  callback?: TaskSearchCallback;
+  setFailedTasks?: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
 const QuickSearchContent: React.FC<QuickSearchContentProps> = ({
@@ -38,6 +41,8 @@ const QuickSearchContent: React.FC<QuickSearchContentProps> = ({
   limitItemCount,
   detailsRenderer,
   onListChange,
+  callback,
+  setFailedTasks,
 }) => {
   return (
     <Split className="ocs-quick-search-content">
@@ -66,6 +71,9 @@ const QuickSearchContent: React.FC<QuickSearchContentProps> = ({
           detailsRenderer={detailsRenderer}
           selectedItem={selectedItem}
           closeModal={closeModal}
+          namespace={namespace}
+          callback={callback}
+          setFailedTasks={setFailedTasks}
         />
       </SplitItem>
     </Split>

--- a/src/components/quick-search/QuickSearchController.tsx
+++ b/src/components/quick-search/QuickSearchController.tsx
@@ -7,6 +7,7 @@ import {
   QuickSearchProviders,
 } from './utils/quick-search-types';
 import { quickSearch } from './utils/quick-search-utils';
+import { TaskSearchCallback } from '../pipeline-builder/types';
 
 type QuickSearchControllerProps = {
   namespace: string;
@@ -20,6 +21,8 @@ type QuickSearchControllerProps = {
   disableKeyboardOpen?: boolean;
   setIsOpen: (isOpen: boolean) => void;
   detailsRenderer?: DetailsRendererFunction;
+  callback?: TaskSearchCallback;
+  setFailedTasks?: React.Dispatch<React.SetStateAction<string[]>>;
 };
 
 const QuickSearchController: React.FC<QuickSearchControllerProps> = ({
@@ -34,6 +37,8 @@ const QuickSearchController: React.FC<QuickSearchControllerProps> = ({
   setIsOpen,
   disableKeyboardOpen = false,
   detailsRenderer,
+  callback,
+  setFailedTasks,
 }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
 
@@ -114,6 +119,8 @@ const QuickSearchController: React.FC<QuickSearchControllerProps> = ({
       searchCatalog={searchCatalog}
       viewContainer={viewContainer}
       detailsRenderer={detailsRenderer}
+      callback={callback}
+      setFailedTasks={setFailedTasks}
     />
   );
 };

--- a/src/components/quick-search/QuickSearchDetails.tsx
+++ b/src/components/quick-search/QuickSearchDetails.tsx
@@ -5,17 +5,21 @@ import {
   TextContent,
   Title,
 } from '@patternfly/react-core';
+import { useHistory } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { CatalogItem } from '@openshift-console/dynamic-plugin-sdk';
 import CatalogBadges from '../catalog/CatalogBadges';
 import { handleCta } from './utils/quick-search-utils';
-import { useHistory } from 'react-router';
+import { TaskSearchCallback } from '../pipeline-builder/types';
 
 import './QuickSearchDetails.scss';
 
 export type QuickSearchDetailsRendererProps = {
   selectedItem: CatalogItem;
   closeModal: () => void;
+  namespace?: string;
+  callback?: TaskSearchCallback;
+  setFailedTasks?: React.Dispatch<React.SetStateAction<string[]>>;
 };
 export type DetailsRendererFunction = (
   props: QuickSearchDetailsRendererProps,
@@ -29,6 +33,9 @@ const QuickSearchDetails: React.FC<QuickSearchDetailsProps> = ({
   selectedItem,
   closeModal,
   detailsRenderer,
+  namespace,
+  callback,
+  setFailedTasks,
 }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
   const history = useHistory();
@@ -69,7 +76,13 @@ const QuickSearchDetails: React.FC<QuickSearchDetailsProps> = ({
 
   return (
     <div className="ocs-quick-search-details">
-      {detailsContentRenderer({ selectedItem, closeModal })}
+      {detailsContentRenderer({
+        selectedItem,
+        closeModal,
+        namespace,
+        callback,
+        setFailedTasks,
+      })}
     </div>
   );
 };

--- a/src/components/quick-search/QuickSearchModal.tsx
+++ b/src/components/quick-search/QuickSearchModal.tsx
@@ -6,6 +6,7 @@ import QuickSearchModalBody from './QuickSearchModalBody';
 import { QuickSearchData } from './utils/quick-search-types';
 import './QuickSearchModal.scss';
 import { useBoundingClientRect } from './useBoundingClientRect';
+import { TaskSearchCallback } from '../pipeline-builder/types';
 
 interface QuickSearchModalProps {
   isOpen: boolean;
@@ -18,6 +19,8 @@ interface QuickSearchModalProps {
   limitItemCount?: number;
   icon?: React.ReactNode;
   detailsRenderer?: DetailsRendererFunction;
+  callback?: TaskSearchCallback;
+  setFailedTasks?: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
 const QuickSearchModal: React.FC<QuickSearchModalProps> = ({
@@ -31,6 +34,8 @@ const QuickSearchModal: React.FC<QuickSearchModalProps> = ({
   icon,
   limitItemCount,
   detailsRenderer,
+  callback,
+  setFailedTasks,
 }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
   const clientRect = useBoundingClientRect(viewContainer);
@@ -60,6 +65,8 @@ const QuickSearchModal: React.FC<QuickSearchModalProps> = ({
         detailsRenderer={detailsRenderer}
         maxDimension={{ maxHeight, maxWidth }}
         viewContainer={viewContainer}
+        callback={callback}
+        setFailedTasks={setFailedTasks}
       />
     </Modal>
   ) : null;

--- a/src/components/quick-search/QuickSearchModalBody.tsx
+++ b/src/components/quick-search/QuickSearchModalBody.tsx
@@ -17,6 +17,8 @@ import {
 } from '../utils/router';
 import { fetchArtifactHubTasks } from '../catalog/apis/artifactHub';
 import { normalizeArtifactHubTasks } from '../catalog/providers/useArtifactHubTasksProvider';
+import { TaskSearchCallback } from '../pipeline-builder/types';
+import useTasksProvider from '../catalog/providers/useTasksProvider';
 
 import './QuickSearchModalBody.scss';
 
@@ -30,7 +32,9 @@ interface QuickSearchModalBodyProps {
   icon?: React.ReactNode;
   detailsRenderer?: DetailsRendererFunction;
   maxDimension?: { maxHeight: number; maxWidth: number };
-  viewContainer?: HTMLElement; // pass the html container element to specify the movement boundary
+  viewContainer?: HTMLElement; // pass the html container element to specifythe movement boundary
+  callback?: TaskSearchCallback;
+  setFailedTasks?: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
 const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
@@ -44,6 +48,8 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
   detailsRenderer,
   maxDimension,
   viewContainer,
+  callback,
+  setFailedTasks,
 }) => {
   const DEFAULT_HEIGHT_WITH_NO_ITEMS = 60;
   const DEFAULT_HEIGHT_WITH_ITEMS = 483;
@@ -71,6 +77,7 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
     height: number;
     width: number;
   }>();
+  const [tektonTasks] = useTasksProvider({});
   const [draggableBoundary, setDraggableBoundary] =
     React.useState<string>(null);
   const ref = React.useRef<HTMLDivElement>();
@@ -162,8 +169,10 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
       // Ignore results if a newer search version has started
       if (currentVersion !== searchVersion.current) return;
 
-      const normalizedArtifactHubItems =
-        normalizeArtifactHubTasks(artifactHubResults);
+      const normalizedArtifactHubItems = normalizeArtifactHubTasks(
+        artifactHubResults,
+        tektonTasks,
+      );
       const { filteredItems, viewAllLinks, catalogItemTypes } = catalogResults;
 
       const mergedItems = [
@@ -361,6 +370,8 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
                 catalogItems?.find((item) => item.uid === itemId),
               );
             }}
+            callback={callback}
+            setFailedTasks={setFailedTasks}
           />
         )}
       </div>

--- a/src/components/quick-search/QuickSearchModalBody.tsx
+++ b/src/components/quick-search/QuickSearchModalBody.tsx
@@ -123,7 +123,10 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
   }, []);
 
   React.useEffect(() => {
-    if (catalogItems && !selectedItemId) {
+    if (
+      catalogItems &&
+      (!selectedItemId || catalogItems[0]?.uid !== selectedItemId)
+    ) {
       setSelectedItemId(catalogItems[0]?.uid);
       setSelectedItem(catalogItems[0]);
     }

--- a/src/components/quick-search/utils/quick-search-utils.tsx
+++ b/src/components/quick-search/utils/quick-search-utils.tsx
@@ -12,7 +12,7 @@ export const handleCta = async (
   item: CatalogItem,
   closeModal: () => void,
   history,
-  callbackProps: { [key: string]: string } = {},
+  callbackProps: { [key: string]: any } = {},
 ) => {
   e.preventDefault();
   const { href, callback } = item.cta;

--- a/src/components/task-quicksearch/PipelineQuickSearch.tsx
+++ b/src/components/task-quicksearch/PipelineQuickSearch.tsx
@@ -189,6 +189,8 @@ const Contents: React.FC<
       setIsOpen={setIsOpen}
       disableKeyboardOpen
       icon={<PlusCircleIcon width="1.5em" height="1.5em" />}
+      callback={savedCallback.current}
+      setFailedTasks={setFailedTasks}
       detailsRenderer={(props) => <PipelineQuickSearchDetails {...props} />}
     />
   );

--- a/src/components/task-quicksearch/PipelineQuickSearchDetails.tsx
+++ b/src/components/task-quicksearch/PipelineQuickSearchDetails.tsx
@@ -43,6 +43,9 @@ import './PipelineQuickSearchDetails.scss';
 const PipelineQuickSearchDetails: React.FC<QuickSearchDetailsRendererProps> = ({
   selectedItem,
   closeModal,
+  namespace,
+  callback,
+  setFailedTasks,
 }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
   const history = useHistory();
@@ -192,6 +195,11 @@ const PipelineQuickSearchDetails: React.FC<QuickSearchDetailsRendererProps> = ({
                 onClick={(e) => {
                   handleCta(e, selectedItem, closeModal, history, {
                     selectedVersion,
+                    selectedItem,
+                    isDevConsoleProxyAvailable,
+                    namespace,
+                    callback,
+                    setFailedTasks,
                   });
                 }}
               >


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/SRVKP-5546

**Description:**

Call to ArtifactHub was happening only once and if user search any task and if that task was not returned in first API call, the task was not listed in quick search. With this fix, if user searched something, API call will be made to ArtifactHub api and fetch the task

**Screen recording:**

![ODC-artifactHub-search-issue-handled](https://github.com/user-attachments/assets/34221c05-40ff-40df-bf28-bdfe7916bc8f)
