### PR TITLE
SRVKP-9436: updated loading component to use spinner from PF5 and used it in Pipeline Overview page

### DIFF
--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,23 +1,28 @@
 import * as React from 'react';
-import classNames from 'classnames';
+import { Bullseye, Spinner, SpinnerProps } from '@patternfly/react-core';
 
 type LoadingProps = {
   className?: string;
+  isInline?: boolean;
+  size?: SpinnerProps["size"];
+  ariaLabel?: string;
 };
 
-export const Loading: React.FC<LoadingProps> = ({ className }) => (
-  <div
-    className={classNames('co-m-loader co-an-fade-in-out', className)}
-    data-test="loading-indicator"
+export const Loading: React.FC<LoadingProps> = ({ className, isInline, size, ariaLabel }) => (
+  <Bullseye 
+    data-test="loading-indicator" 
+    className={className}
   >
-    <div className="co-m-loader-dot__one" />
-    <div className="co-m-loader-dot__two" />
-    <div className="co-m-loader-dot__three" />
-  </div>
+    <Spinner 
+      size={size}
+      isInline={isInline}
+      aria-label={ariaLabel}
+    />
+  </Bullseye>
 );
 Loading.displayName = 'Loading';
 
 export const LoadingInline: React.FC = () => (
-  <Loading className="co-m-loader--inline" />
+  <Loading isInline = {true} />
 );
 LoadingInline.displayName = 'LoadingInline';

--- a/src/components/pipelines-metrics/url-poll-hook.ts
+++ b/src/components/pipelines-metrics/url-poll-hook.ts
@@ -16,6 +16,7 @@ export const useURLPoll: UseURLPoll = <R>(
   const safeFetch = useSafeFetch();
   const tick = useCallback(() => {
     if (url) {
+      setLoading(true);
       safeFetch(url)
         .then((data) => {
           setResponse(data);

--- a/src/components/pipelines-overview/PipelineRunsDurationCard.tsx
+++ b/src/components/pipelines-overview/PipelineRunsDurationCard.tsx
@@ -57,6 +57,7 @@ const PipelinesRunsDurationCard: React.FC<PipelinesRunsDurationProps> = ({
   const date = getDropDownDate(timespan).toISOString();
 
   const getSummaryData = () => {
+    setLoaded(false);
     getResultsSummary(
       namespace,
       {

--- a/src/components/pipelines-overview/PipelineRunsDurationCardK8s.tsx
+++ b/src/components/pipelines-overview/PipelineRunsDurationCardK8s.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import {
   HistoryIcon,
@@ -31,6 +31,7 @@ import {
 } from '../pipelines-metrics/hooks';
 import { MetricsQueryPrefix, PipelineQuery } from '../pipelines-metrics/utils';
 import { getXaxisValues } from './dateTime';
+import { LoadingInline } from '../Loading';
 
 interface PipelinesRunsDurationProps {
   namespace: string;
@@ -50,7 +51,7 @@ const PipelineRunsDurationCardK8s: React.FC<PipelinesRunsDurationProps> = ({
 }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
 
-  const [totalPipelineRunsCountData] =
+  const [totalPipelineRunsCountData, , loadingPipelineRunsCount] =
     parentName && namespace
       ? usePipelineMetricsForNamespaceForPipelinePoll({
           namespace,
@@ -83,7 +84,7 @@ const PipelineRunsDurationCardK8s: React.FC<PipelinesRunsDurationProps> = ({
     type,
   );
 
-  const [totalPipelineRunsDurationData] =
+  const [totalPipelineRunsDurationData, , loadingPipelineRunsDuration] =
     parentName && namespace
       ? usePipelineMetricsForNamespaceForPipelinePoll({
           namespace,
@@ -144,7 +145,9 @@ const PipelineRunsDurationCardK8s: React.FC<PipelinesRunsDurationProps> = ({
               span={6}
               className="pipeline-overview__duration-card__value"
             >
-              {averageDuration}
+              {loadingPipelineRunsCount ? 
+                <LoadingInline/>
+                : averageDuration}
             </GridItem>
           </Grid>
           <Grid hasGutter className="pipeline-overview__duration-card__grid">
@@ -158,7 +161,9 @@ const PipelineRunsDurationCardK8s: React.FC<PipelinesRunsDurationProps> = ({
               span={6}
               className="pipeline-overview__duration-card__value"
             >
-              {'-'}
+              {loadingPipelineRunsCount ? 
+                <LoadingInline/>
+                : '-'}
             </GridItem>
           </Grid>
           <Grid hasGutter>
@@ -172,7 +177,9 @@ const PipelineRunsDurationCardK8s: React.FC<PipelinesRunsDurationProps> = ({
               span={6}
               className="pipeline-overview__duration-card__value"
             >
-              {totalPipelineRunsDuration ?? '-'}
+              {loadingPipelineRunsDuration ? 
+                <LoadingInline/>
+                : totalPipelineRunsDuration ?? '-'}
             </GridItem>
           </Grid>
         </CardBody>

--- a/src/components/pipelines-overview/PipelineRunsNumbersChart.tsx
+++ b/src/components/pipelines-overview/PipelineRunsNumbersChart.tsx
@@ -105,6 +105,7 @@ const PipelinesRunsNumbersChart: React.FC<PipelinesRunsNumbersChartProps> = ({
       groupBy: group_by,
     };
 
+    setLoaded(false);
     getResultsSummary(
       namespace,
       summaryOpt,
@@ -241,7 +242,7 @@ const PipelinesRunsNumbersChart: React.FC<PipelinesRunsNumbersChartProps> = ({
                 </ChartGroup>
               </Chart>
             ) : (
-              <div className="pipeline-overview__number-of-plr-card__loading">
+              <div className="pipeline-overview__number-of-plr-card__loading pf-v5-u-h-100">
                 <LoadingInline />
               </div>
             )}

--- a/src/components/pipelines-overview/PipelineRunsNumbersChartK8s.tsx
+++ b/src/components/pipelines-overview/PipelineRunsNumbersChartK8s.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { DomainPropType, DomainTuple } from 'victory-core';
 import {
@@ -31,6 +31,7 @@ import {
   PipelineQuery,
   adjustToStartOfWeek,
 } from '../pipelines-metrics/utils';
+import { LoadingInline } from '../Loading';
 
 interface PipelinesRunsNumbersChartProps {
   namespace?: string;
@@ -123,7 +124,7 @@ const PipelineRunsNumbersChartK8s: React.FC<PipelinesRunsNumbersChartProps> = ({
     y: domainY || undefined,
   };
 
-  const [runSuccessRatioData] =
+  const [runSuccessRatioData, , loadingRunSuccessRatioData] =
     parentName && namespace
       ? usePipelineMetricsForNamespaceForPipelinePoll({
           namespace,
@@ -232,6 +233,9 @@ const PipelineRunsNumbersChartK8s: React.FC<PipelinesRunsNumbersChartProps> = ({
         </CardTitle>
         <CardBody className="pipeline-overview__number-of-plr-card__body">
           <div className="pipeline-overview__number-of-plr-card__bar-chart-div">
+          {loadingRunSuccessRatioData ? (
+              <LoadingInline />
+            ) : (
             <Chart
               containerComponent={
                 <ChartVoronoiContainer
@@ -262,6 +266,7 @@ const PipelineRunsNumbersChartK8s: React.FC<PipelinesRunsNumbersChartProps> = ({
                 <ChartBar data={chartData} barWidth={18} />
               </ChartGroup>
             </Chart>
+            )}
           </div>
         </CardBody>
       </Card>

--- a/src/components/pipelines-overview/PipelineRunsStatusCard.tsx
+++ b/src/components/pipelines-overview/PipelineRunsStatusCard.tsx
@@ -124,7 +124,8 @@ const PipelinesRunsStatusCard: React.FC<PipelinesRunsStatusCardProps> = ({
       data_type: DataType?.PipelineRun,
     };
     groupBy && (summaryOpt['groupBy'] = groupBy);
-
+    
+    setLoaded(false);
     getResultsSummary(
       namespace,
       summaryOpt,
@@ -361,9 +362,9 @@ const PipelinesRunsStatusCard: React.FC<PipelinesRunsStatusCardProps> = ({
         </CardTitle>
         <CardBody className="pipeline-overview__pipelinerun-status-card__title">
           <Grid>
-            <GridItem xl2={4} xl={12} lg={12} md={12} sm={12}>
-              <div className="pipeline-overview__pipelinerun-status-card__donut-chart-div">
-                {loaded ? (
+            <GridItem xl2={4} xl={12} lg={12} md={12} sm={12}>              
+              {loaded ? (
+                <div className="pipeline-overview__pipelinerun-status-card__donut-chart-div">
                   <ChartDonut
                     constrainToVisibleArea={true}
                     data={donutData}
@@ -410,10 +411,10 @@ const PipelinesRunsStatusCard: React.FC<PipelinesRunsStatusCardProps> = ({
                     }
                     width={350}
                   />
-                ) : (
-                  <LoadingInline />
-                )}
-              </div>
+                </div>
+              ) : (
+                <LoadingInline />
+              )}              
             </GridItem>
             <GridItem xl2={8} xl={12} lg={12} md={12} sm={12}>
               <div className="pipeline-overview__pipelinerun-status-card__bar-chart-div">

--- a/src/components/pipelines-overview/PipelineRunsStatusCardK8s.tsx
+++ b/src/components/pipelines-overview/PipelineRunsStatusCardK8s.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { DomainPropType, DomainTuple } from 'victory-core';
 import {
@@ -48,6 +48,7 @@ import {
   adjustToStartOfWeek,
 } from '../pipelines-metrics/utils';
 import { getTotalPipelineRuns, isMatchingFirstTickValue } from './utils';
+import { LoadingInline } from '../Loading';
 
 interface PipelinesRunsStatusCardProps {
   timespan?: number;
@@ -236,7 +237,7 @@ const PipelineRunsStatusCardK8s: React.FC<PipelinesRunsStatusCardProps> = ({
     x: domainX || [startDate, endDate],
     y: domainY || undefined,
   };
-  const [runSuccessRatioData] =
+  const [runSuccessRatioData, , loadingRunSuccessRatioData] =
     parentName && namespace
       ? usePipelineMetricsForNamespaceForPipelinePoll({
           namespace,
@@ -263,7 +264,7 @@ const PipelineRunsStatusCardK8s: React.FC<PipelinesRunsStatusCardProps> = ({
           metricsQuery:
             PipelineQuery.PIPELINERUN_COUNT_FOR_STATUS_FOR_NAMESPACE,
         });
-  const [totalPipelineRunsData] =
+  const [totalPipelineRunsData, , loadingTotalPipelineRunsData] =
     parentName && namespace
       ? usePipelineMetricsForNamespaceForPipelinePoll({
           namespace,
@@ -499,6 +500,9 @@ const PipelineRunsStatusCardK8s: React.FC<PipelinesRunsStatusCardProps> = ({
         <CardBody className="pipeline-overview__pipelinerun-status-card__title">
           <Grid>
             <GridItem xl2={4} xl={12} lg={12} md={12} sm={12}>
+              {loadingRunSuccessRatioData ? (
+                <LoadingInline />
+              ) : (
               <div className="pipeline-overview__pipelinerun-status-card__donut-chart-div">
                 <ChartDonut
                   constrainToVisibleArea={true}
@@ -545,9 +549,13 @@ const PipelineRunsStatusCardK8s: React.FC<PipelinesRunsStatusCardProps> = ({
                   width={350}
                 />
               </div>
+              )}
             </GridItem>
             <GridItem xl2={8} xl={12} lg={12} md={12} sm={12}>
               <div className="pipeline-overview__pipelinerun-status-card__bar-chart-div">
+                {loadingTotalPipelineRunsData ? (
+                <LoadingInline />
+              ) : (
                 <Chart
                   containerComponent={
                     <ChartVoronoiContainer
@@ -585,6 +593,7 @@ const PipelineRunsStatusCardK8s: React.FC<PipelinesRunsStatusCardProps> = ({
                     <ChartLine data={chartDataCancelledK8s} />
                   </ChartGroup>
                 </Chart>
+                )}
               </div>
             </GridItem>
           </Grid>

--- a/src/components/pipelines-overview/PipelineRunsTotalCard.tsx
+++ b/src/components/pipelines-overview/PipelineRunsTotalCard.tsx
@@ -55,6 +55,7 @@ const PipelinesRunsTotalCard: React.FC<PipelinesRunsDurationProps> = ({
   const date = getDropDownDate(timespan).toISOString();
 
   const getSummaryData = (filter, setData) => {
+    setLoaded(false);
     getResultsSummary(
       namespace,
       {

--- a/src/components/pipelines-overview/PipelineRunsTotalCardK8s.tsx
+++ b/src/components/pipelines-overview/PipelineRunsTotalCardK8s.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { CheckIcon } from '@patternfly/react-icons';
 import {
@@ -22,6 +22,7 @@ import {
   usePipelineMetricsForNamespacePoll,
 } from '../pipelines-metrics/hooks';
 import { getXaxisValues } from './dateTime';
+import { LoadingInline } from '../Loading';
 
 interface PipelinesRunsDurationProps {
   namespace: string;
@@ -39,7 +40,7 @@ const PipelineRunsTotalCardK8s: React.FC<PipelinesRunsDurationProps> = ({
 }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
 
-  const [totalPipelineRunsData] =
+  const [totalPipelineRunsData, , loadingTotalPipelineRunsData] =
     namespace == ALL_NAMESPACES_KEY
       ? usePipelineMetricsForAllNamespacePoll({
           timespan,
@@ -90,7 +91,10 @@ const PipelineRunsTotalCardK8s: React.FC<PipelinesRunsDurationProps> = ({
               span={3}
               className="pipeline-overview__totals-card__value"
             >
-              {'-'}
+              {loadingTotalPipelineRunsData ? 
+                <LoadingInline/>
+                : '-'
+              }
             </GridItem>
           </Grid>
           <Grid hasGutter className="pipeline-overview__totals-card__grid">
@@ -109,7 +113,10 @@ const PipelineRunsTotalCardK8s: React.FC<PipelinesRunsDurationProps> = ({
               span={3}
               className="pipeline-overview__totals-card__value"
             >
-              {'-'}
+              {loadingTotalPipelineRunsData ? 
+                <LoadingInline/>
+                : '-'
+              }
             </GridItem>
           </Grid>
           <Grid hasGutter>
@@ -123,7 +130,10 @@ const PipelineRunsTotalCardK8s: React.FC<PipelinesRunsDurationProps> = ({
               span={3}
               className="pipeline-overview__totals-card__value"
             >
-              {totalPipelineRuns}
+              {loadingTotalPipelineRunsData ? 
+                <LoadingInline/>
+                : totalPipelineRuns
+              }
             </GridItem>
           </Grid>
         </CardBody>

--- a/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesList.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesList.tsx
@@ -124,7 +124,7 @@ const PipelineRunsForPipelinesList: React.FC<
     (!summaryDataFiltered || summaryDataFiltered.length === 0) &&
     (!summaryData || summaryData.length === 0);
 
-  if (isEmptyData) {
+  if (loaded && isEmptyData) {
     return <EmptyMsg />;
   }
 

--- a/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesListK8s.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesListK8s.tsx
@@ -134,7 +134,7 @@ const PipelineRunsForPipelinesListK8s: React.FC<
     (!summaryDataFiltered || summaryDataFiltered.length === 0) &&
     (!summaryData || summaryData.length === 0);
 
-  if (isEmptyData) {
+  if (loaded && isEmptyData) {
     return <EmptyMsg />;
   }
   return (

--- a/src/components/pipelines-overview/list-pages/PipelineRunsListPage.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsListPage.tsx
@@ -48,6 +48,7 @@ const PipelineRunsListPage: React.FC<PipelineRunsListPageProps> = ({
     namespace = '-';
   }
   const getSummaryData = () => {
+    setloaded(false);
     getResultsSummary(
       namespace,
       pageFlag === 1
@@ -68,8 +69,8 @@ const PipelineRunsListPage: React.FC<PipelineRunsListPageProps> = ({
     )
       .then((response) => {
         setloaded(true);
-        setSummaryData(response.summary);
-        setSummaryDataFiltered(response.summary);
+        setSummaryData(response?.summary ?? []);
+        setSummaryDataFiltered(response?.summary ?? []);
       })
       .catch((e) => {
         throw e;

--- a/src/components/pipelines-overview/list-pages/PipelineRunsListPageK8s.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsListPageK8s.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { Card, CardBody, Grid, GridItem } from '@patternfly/react-core';
 import {
   PrometheusResponse,
@@ -131,7 +131,7 @@ const PipelineRunsListPageK8s: React.FC<PipelineRunsListPageProps> = ({
     kind: 'Project',
     optional: true,
   });
-  const [pipelineRunsMetricsCountData] =
+  const [pipelineRunsMetricsCountData, , loadingPipelineRunsMetricsCount] =
     namespace == ALL_NAMESPACES_KEY
       ? usePipelineMetricsForAllNamespacePoll({
           timespan,
@@ -149,7 +149,7 @@ const PipelineRunsListPageK8s: React.FC<PipelineRunsListPageProps> = ({
             PipelineQuery.PIPELINERUN_COUNT_WITH_METRIC_FOR_NAMESPACE,
         });
 
-  const [pipelineRunsMetricsSumData] =
+  const [pipelineRunsMetricsSumData, , loadingPipelineRunsMetricsSum] =
     namespace == ALL_NAMESPACES_KEY
       ? usePipelineMetricsForAllNamespacePoll({
           timespan,
@@ -252,7 +252,7 @@ const PipelineRunsListPageK8s: React.FC<PipelineRunsListPageProps> = ({
               <PipelineRunsForPipelinesListK8s
                 summaryData={summaryDataK8s}
                 summaryDataFiltered={summaryDataFiltered}
-                loaded={true}
+                loaded={!loadingPipelineRunsMetricsCount && !loadingPipelineRunsMetricsSum}
                 hideLastRunTime={true}
                 projects={projects}
                 projectsLoaded={projectsLoaded}
@@ -261,7 +261,7 @@ const PipelineRunsListPageK8s: React.FC<PipelineRunsListPageProps> = ({
               <PipelineRunsForRepositoriesList
                 summaryData={summaryDataK8s}
                 summaryDataFiltered={summaryDataFiltered}
-                loaded={true}
+                loaded={!loadingPipelineRunsMetricsCount && !loadingPipelineRunsMetricsSum}
               />
             )}
           </GridItem>


### PR DESCRIPTION
### **PR Description**

Enhancing user experience by displaying a Loading spinner when the individual card components in Pipelines Overview page fetch data from API.

### **Key Changes**

1. Updated the Loading.tsx component to use the Spinner component from PF5.
2. Added necessary loading states to conditionally display the Loading spinner in the card components.
3. Updated respective changes in k8 components which loads form Prometheus API
4. Added appropriate css classes from PF5 to display the loading spinner in a consistent manner.

### **Outcome**

1. The cards in Pipeline Overview page displays a loading spinner when the user lands on the page.
2. Loading spinner is removed once the respective API data is loaded and the actual chart is rendered.

### **Tekton results screen recordings - Before Fix**

https://github.com/user-attachments/assets/aa63f8b6-3d8c-4eb7-a227-fe40ba0dea52

### **Tekton results screen recordings - After Fix**

https://github.com/user-attachments/assets/d67ba851-5017-49e5-8223-aab9bc889edc

### **Prometheus results screen recordings - Before Fix**

https://github.com/user-attachments/assets/296e2354-1802-4691-95af-43b9dd8141de


### **Prometheus results screen recordings - After Fix**


https://github.com/user-attachments/assets/b01a4ad3-289c-496d-b2f4-4eea4a176f33

