### PR TITLE
SRVKP-9397: updated field name for capturing next page token in tkr

### DIFF
--- a/src/components/hooks/useTektonResults.ts
+++ b/src/components/hooks/useTektonResults.ts
@@ -57,7 +57,9 @@ const useTRRuns = <Kind extends K8sResourceCommon>(
           isDevConsoleProxyAvailable,
         );
         if (!disposed) {
-          const token = tkPipelineRuns[1].nextPageToken;
+          const token =
+            tkPipelineRuns[1].nextPageToken ||
+            tkPipelineRuns[1].next_page_token;
           const callInflight = !!tkPipelineRuns?.[2];
           const loaded = !callInflight;
           if (!callInflight) {

--- a/src/types/resultsSummary.ts
+++ b/src/types/resultsSummary.ts
@@ -37,6 +37,7 @@ export type Log = {
 
 export type RecordsList = {
   nextPageToken?: string;
+  next_page_token?: string;
   records: ResultRecord[];
 };
 


### PR DESCRIPTION
### **PR Description**

This PR fixes an issue where scrolling fails to load additional PipelineRun results when the `data_source` filter is set to `archived`. The `onScroll` callback never triggered the next-page request because the Tekton Results client was reading `nextPageToken`, while the API returns `next_page_token`. Due to this mismatch, the next-page callback was not created, causing pagination to stop after the first page.

For demonstration purposes, the `page_size` has been temporarily set to **10** to make pagination behavior easier to observe.

---

### **Steps to Reproduce**

1. Open the PipelineRun list page.
2. Set the `data_source` filter to **archived**.
3. Scroll to the bottom.
4. No additional results load.

---

### **Actual Result**

Pagination stops after the first page; scrolling does not fetch more results.

---

### **Expected Result**

The list should fetch the next page using `next_page_token` and load results continuously as the user scrolls.

---

### **Root Cause**

The client expected `nextPageToken`, but the API provides `next_page_token`, preventing the next-page fetch logic from initializing.

---

### **Fix Implemented**

* Updated pagination logic to use `next_page_token` from the API response.

---

### **Screen Recording Before**

https://github.com/user-attachments/assets/9008c300-f6bb-4d5a-9903-123f2e466cbb

---

### **Screen Recording After**

https://drive.google.com/file/d/1nAAVR7Uu3UaC7ljFKBnJUxqZafCn6YaN/view?usp=sharing

---