### PR TITLE
SRVKP-9456: Add console.navigation/section for Pipelines

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -921,6 +921,23 @@
     }
   },
   {
+    "type": "console.navigation/section",
+    "properties": {
+      "perspective": "admin",
+      "id": "pipelines",
+      "name": "%plugin__pipelines-console-plugin~Pipelines%",
+      "insertAfter": "builds",
+      "insertBefore": "servicecatalog",
+      "dataAttributes": {
+        "data-quickstart-id": "qs-nav-pipelines",
+        "data-test": "nav-pipelines"
+      }
+    },
+    "flags": {
+      "required": ["OPENSHIFT_PIPELINE"]
+    }
+  },
+  {
     "type": "console.navigation/href",
     "properties": {
       "id": "pipelines",


### PR DESCRIPTION
Add a missing extension for adding the Pipelines section in the console nav.