### PR TITLE
SRVKP-8571: Pipeline builder UI fails to save buildah task with default BUILD_ARGS parameter

### DIFF
--- a/src/components/pipeline-builder/__tests__/validation-utils.spec.ts
+++ b/src/components/pipeline-builder/__tests__/validation-utils.spec.ts
@@ -434,6 +434,86 @@ describe('Pipeline Build validation schema', () => {
           .catch(shouldHavePassed);
       });
 
+      it('should pass if the task params is string and empty', async () => {
+        await withFormData({
+          ...initialPipelineFormData,
+          tasks: [
+            {
+              name: 'test-task',
+              taskSpec: embeddedTaskSpec,
+              params: [{ name: 'test_param', value: '' }],
+            },
+          ],
+        })
+          .then(hasResults)
+          .catch(shouldHavePassed);
+      });
+
+      it('should pass if the task params is array and empty', async () => {
+        await withFormData({
+          ...initialPipelineFormData,
+          tasks: [
+            {
+              name: 'test-task',
+              taskSpec: embeddedTaskSpec,
+              params: [{ name: 'test_param', value: [] }],
+            },
+          ],
+        })
+          .then(hasResults)
+          .catch(shouldHavePassed);
+      });
+
+      it('should pass if the task params is array and has empty string as value', async () => {
+        await withFormData({
+          ...initialPipelineFormData,
+          tasks: [
+            {
+              name: 'test-task',
+              taskSpec: embeddedTaskSpec,
+              params: [{ name: 'test_param', value: [''] }],
+            },
+          ],
+        })
+          .then(hasResults)
+          .catch(shouldHavePassed);
+      });
+
+      it('should pass if the task params is string and has a value', async () => {
+        await withFormData({
+          ...initialPipelineFormData,
+          tasks: [
+            {
+              name: 'test-task',
+              taskSpec: embeddedTaskSpec,
+              params: [{ name: 'test_param', value: 'some value' }],
+            },
+          ],
+        })
+          .then(hasResults)
+          .catch(shouldHavePassed);
+      });
+
+      it('should pass if the task params is array and has values', async () => {
+        await withFormData({
+          ...initialPipelineFormData,
+          tasks: [
+            {
+              name: 'test-task',
+              taskSpec: embeddedTaskSpec,
+              params: [
+                {
+                  name: 'test_param',
+                  value: ['some value arg1', 'some value arg2'],
+                },
+              ],
+            },
+          ],
+        })
+          .then(hasResults)
+          .catch(shouldHavePassed);
+      });
+
       it('should fail if the taskSpec params are required and not provided', async () => {
         const taskSpecWithParam = merge({}, embeddedTaskSpec, {
           params: [{ name: 'name', description: 'Your name to echo out' }],

--- a/src/components/pipeline-builder/validation-utils.ts
+++ b/src/components/pipeline-builder/validation-utils.ts
@@ -223,10 +223,11 @@ const taskValidation = (
               name: yup.string().required(t('Required')),
               value: yup.lazy((value) => {
                 if (Array.isArray(value)) {
-                  return yup.array().of(yup.string().required(t('Required')));
+                  return yup.array().of(yup.string());
                 }
                 return yup.string();
               }),
+              type: yup.string().oneOf(['string', 'array']),
             }),
           )
           .test(


### PR DESCRIPTION
Pipeline builder UI fails to save buildah task with default BUILD_ARGS parameter

Workaround:

This issue can be worked around via removing the element, making the value an empty array - but the UI does not indicate that this needs to be done.

Prerequisites (if any, like setup, operators/versions):
OpenShift Pipelines operator

Steps to Reproduce
Navigate to the OpenShift Pipelines Operator pipeline builder in the OpenShift console.
Add the buildah task to a new pipeline.
Observe the BUILD_ARGS parameter in the side panel. Note that its default value is [""] (a single element with an empty string).
Do not modify this parameter.
Attempt to save the pipeline by clicking the "Create" button.
 

Actual Results:
The UI displays a validation error and prevents the pipeline from being saved.

Expected results:
The pipeline should be created successfully, as the buildah task can run without issue with the default [""] value for the BUILD_ARGS parameter.

Reproducibility (Always/Intermittent/Only Once):
Always

Current behavior after fix

https://github.com/user-attachments/assets/53bbe03b-f4f4-4034-9901-09ccc46ef444