### PR TITLE
SRVKP-6960: Fix pipelinerun cancelation status

### DIFF
--- a/src/components/utils/pipeline-filter-reducer.ts
+++ b/src/components/utils/pipeline-filter-reducer.ts
@@ -20,16 +20,25 @@ export enum SucceedConditionReason {
 export const pipelineRunStatus = (pipelineRun): ComputedStatus => {
   const conditions = _.get(pipelineRun, ['status', 'conditions'], []);
   if (conditions.length === 0) return null;
-
+  const cancelledReasons = [
+    'Cancelled',
+    'CancelledRunningFinally',
+    'StoppedRunningFinally',
+  ];
   const succeedCondition = conditions.find((c) => c.type === 'Succeeded');
-  const cancelledCondition = conditions.find((c) => c.reason === 'Cancelled');
+  const cancelledCondition = conditions.find((c) =>
+    cancelledReasons.includes(c.reason),
+  );
+  const cancelledStatus = conditions.find((c) => c.status === 'Unknown');
 
   if (
     [
       SucceedConditionReason.PipelineRunStopped,
       SucceedConditionReason.PipelineRunCancelled,
+      SucceedConditionReason.Cancelled,
     ].includes(pipelineRun.spec?.status) &&
-    !cancelledCondition
+    cancelledCondition &&
+    cancelledStatus
   ) {
     return ComputedStatus.Cancelling;
   }


### PR DESCRIPTION
If pipelinerun spec has status reason CancelledRunFinally and 
pipelinerun has few finally tasks, if a task gets fail then 
pipelinerun status showing as Cancelling on the console UI.
This patch handles Cancelling status of pipelinerun

Fixes: [SRVKP-6960](https://issues.redhat.com/browse/SRVKP-6960)

UI image before Fix:
<img width="1585" height="580" alt="Screenshot from 2025-07-30 12-41-06" src="https://github.com/user-attachments/assets/06672612-5f4f-48d5-bff8-9e42e2271c34" />

UI Image after Fix:

<img width="1556" height="546" alt="Screenshot from 2025-07-30 12-37-20" src="https://github.com/user-attachments/assets/bd4aa852-24cd-42c1-9341-6999c53fb5ff" />
