### PR TITLE
fix: [SRVKP-8205] sync issue while creating pipeline using yaml editor

### DIFF
--- a/src/components/pipeline-builder/PipelineBuilderForm.tsx
+++ b/src/components/pipeline-builder/PipelineBuilderForm.tsx
@@ -280,7 +280,7 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
                 submitLabel={existingPipeline ? t('Save') : t('Create')}
                 disableSubmit={
                   editorType === EditorType.YAML
-                    ? !dirty
+                    ? !dirty || !_.isEmpty(errors) || !!status?.submitError
                     : !dirty ||
                       !_.isEmpty(errors) ||
                       !_.isEmpty(status?.tasks) ||

--- a/src/components/pipeline-builder/SyncedEditorField.tsx
+++ b/src/components/pipeline-builder/SyncedEditorField.tsx
@@ -140,6 +140,39 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
     }
   }, [editorType, field.value, formContext.isDisabled, name, setFieldValue]);
 
+  React.useEffect(() => {
+    // Sync formData when yamlData changes (while in YAML mode)
+    if (editorType === EditorType.YAML && yamlData) {
+      const syncFormDataFromYaml = async () => {
+        try {
+          const content = safeYAMLToJS(yamlData);
+          if (!_.isEmpty(content) && formContext.sanitizeTo) {
+            const sanitizedContent = await formContext.sanitizeTo(content);
+            if (
+              typeof sanitizedContent === 'object' &&
+              !_.isEmpty(sanitizedContent)
+            ) {
+              // Only update if the content is different
+              if (!_.isEqual(sanitizedContent, formData)) {
+                setFieldValue(formContext.name, sanitizedContent);
+              }
+            }
+          }
+        } catch (e) {
+          console.warn('Failed to sync form data from YAML', e);
+        }
+      };
+      syncFormDataFromYaml();
+    }
+  }, [
+    yamlData,
+    editorType,
+    formContext.sanitizeTo,
+    formContext.name,
+    setFieldValue,
+    formData,
+  ]);
+
   return (
     <>
       <div


### PR DESCRIPTION
Description of problem: YAML view in pipelines console does not work

Workaround: From YAML view, after entering the pipelines config, first switch to `pipeline builder` view, then again to `YAML view`, then client on `create`.

Prerequisites (if any, like setup, operators/versions): OpenShift Pipelines 1.19 on OCP version 4.19

Steps to Reproduce
Install OpenShift Pipelines 1.19 on OCP version 4.19
Create any sample pipeline from the YAML view in pipelines section of web console.
Click on `Create`. The Create option will not work.

Actual results: The pipeline is not getting created when we click on `Create`.

Expected results: The pipeline should be created from web console YAML view.

Reproducibility (Always/Intermittent/Only Once): Always

Screen recording before fix:
https://github.com/user-attachments/assets/103e3403-501a-4c49-917f-196311228a41

Screen recording after fix:
https://github.com/user-attachments/assets/a52815b9-7c1f-4892-b62f-f331c6b60d90
