### PR TITLE
SRVKP-8209: Tasks provided by Artifacts hub do not work properly in pipeline builder page

### DIFF
--- a/src/components/catalog/apis/artifactHub.ts
+++ b/src/components/catalog/apis/artifactHub.ts
@@ -191,7 +191,7 @@ export const fetchArtifactHubTasks = async (
     const response = await fetch(
       `${ARTIFACTHUB_API_BASE_URL}/packages/search?ts_query_web=${encodeURIComponent(
         query,
-      )}&facets=false&sort=relevance&limit=${limit}&offset=0`,
+      )}&facets=false&sort=relevance&limit=${limit}&offset=0&kind=7`,
     );
     const data = await response.json();
     return data.packages || [];


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/SRVKP-8209

**Description:**

Listing only tekton tasks from artifact hub