### PR TITLE
fix: updated BUILDER and RUNTIME in konflux/dockerfile

### DIFF
--- a/.konflux/dockerfiles/console-plugin.Dockerfile
+++ b/.konflux/dockerfiles/console-plugin.Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILDER=registry.redhat.io/ubi9/nodejs-18@sha256:4c71d9a21ab7c87c3de4d9e49228fb9724142c40e21503e2d9a1e291941478f6
-ARG RUNTIME=registry.access.redhat.com/ubi9/nginx-124@sha256:6465906193329d883dfe2de4077e5618420fa39885107f6dacd87fe00629ef4c
+ARG BUILDER=registry.redhat.io/ubi9/nodejs-20@sha256:938970e0012ddc784adda181ede5bc00a4dfda5e259ee4a57f67973720a565d1
+ARG RUNTIME=registry.redhat.io/ubi9/nginx-124@sha256:aa73fdb10af2bf24611ba714a412c2e65cec88a00eee628a0f2a75e564ec18f2
 
 FROM $BUILDER AS builder-ui
 


### PR DESCRIPTION
### Summary
This PR updates the UI plugin's Dockerfile to use the latest UBI 9 base images:

- **Builder:** NodeJS 20 on UBI 9
- **Runtime:** Nginx 1.24 on UBI 9

### Changes Made
- Updated `ARG BUILDER` to: (https://catalog.redhat.com/en/software/containers/ubi9/nginx-124/657b066b6c1bc124a1d7ff39#get-this-image)
- Updated `ARG RUNTIME` to: (https://catalog.redhat.com/en/software/containers/ubi9/nginx-124/657b066b6c1bc124a1d7ff39#get-this-image)

### Notes
- These updates address CVE-related vulnerabilities
- No functional changes to the application code.
