### PR TITLE
SRVKP-8256: Fix manual approval gate pipelinerun UI filer

### DIFF
--- a/src/components/approval-tasks/ApprovalTasksList.tsx
+++ b/src/components/approval-tasks/ApprovalTasksList.tsx
@@ -27,7 +27,14 @@ type ApprovalTasksListProps = {
 
 const pipelineApprovalFilterReducer = (obj: ApprovalTaskKind, pipelineRuns) => {
   const pipelineRun = getPipelineRunOfApprovalTask(pipelineRuns, obj);
-  return getApprovalStatus(obj, pipelineRun) || ApprovalStatus.Unknown;
+  const status = getApprovalStatus(obj, pipelineRun);
+  if (
+    status === ApprovalStatus.PartiallyApproved ||
+    status === ApprovalStatus.AlmostApproved
+  ) {
+    return ApprovalStatus.RequestSent;
+  }
+  return status ||  ApprovalStatus.Unknown;
 };
 
 const ApprovalTasksList: React.FC<ApprovalTasksListProps> = ({


### PR DESCRIPTION
This patch fixes any partially approved pipelinerun to show in the 
pending category of manual approval gate pipelinerun UI filter

fixes: [SRVKP-8256](https://issues.redhat.com/browse/SRVKP-8256)

After fix:
<img width="1768" height="962" alt="Screenshot From 2025-09-01 16-45-31" src="https://github.com/user-attachments/assets/842569fa-739b-458a-bdc5-a30fb88e6c5e" />
