### PR TITLE
SRVKP-8835: updated the sort method for pipeline run and taskrun

### DIFF
--- a/src/components/pipelineRuns-list/usePipelineRunsColumns.ts
+++ b/src/components/pipelineRuns-list/usePipelineRunsColumns.ts
@@ -8,9 +8,8 @@ import {
   RepositoryLabels,
 } from '../../consts';
 import { PipelineRunKind } from '../../types';
+import { sortPipelineAndTaskRunsByDuration } from '../pipelines-details/pipeline-step-utils';
 import { tableColumnClasses } from './PipelineRunsRow';
-import { sortPipelineRunsByDuration } from '../pipelines-details/pipeline-step-utils';
-
 const usePipelineRunsColumns = (
   namespace: string,
   repositoryPLRs?: boolean,
@@ -77,7 +76,7 @@ const usePipelineRunsColumns = (
     {
       id: 'duration',
       title: t('Duration'),
-      sort: sortPipelineRunsByDuration,
+      sort: sortPipelineAndTaskRunsByDuration,
       transforms: [sortable],
       props: { className: tableColumnClasses.duration },
     },

--- a/src/components/pipelines-details/__tests__/pipeline-step-utils.spec.ts
+++ b/src/components/pipelines-details/__tests__/pipeline-step-utils.spec.ts
@@ -1,6 +1,6 @@
 import { ComputedStatus, PipelineRunKind } from '../../../types';
 import { pipelineRunStatus } from '../../utils/pipeline-filter-reducer';
-import { sortPipelineRunsByDuration } from '../pipeline-step-utils';
+import { sortPipelineAndTaskRunsByDuration } from '../pipeline-step-utils';
 
 // Mock the pipeline-filter-reducer module
 jest.mock('../../utils/pipeline-filter-reducer', () => ({
@@ -11,7 +11,7 @@ const mockPipelineRunStatus = pipelineRunStatus as jest.MockedFunction<
   typeof pipelineRunStatus
 >;
 
-describe('sortPipelineRunsByDuration', () => {
+describe('sortPipelineAndTaskRunsByDuration', () => {
   const createMockPipelineRun = (
     name: string,
     startTime?: string,
@@ -63,7 +63,7 @@ describe('sortPipelineRunsByDuration', () => {
         ),
       ];
 
-      const result = sortPipelineRunsByDuration(pipelineRuns, 'asc');
+      const result = sortPipelineAndTaskRunsByDuration(pipelineRuns, 'asc');
 
       expect(result[0].metadata.name).toBe('run-very-short');
       expect(result[1].metadata.name).toBe('run-short');
@@ -88,7 +88,7 @@ describe('sortPipelineRunsByDuration', () => {
         ),
       ];
 
-      const result = sortPipelineRunsByDuration(pipelineRuns, 'asc');
+      const result = sortPipelineAndTaskRunsByDuration(pipelineRuns, 'asc');
 
       expect(result[0].metadata.name).toBe('run-completed');
       expect(result[1].metadata.name).toBe('run-running');
@@ -117,7 +117,7 @@ describe('sortPipelineRunsByDuration', () => {
         ),
       ];
 
-      const result = sortPipelineRunsByDuration(pipelineRuns, 'desc');
+      const result = sortPipelineAndTaskRunsByDuration(pipelineRuns, 'desc');
 
       expect(result[0].metadata.name).toBe('run-long');
       expect(result[1].metadata.name).toBe('run-medium');
@@ -138,7 +138,7 @@ describe('sortPipelineRunsByDuration', () => {
         ),
       ];
 
-      const result = sortPipelineRunsByDuration(pipelineRuns, 'asc');
+      const result = sortPipelineAndTaskRunsByDuration(pipelineRuns, 'asc');
 
       expect(result[0].metadata.name).toBe('run-no-completion');
       expect(result[1].metadata.name).toBe('run-normal');
@@ -163,7 +163,7 @@ describe('sortPipelineRunsByDuration', () => {
         ),
       ];
 
-      const result = sortPipelineRunsByDuration(pipelineRuns, 'asc');
+      const result = sortPipelineAndTaskRunsByDuration(pipelineRuns, 'asc');
 
       expect(result[0].metadata.name).toBe('run-a');
       expect(result[1].metadata.name).toBe('run-m');
@@ -185,7 +185,7 @@ describe('sortPipelineRunsByDuration', () => {
       ];
 
       const originalOrder = pipelineRuns.map((run) => run.metadata.name);
-      sortPipelineRunsByDuration(pipelineRuns, 'asc');
+      sortPipelineAndTaskRunsByDuration(pipelineRuns, 'asc');
 
       // Original array should remain unchanged
       expect(pipelineRuns.map((run) => run.metadata.name)).toEqual(
@@ -194,7 +194,7 @@ describe('sortPipelineRunsByDuration', () => {
     });
 
     it('should handle empty array', () => {
-      const result = sortPipelineRunsByDuration([], 'asc');
+      const result = sortPipelineAndTaskRunsByDuration([], 'asc');
       expect(result).toEqual([]);
     });
 
@@ -207,7 +207,7 @@ describe('sortPipelineRunsByDuration', () => {
         ),
       ];
 
-      const result = sortPipelineRunsByDuration(pipelineRuns, 'asc');
+      const result = sortPipelineAndTaskRunsByDuration(pipelineRuns, 'asc');
 
       expect(result).toHaveLength(1);
       expect(result[0].metadata.name).toBe('single-run');
@@ -229,7 +229,7 @@ describe('sortPipelineRunsByDuration', () => {
         ),
       ];
 
-      const result = sortPipelineRunsByDuration(pipelineRuns, 'asc');
+      const result = sortPipelineAndTaskRunsByDuration(pipelineRuns, 'asc');
 
       // Should handle negative duration gracefully
       expect(result).toHaveLength(2);

--- a/src/components/pipelines-details/pipeline-step-utils.ts
+++ b/src/components/pipelines-details/pipeline-step-utils.ts
@@ -1,7 +1,6 @@
-import { ComputedStatus } from '../../types';
-import { calculateDuration } from '../utils/pipeline-utils';
-import { PipelineRunKind } from '../../types';
+import { ComputedStatus, PipelineRunKind, TaskRunKind } from '../../types';
 import { pipelineRunStatus } from '../utils/pipeline-filter-reducer';
+import { calculateDuration } from '../utils/pipeline-utils';
 
 enum TerminatedReasons {
   Completed = 'Completed',
@@ -100,12 +99,14 @@ export const createStepStatus = (
   };
 };
 
-export const sortPipelineRunsByDuration = (
-  pipelineRuns: PipelineRunKind[],
+export const sortPipelineAndTaskRunsByDuration = <
+  T extends PipelineRunKind | TaskRunKind,
+>(
+  runs: T[],
   direction: 'asc' | 'desc',
-) => {
-  return [...pipelineRuns].sort((a: PipelineRunKind, b: PipelineRunKind) => {
-    const getDurationMs = (run: PipelineRunKind): number => {
+): T[] => {
+  return [...runs].sort((a: T, b: T) => {
+    const getDurationMs = (run: T): number => {
       const startTime = run?.status?.startTime ?? null;
       const completionTime = run?.status?.completionTime ?? null;
 

--- a/src/components/pipelines-tasks/TaskRunsList.tsx
+++ b/src/components/pipelines-tasks/TaskRunsList.tsx
@@ -20,6 +20,7 @@ import { getReferenceForModel } from '../pipelines-overview/utils';
 import { useTaskRunsFilters } from './useTaskRunsFilters';
 import { useLoadMoreOnScroll } from '../utils/tekton-results';
 import { ListPageFilter } from '../list-pages/ListPageFilter';
+import { sortPipelineAndTaskRunsByDuration } from '../pipelines-details/pipeline-step-utils';
 
 interface TaskRunsListPageProps {
   showTitle?: boolean;
@@ -79,7 +80,7 @@ const useTaskColumns = () => {
     },
     {
       id: 'duration',
-      sort: 'status.completionTime',
+      sort: sortPipelineAndTaskRunsByDuration,
       title: t('Duration'),
       transforms: [sortable],
       additional: true,


### PR DESCRIPTION
### **Fix TaskRun Sorting by Duration**

**Description of problem:**
When sorting **TaskRuns** by duration, the list was incorrectly sorted based on **completion time** instead of the actual elapsed duration.
This caused incorrect ordering — for example:

* “6 minutes 5 seconds” appearing **above** “50 seconds”
* “3 minutes 10 seconds” appearing **below** “1 minute 5 seconds”

**Root cause:**
The sorting logic used the TaskRun’s `completionTime` value rather than the computed duration field.

**Fix implemented:**

* Updated the TaskRun list to sort by **numeric duration** (elapsed time in seconds) instead of completion time.

**Steps to reproduce:**

1. Have multiple TaskRuns with a wide range of durations (seconds → several minutes).
2. Observe that the TaskRuns are sorted incorrectly by completion time instead of elapsed duration.

**Expected result:**
TaskRuns should be sorted based on the actual numeric duration (in seconds).

**Actual result:**
Durations were sorted lexicographically by string/completion time, resulting in incorrect ordering.

**Please note:**
Please note there is a flag `additional: true` to the TaskRun column

**Screen recording:**
TaskRun duration sorting preview
https://github.com/user-attachments/assets/e4d4eadd-bd73-48a3-9af4-fd7aaf3fa06f

PipelineRun  duration sorting preview
https://github.com/user-attachments/assets/a11f76fc-947d-455b-a7e6-2b6cc0c60d0e



