### PR TITLE
SRVKP-9450: preserve error state for all-namespace for the case when there is an error for non-admin users for pipelineruns

### DIFF
--- a/src/components/hooks/useTaskRuns.ts
+++ b/src/components/hooks/useTaskRuns.ts
@@ -315,6 +315,8 @@ export const useRuns = <Kind extends K8sResourceCommon>(
             : // when searching by name, return an error if we have no result
               trError && (trLoaded && !trResources.length ? error : undefined)
           : error
+        : error
+        ? error
         : undefined,
       trGetNextPage,
     ];


### PR DESCRIPTION
**Fix:**
Preserve error state for all-namespace for the case when there is an error for non-admin users for pipelineruns

**Problem:**
When querying pipeline runs for all-namespace, the hook would return `undefined` as the error value even if there is an error. This caused errors to be silently swallowed, making it difficult to debug issues like network failures or permission problems.

**Solution:**
Updated the error handling logic in the `useRuns` hook to check and return errors if there is an error.

**Before:**
```typescript
namespace
  ? queryTr
    ? isList
      ? trError || error
      : trError || (trLoaded && !trResources.length ? error : undefined)
    : error
  : undefined,
```

**After:**
```typescript
namespace
  ? queryTr
    ? isList
      ? trError || error
      : trError || (trLoaded && !trResources.length ? error : undefined)
    : error
  : error
    ? error
    : undefined,
```

**Screen recording Before fix**
https://github.com/user-attachments/assets/7e55c828-fa10-4643-9244-7838bc190a29


**Screen recording After fix**
https://github.com/user-attachments/assets/920f714e-3085-4bde-8508-2a8e08a5d923

