### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for console-plugin-1-15-console-plugin

### DIFF
--- a/.konflux/dockerfiles/console-plugin.Dockerfile
+++ b/.konflux/dockerfiles/console-plugin.Dockerfile
@@ -31,4 +31,5 @@ LABEL \
       description="Red Hat OpenShift Pipelines Console Plugin" \
       io.k8s.display-name="Red Hat OpenShift Pipelines Console Plugin" \
       io.k8s.description="Red Hat OpenShift Pipelines Console Plugin" \
-      io.openshift.tags="pipelines,tekton,openshift"
+      io.openshift.tags="pipelines,tekton,openshift" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.15::el8"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
