### PR TITLE
SRVKP-8351: Fix details page item alignment

### DIFF
--- a/src/components/pipelineRuns-details/PipelineRunDetails.tsx
+++ b/src/components/pipelineRuns-details/PipelineRunDetails.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { PipelineRunModel } from '../../models';
 import PipelineRunVisualization from './PipelineRunVisualization';
 import PipelineRunCustomDetails from './PipelineRunCustomDetails';
-import { PageSection, Title } from '@patternfly/react-core';
+import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
 
 type PipelineRunDetailsProps = {
   obj: PipelineRunKind;
@@ -19,14 +19,14 @@ const PipelineRunDetails: React.FC<PipelineRunDetailsProps> = ({
     <PageSection isFilled variant="light">
       <Title headingLevel="h2">{t('PipelineRun details')}</Title>
       <PipelineRunVisualization pipelineRun={pipelineRun} />
-      <div className="row">
-        <div className="col-sm-6">
+      <Grid hasGutter>
+        <GridItem sm={6}>
           <ResourceSummary resource={pipelineRun} model={PipelineRunModel} />
-        </div>
-        <div className="col-sm-6 odc-pipeline-run-details__customDetails">
+        </GridItem>
+        <GridItem sm={6} className="odc-pipeline-run-details__customDetails">
           <PipelineRunCustomDetails pipelineRun={pipelineRun} />
-        </div>
-      </div>
+        </GridItem>
+      </Grid>
     </PageSection>
   );
 };

--- a/src/components/pipelines-details/PipelineDetails.tsx
+++ b/src/components/pipelines-details/PipelineDetails.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { PageSection, Title } from '@patternfly/react-core';
+import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
 
 import PipelineVisualization from './PipelineVisualization';
 import { ResourceSummary } from '../details-page/details-page';
@@ -29,11 +29,11 @@ const PipelineDetails: React.FC<PipelineDetailsTabProps> = ({
       <PageSection isFilled variant="light">
         <Title headingLevel="h2">{t('Pipeline details')}</Title>
         <PipelineVisualization pipeline={pipeline} />
-        <div className="row">
-          <div className="col-sm-6">
+        <Grid hasGutter>
+          <GridItem sm={6}>
             <ResourceSummary resource={pipeline} model={PipelineModel} />
-          </div>
-          <div className="col-sm-6">
+          </GridItem>
+          <GridItem sm={6}>
             <TriggerTemplateResourceLink
               namespace={pipeline.metadata.namespace}
               model={TriggerTemplateModel}
@@ -50,8 +50,8 @@ const PipelineDetails: React.FC<PipelineDetailsTabProps> = ({
               title={t('Finally tasks')}
             />
             <WorkspaceDefinitionList obj={pipeline} />
-          </div>
-        </div>
+          </GridItem>
+        </Grid>
       </PageSection>
     </>
   );

--- a/src/components/pipelines-tasks/tasks-details-pages/TaskRunDetailsSection.tsx
+++ b/src/components/pipelines-tasks/tasks-details-pages/TaskRunDetailsSection.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Title } from '@patternfly/react-core';
+import { Grid, GridItem, Title } from '@patternfly/react-core';
 
 import TaskRunDetailsStatus from './TaskRunDetailsStatus';
 import { TaskRunModel } from '../../../models';
@@ -22,14 +22,14 @@ const TaskRunDetailsSection: React.FC<TaskRunDetailsSectionProps> = ({
           taskRunLabel: t(TaskRunModel.labelKey),
         })}
       </Title>
-      <div className="row">
-        <div className="col-sm-6">
+      <Grid hasGutter>
+        <GridItem sm={6}>
           <ResourceSummary resource={taskRun} model={TaskRunModel} />
-        </div>
-        <div className="col-sm-6 odc-taskrun-details__status">
+        </GridItem>
+        <GridItem sm={6} className="odc-taskrun-details__status">
           <TaskRunDetailsStatus taskRun={taskRun} />
-        </div>
-      </div>
+        </GridItem>
+      </Grid>
     </>
   );
 };

--- a/src/components/tasks/TaskDetails.tsx
+++ b/src/components/tasks/TaskDetails.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { TaskModel } from '../../models';
 import { TaskKind } from '../../types';
-import { PageSection } from '@patternfly/react-core';
+import { Grid, GridItem, PageSection } from '@patternfly/react-core';
 import { SectionHeading } from '../pipelines-tasks/tasks-details-pages/headings';
 import { ResourceSummary } from '../details-page/details-page';
 import { WorkspaceDefinitionList } from '../pipelines-tasks';
@@ -20,14 +20,14 @@ const TaskDetails: React.FC<TaskDetailsProps> = ({ obj: task }) => {
           taskLabel: t(TaskModel.labelKey),
         })}
       />
-      <div className="row">
-        <div className="col-sm-6">
+      <Grid hasGutter>
+        <GridItem sm={6}>
           <ResourceSummary resource={task} model={TaskModel} />
-        </div>
-        <div className="col-sm-6 odc-task-details__status">
+        </GridItem>
+        <GridItem sm={6} className="odc-task-details__status">
           <WorkspaceDefinitionList obj={task} />
-        </div>
-      </div>
+        </GridItem>
+      </Grid>
     </PageSection>
   );
 };


### PR DESCRIPTION
**Before:**
- Task details page
<img width="1131" height="749" alt="image" src="https://github.com/user-attachments/assets/54062661-a895-4052-80d3-44269824471a" />

- TaskRun details page
<img width="1422" height="746" alt="image" src="https://github.com/user-attachments/assets/2493d636-1af3-4b97-a705-8a97e73832a3" />

- PipelineRun details page
<img width="1486" height="823" alt="image" src="https://github.com/user-attachments/assets/7a8d37c8-8366-4ded-9981-2335163424de" />

- Pipeline details page
<img width="1454" height="812" alt="image" src="https://github.com/user-attachments/assets/e0f84537-f9a4-45d4-bd01-0623f08d4731" />


**After:**
- Task details page
<img width="1160" height="706" alt="image" src="https://github.com/user-attachments/assets/91ac6a16-b56c-43d6-b341-fed13ac7cc96" />

- TaskRun details page
<img width="1227" height="745" alt="image" src="https://github.com/user-attachments/assets/6e1fd366-c9c1-427d-9fda-b452a6892e4c" />

- PipelineRun details page
<img width="1171" height="811" alt="image" src="https://github.com/user-attachments/assets/230f39ed-4a04-44d6-94e2-fe1a94f77980" />

- Pipeline details page
<img width="1453" height="795" alt="image" src="https://github.com/user-attachments/assets/b4348d43-b851-4fa6-a1fe-c19a47e5d6fd" />
