### PR TITLE
SRVKP-8076: Handle "Oh No! Something Went Wrong" error when response is empty on the overview page

### DIFF
--- a/src/components/pipelines-overview/PipelineRunsStatusCard.tsx
+++ b/src/components/pipelines-overview/PipelineRunsStatusCard.tsx
@@ -296,31 +296,31 @@ const PipelinesRunsStatusCard: React.FC<PipelinesRunsStatusCardProps> = ({
     {
       x: t('Succeeded'),
       y: Math.round(
-        (100 * data?.summary?.[0].succeeded) / data?.summary?.[0].total,
+        (100 * data?.summary?.[0]?.succeeded) / data?.summary?.[0]?.total,
       ),
     },
     {
       x: t('Failed'),
       y: Math.round(
-        (100 * data?.summary?.[0].failed) / data?.summary?.[0].total,
+        (100 * data?.summary?.[0]?.failed) / data?.summary?.[0]?.total,
       ),
     },
     {
       x: t('Running'),
       y: Math.round(
-        (100 * data?.summary?.[0].running) / data?.summary?.[0].total,
+        (100 * data?.summary?.[0]?.running) / data?.summary?.[0]?.total,
       ),
     },
     {
       x: t('Cancelled'),
       y: Math.round(
-        (100 * data?.summary?.[0].cancelled) / data?.summary?.[0].total,
+        (100 * data?.summary?.[0]?.cancelled) / data?.summary?.[0]?.total,
       ),
     },
     {
       x: t('Others'),
       y: Math.round(
-        (100 * data?.summary?.[0].others) / data?.summary?.[0].total,
+        (100 * data?.summary?.[0]?.others) / data?.summary?.[0]?.total,
       ),
     },
   ];
@@ -397,7 +397,9 @@ const PipelinesRunsStatusCard: React.FC<PipelinesRunsStatusCardProps> = ({
                         }}
                       />
                     }
-                    title={`${data?.summary?.[0].succeeded}/${data?.summary?.[0].total}`}
+                    title={`${data?.summary?.[0]?.succeeded ?? 0}/${
+                      data?.summary?.[0]?.total ?? 0
+                    }`}
                     titleComponent={
                       <ChartLabel
                         style={{

--- a/src/components/pipelines-overview/PipelineRunsTotalCard.tsx
+++ b/src/components/pipelines-overview/PipelineRunsTotalCard.tsx
@@ -67,7 +67,7 @@ const PipelinesRunsTotalCard: React.FC<PipelinesRunsDurationProps> = ({
     )
       .then((response) => {
         setLoaded(true);
-        setData(response.summary?.[0].total);
+        setData(response?.summary?.[0]?.total);
       })
       .catch((e) => {
         console.error('Error in getSummary', e);


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/SRVKP-8076

**Before:**

<img width="1722" alt="Screenshot 2025-07-07 at 11 54 59 AM" src="https://github.com/user-attachments/assets/3cb0f6ba-4f75-4989-b296-3c40b2bd697d" />

--------

**After:**

![ODC-overview-page-empty-data-resolved](https://github.com/user-attachments/assets/43a15526-c33a-4d64-a8f9-978b7a5b2cd0)
