### PR TITLE
feat: Enable 'All' namespaces view for non-admin users

### DIFF
--- a/src/components/pipelines-overview/NamespaceDropdown.tsx
+++ b/src/components/pipelines-overview/NamespaceDropdown.tsx
@@ -58,11 +58,15 @@ const NameSpaceDropdown: React.FC<NameSpaceDropdownProps> = ({
       items.push({ title: selected, key: selected }); // Add current namespace if it isn't included
     }
     items.sort((a, b) => alphanumericCompare(a.title, b.title));
-    if (canListNS) {
+
+    // Always show "All" option - behavior depends on user permissions:
+    // - Admins (canListNS=true): See all cluster namespaces
+    // - Non-admins (canListNS=false): See all their accessible namespaces
+    if (projects.length > 0) {
       items.unshift({ title: allNamespacesTitle, key: ALL_NAMESPACES_KEY });
     }
     return items;
-  }, [projects, projectsLoaded]);
+  }, [projects, projectsLoaded, allNamespacesTitle]);
 
   return (
     <>

--- a/src/components/pipelines-overview/PipelinesOverviewPage.tsx
+++ b/src/components/pipelines-overview/PipelinesOverviewPage.tsx
@@ -48,9 +48,8 @@ const PipelinesOverviewPage: React.FC = () => {
     loadFormat: parsePrometheusDuration,
   });
 
-  if (!canListNS && activeNamespace === ALL_NAMESPACES_KEY) {
-    return <AllProjectsPage pageTitle={t('Overview')} />;
-  }
+  // Remove restriction - allow all users to see "All" namespaces view
+  // The data will be scoped to namespaces they have access to based on their permissions
 
   return (
     <>

--- a/src/components/pipelines-overview/PipelinesOverviewPageK8s.tsx
+++ b/src/components/pipelines-overview/PipelinesOverviewPageK8s.tsx
@@ -50,9 +50,8 @@ const PipelinesOverviewPageK8s: React.FC = () => {
     loadFormat: parsePrometheusDuration,
   });
 
-  if (!canListNS && activeNamespace === ALL_NAMESPACES_KEY) {
-    return <AllProjectsPage pageTitle={t('Overview')} />;
-  }
+  // Remove restriction - allow all users to see "All" namespaces view
+  // The data will be scoped to namespaces they have access to based on their permissions
 
   return (
     <>


### PR DESCRIPTION
- Show 'All' option in namespace dropdown for all users with accessible namespaces
- Remove admin-only restriction from pipelines overview pages
- Non-admins see pipeline data scoped to their accessible namespaces
- Maintains security through existing RBAC permissions

Fixes: [SRVKP-6766](https://issues.redhat.com//browse/SRVKP-6766)