### PR TITLE
SRVKP-9591: updated condition to show error message instead of the loader after api has failed

### DIFF
--- a/src/components/logs/TektonTaskRunLog.tsx
+++ b/src/components/logs/TektonTaskRunLog.tsx
@@ -29,8 +29,8 @@ export const TektonTaskRunLog: React.FC<TektonTaskRunLogProps> = ({
   }, [setCurrentLogsGetter, trResults]);
 
   const errorMessage =
-    (trError as HttpError)?.code === 404
-      ? `Logs are no longer accessible for ${taskName} task`
+    (trError as HttpError)?.code === 404 || (trError as HttpError)?.code === 500
+      ? `Unable to access log for ${taskName} task`
       : null;
 
   // Format trResults to include taskName
@@ -49,14 +49,14 @@ export const TektonTaskRunLog: React.FC<TektonTaskRunLogProps> = ({
         data-test-id="logs-taskName"
       >
         {taskName}
-        {!trLoaded && (
+        {!trLoaded && !errorMessage ? (
           <span
             className="odc-multi-stream-logs__taskName__loading-indicator"
             data-test-id="loading-indicator"
           >
             <LoadingInline />
           </span>
-        )}
+        ) : null}
       </div>
       <div
         className="odc-multi-stream-logs__logviewer"


### PR DESCRIPTION
## Fix: Show error message instead of loader when API fails ( for logs )

**Ticket:** [SRVKP-9591](https://issues.redhat.com//browse/SRVKP-9591)

### Changes
- Updated condition logic to display error messages when API requests fail
- Prevents infinite loader state on failed API responses

### Impact
Users will now see clear error messages instead of indefinite loading states when API calls fail in the log viewer

### Screen Recording Before
https://github.com/user-attachments/assets/a87819e9-e3e5-44aa-9e15-a42f4bec9151


### Screen Recording After
https://github.com/user-attachments/assets/53802824-33fd-4359-8a87-9460a3009719


