### PR TITLE
SRVKP-8998: fix Pipeline Builder UI shows stale parameter data for tasks with same name across namespaces

### DIFF
--- a/src/components/catalog/apis/artifactHub.ts
+++ b/src/components/catalog/apis/artifactHub.ts
@@ -102,6 +102,7 @@ export const createArtifactHubTask = (
   namespace: string,
   version: string,
   isDevConsoleProxyAvailable?: boolean,
+  customName?: string,
 ) => {
   const fetchTask = async (): Promise<K8sResourceKind> => {
     if (isDevConsoleProxyAvailable) {
@@ -122,6 +123,9 @@ export const createArtifactHubTask = (
   return fetchTask()
     .then((task: K8sResourceKind) => {
       task.metadata.namespace = namespace;
+      if (customName) {
+        task.metadata.name = customName;
+      }
       task.metadata.annotations = {
         ...task.metadata.annotations,
         [TektonTaskAnnotation.installedFrom]: ARTIFACTHUB,
@@ -185,6 +189,7 @@ export const updateArtifactHubTask = async (
 
 export const fetchArtifactHubTasks = async (
   query: string,
+  // eslint-disable-next-line @typescript-eslint/no-inferrable-types
   limit: number = 20,
 ): Promise<ArtifactHubTask[]> => {
   try {

--- a/src/components/pipeline-builder/PipelineBuilderForm.tsx
+++ b/src/components/pipeline-builder/PipelineBuilderForm.tsx
@@ -105,7 +105,6 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
   const updateTasks = (changes: CleanupResults): void => {
     const { tasks, listTasks, finallyTasks, finallyListTasks, loadingTasks } =
       changes;
-
     setFieldValue('formData', {
       ...formData,
       tasks,
@@ -179,6 +178,20 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
     }
   }, [selectedTask]);
 
+  const handleRemoveTask = React.useCallback(
+    async (taskName: string) => {
+      setSelectedTask(null);
+      updateTasks(
+        applyChange(
+          taskGroup,
+          { type: UpdateOperationType.REMOVE_TASK, data: { taskName } },
+          namespace,
+        ),
+      );
+    },
+    [namespace, taskGroup, updateTasks],
+  );
+
   return (
     <Drawer isExpanded={!!selectedTask} position="right">
       <DrawerContent
@@ -206,19 +219,7 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
               onRemoveTask={(taskName: string) => {
                 launchModal(RemoveTaskModal, {
                   taskName,
-                  onRemove: () => {
-                    setSelectedTask(null);
-                    updateTasks(
-                      applyChange(
-                        taskGroup,
-                        {
-                          type: UpdateOperationType.REMOVE_TASK,
-                          data: { taskName },
-                        },
-                        namespace,
-                      ),
-                    );
-                  },
+                  onRemove: () => handleRemoveTask(taskName),
                 });
               }}
               selectedData={selectedTask}

--- a/src/components/quick-search/utils/quick-search-utils.tsx
+++ b/src/components/quick-search/utils/quick-search-utils.tsx
@@ -20,7 +20,7 @@ export const handleCta = async (
     closeModal();
     await callback({
       ...callbackProps,
-      selectedVersion: item.data?.version,
+      selectedVersion: item.data?.version ?? item.data?.task?.version,
       selectedItem: item,
     });
     removeQueryArgument('catalogSearch');

--- a/src/components/task-quicksearch/pipeline-quicksearch-utils.ts
+++ b/src/components/task-quicksearch/pipeline-quicksearch-utils.ts
@@ -174,12 +174,19 @@ export const updateTask = async (
     });
 };
 
-export const createTask = (url: string, namespace: string) => {
+export const createTask = (
+  url: string,
+  namespace: string,
+  customName?: string,
+) => {
   return consoleFetch(url)
     .then(async (res) => {
       const yaml = await res.text();
       const task = load(yaml) as TaskKind;
       task.metadata.namespace = namespace;
+      if (customName) {
+        task.metadata.name = customName;
+      }
       task.metadata.annotations = {
         ...task.metadata.annotations,
         [TektonTaskAnnotation.installedFrom]: TEKTONHUB,


### PR DESCRIPTION
## **Description of the Problem**

The customer experiences confusion and incorrect task configuration when editing pipelines through the **Pipeline Builder UI**.
Because the side panel displays **stale or incorrect parameter data** for tasks that share the same name across namespaces, users may unknowingly save or deploy pipelines with invalid configurations.
This leads to **pipeline failures** and **loss of confidence** in the UI’s reliability.

---

## **Workaround**

A **partial workaround** exists:
Users can manually verify and edit the **Pipeline YAML** to ensure it references the correct task and parameters from the intended namespace.
However, this requires advanced Tekton knowledge and defeats the purpose of the visual builder — making it unsuitable for most users.

---

## **Versions**

* **OCP Version:** 4.16
* **Pipelines Operator Version:** 1.17, 1.18

---

## **Steps to Reproduce**

1. Create a task with a name identical to an existing task in the `openshift-pipelines` namespace.
2. Using the **Pipeline Builder UI**, create a new pipeline and add the task from the `openshift-pipelines` namespace.
3. Observe that the **Pipeline Builder side panel** shows parameters from the task in the current namespace instead of the selected one.
4. Check the **YAML editor** — it correctly references the task from the cluster resolver and displays the accurate parameter data.

---

## **Reproducibility**

* **Yes**, reproducible **Always**

---

## **Customer Impact**

* **Customer Name:** Jeffrey Luckett
* **Revenue Impact:** Medium — misconfigured pipelines can lead to failed runs and CI/CD delays, increasing support overhead and reducing user trust in the console plugin UI.

---

## **Root Cause**

In the previous implementation, installation of **Artifact Hub tasks** failed because tasks with the same names already existed in the cluster resolver or namespace.
As a result:

* The data displayed in the **Pipeline Builder form** became stale.
* When tasks were removed from the Pipeline Builder, the actual cluster task was **not uninstalled**.
* Upon reinstalling a task with the same name, the old (stale) data persisted.

---

## **Fix Implemented**

* Added a **check for existing tasks** with the same name before installation.
* If a conflict is found, a **safe name** is generated and used for creating a new task.
* During task removal, the system:

  * Checks if a task with the same name exists.
  * If yes, **uninstalls** it to maintain data hygiene.
  * If not, it updates the **React state** accordingly.

This ensures consistent task data and prevents stale or incorrect parameter references.

---

## **Screen Recordings**

(Since GitHub upload size limits apply, videos are uploaded to Google Drive)

* 🎥 [[Before Fix – Showcasing Issue](https://drive.google.com/drive/folders/1THodXuVY6VyDOf_xiMcc8uOKBh7fP-LC)]
* 🎥 [[After Fix – Validation](https://drive.google.com/drive/folders/1THodXuVY6VyDOf_xiMcc8uOKBh7fP-LC)]