### PR TITLE
SRVKP-8011: Error in loading the Console Plugin overview page due breaking of VirtualizedTable component

### DIFF
--- a/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesList.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesList.tsx
@@ -120,6 +120,14 @@ const PipelineRunsForPipelinesList: React.FC<
     columnManagementID: '',
   });
 
+  const isEmptyData =
+    (!summaryDataFiltered || summaryDataFiltered.length === 0) &&
+    (!summaryData || summaryData.length === 0);
+
+  if (isEmptyData) {
+    return <EmptyMsg />;
+  }
+
   return (
     <VirtualizedTable
       columns={columns}

--- a/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesListK8s.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesListK8s.tsx
@@ -130,6 +130,13 @@ const PipelineRunsForPipelinesListK8s: React.FC<
     columnManagementID: '',
   });
 
+  const isEmptyData =
+    (!summaryDataFiltered || summaryDataFiltered.length === 0) &&
+    (!summaryData || summaryData.length === 0);
+
+  if (isEmptyData) {
+    return <EmptyMsg />;
+  }
   return (
     <VirtualizedTable
       columns={columns}

--- a/src/components/pipelines-overview/list-pages/PipelineRunsForRepositoriesList.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsForRepositoriesList.tsx
@@ -116,6 +116,14 @@ const PipelineRunsForRepositoriesList: React.FC<
     columnManagementID: '',
   });
 
+  const isEmptyData =
+    (!summaryDataFiltered || summaryDataFiltered.length === 0) &&
+    (!summaryData || summaryData.length === 0);
+
+  if (isEmptyData) {
+    return <EmptyMsg />;
+  }
+
   return (
     <VirtualizedTable
       columns={columns}


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/SRVKP-8011

**Description:**

If there is no data, then overview page was getting crashed due to sorting issue in `VirtualizedTable` component - https://issues.redhat.com//browse/OCPBUGS-56044 This workaround is to avoid rendering `VirtualizedTable` component if data is not there

**Steps to Reproduce:**

    1. Install 1.19.0 on 4.18.z OCP cluster 
    2. Enable the openshift pipelines console plugin 
    3. See the Pipelines Overview page 