### PR TITLE
SRVKP-9607: added redux state for pipeline overview filter to persist

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -1,5 +1,14 @@
 [
   {
+    "type": "console.redux-reducer",
+    "properties": {
+      "scope": "pipelinesOverviewFilters",
+      "reducer": {
+        "$codeRef": "pipelinesOverviewFiltersReducer.pipelinesOverviewFiltersReducer"
+      }
+    }
+  },
+  {
     "type": "console.flag/model",
     "properties": {
       "model": {

--- a/package.json
+++ b/package.json
@@ -158,7 +158,8 @@
       "taskDetails": "./components/tasks",
       "pacComponent": "./components/pac/",
       "yamlTemplates": "./components/templates",
-      "topology": "./components/topology"
+      "topology": "./components/topology",
+      "pipelinesOverviewFiltersReducer": "./redux/reducers/pipelines-overview-filters"
     },
     "dependencies": {
       "@console/pluginAPI": ">=4.15"

--- a/src/components/hooks/usePersistedFiltersForPipelineOverview.ts
+++ b/src/components/hooks/usePersistedFiltersForPipelineOverview.ts
@@ -1,0 +1,111 @@
+import * as React from 'react';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useDispatch, useSelector } from 'react-redux';
+import { useLocation } from 'react-router-dom-v5-compat';
+import {
+  setInterval as setIntervalAction,
+  setTimespan as setTimespanAction,
+} from '../../redux/actions/pipelines-overview-filters';
+import {
+  getPipelinesOverviewInterval,
+  getPipelinesOverviewTimespan,
+} from '../../redux/selectors/pipelines-overview-filters';
+import { useQueryParams } from '../pipelines-overview/utils';
+
+export const usePersistedTimespanWithUrl = (
+  defaultValue: number,
+  options: {
+    displayFormat: (v: number) => string;
+    loadFormat: (v: string) => number;
+    options: Record<string, any>;
+  },
+  namespace: string,
+) => {
+  const dispatch = useDispatch();
+  const reduxTimespan = useSelector(getPipelinesOverviewTimespan);
+  const location = useLocation();
+  const prevNamespaceRef = React.useRef(namespace);
+  const [timespan, setTimespanValue] = React.useState(() => {
+    const urlParams = new URLSearchParams(location.search);
+    const urlValue = urlParams.has('timerange')
+      ? urlParams.get('timerange')
+      : null;
+    if (urlValue) {
+      return options.loadFormat(urlValue);
+    }
+    return reduxTimespan ?? defaultValue;
+  });
+
+  // Reset to default when namespace changes
+  React.useEffect(() => {
+    if (prevNamespaceRef.current !== namespace) {
+      prevNamespaceRef.current = namespace;
+      setTimespanValue(defaultValue);
+    }
+  }, [namespace, defaultValue]);
+
+  // Persist to Redux whenever value changes
+  React.useEffect(() => {
+    dispatch(setTimespanAction(timespan));
+  }, [timespan, dispatch]);
+
+  useQueryParams({
+    key: 'timerange',
+    value: timespan,
+    setValue: setTimespanValue,
+    defaultValue: timespan,
+    ...options,
+  });
+
+  return [timespan, setTimespanValue];
+};
+
+export const usePersistedIntervalWithUrl = (
+  defaultValue: number,
+  options: {
+    displayFormat: (v: number | null) => string;
+    loadFormat: (v: string) => number | null;
+    options: Record<string, any>;
+  },
+  namespace: string,
+) => {
+  const dispatch = useDispatch();
+  const reduxInterval = useSelector(getPipelinesOverviewInterval);
+  const location = useLocation();
+  const prevNamespaceRef = React.useRef(namespace);
+  const [interval, setIntervalValue] = React.useState(() => {
+    const urlParams = new URLSearchParams(location.search);
+    const urlValue = urlParams.has('refreshinterval')
+      ? urlParams.get('refreshinterval')
+      : null;
+    if (urlValue) {
+      return options.loadFormat(urlValue);
+    }
+    // to handle refresh interval "off" state
+    return reduxInterval !== undefined ? reduxInterval : defaultValue;
+  });
+
+  // Reset to default when namespace changes
+  React.useEffect(() => {
+    if (prevNamespaceRef.current !== namespace) {
+      prevNamespaceRef.current = namespace;
+      setIntervalValue(defaultValue);
+    }
+  }, [namespace, defaultValue]);
+
+  // Persist to Redux whenever value changes
+  React.useEffect(() => {
+    dispatch(setIntervalAction(interval));
+  }, [interval, dispatch]);
+
+  useQueryParams({
+    key: 'refreshinterval',
+    value: interval,
+    setValue: setIntervalValue,
+    defaultValue: interval,
+    ...options,
+  });
+
+  return [interval, setIntervalValue];
+};

--- a/src/components/pipelines-overview/PipelinesOverviewPage.tsx
+++ b/src/components/pipelines-overview/PipelinesOverviewPage.tsx
@@ -14,39 +14,39 @@ import NameSpaceDropdown from './NamespaceDropdown';
 import PipelineRunsListPage from './list-pages/PipelineRunsListPage';
 import TimeRangeDropdown from './TimeRangeDropdown';
 import RefreshDropdown from './RefreshDropdown';
-import { IntervalOptions, TimeRangeOptions, useQueryParams } from './utils';
+import { IntervalOptions, TimeRangeOptions } from './utils';
 import { ALL_NAMESPACES_KEY } from '../../consts';
 import AllProjectsPage from '../projects-list/AllProjectsPage';
 import { FLAGS } from '../../types';
+import {
+  usePersistedTimespanWithUrl,
+  usePersistedIntervalWithUrl,
+} from '../hooks/usePersistedFiltersForPipelineOverview';
 
 const PipelinesOverviewPage: React.FC = () => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
   const canListNS = useFlag(FLAGS.CAN_LIST_NS);
   const [activeNamespace, setActiveNamespace] = useActiveNamespace();
-  const [timespan, setTimespan] = React.useState(parsePrometheusDuration('1d'));
-  const [interval, setInterval] = React.useState(
-    parsePrometheusDuration('30s'),
+
+  const [timespan, setTimespan] = usePersistedTimespanWithUrl(
+    parsePrometheusDuration('1d'),
+    {
+      options: TimeRangeOptions(),
+      displayFormat: formatPrometheusDuration,
+      loadFormat: parsePrometheusDuration,
+    },
+    activeNamespace,
   );
 
-  useQueryParams({
-    key: 'refreshinterval',
-    value: interval,
-    setValue: setInterval,
-    defaultValue: parsePrometheusDuration('30s'),
-    options: { ...IntervalOptions(), off: 'OFF_KEY' },
-    displayFormat: (v) => (v ? formatPrometheusDuration(v) : 'off'),
-    loadFormat: (v) => (v == 'off' ? null : parsePrometheusDuration(v)),
-  });
-
-  useQueryParams({
-    key: 'timerange',
-    value: timespan,
-    setValue: setTimespan,
-    defaultValue: parsePrometheusDuration('1w'),
-    options: TimeRangeOptions(),
-    displayFormat: formatPrometheusDuration,
-    loadFormat: parsePrometheusDuration,
-  });
+  const [interval, setInterval] = usePersistedIntervalWithUrl(
+    parsePrometheusDuration('30s'),
+    {
+      options: { ...IntervalOptions(), off: 'OFF_KEY' },
+      displayFormat: (v) => (v ? formatPrometheusDuration(v) : 'off'),
+      loadFormat: (v) => (v == 'off' ? null : parsePrometheusDuration(v)),
+    },
+    activeNamespace,
+  );
 
   if (!canListNS && activeNamespace === ALL_NAMESPACES_KEY) {
     return <AllProjectsPage pageTitle={t('Overview')} />;

--- a/src/components/pipelines-overview/PipelinesOverviewPageK8s.tsx
+++ b/src/components/pipelines-overview/PipelinesOverviewPageK8s.tsx
@@ -9,7 +9,7 @@ import { formatPrometheusDuration, parsePrometheusDuration } from './dateTime';
 import NameSpaceDropdown from './NamespaceDropdown';
 import TimeRangeDropdown from './TimeRangeDropdown';
 import RefreshDropdown from './RefreshDropdown';
-import { IntervalOptions, TimeRangeOptionsK8s, useQueryParams } from './utils';
+import { IntervalOptions, TimeRangeOptionsK8s } from './utils';
 import PipelineRunsStatusCardK8s from './PipelineRunsStatusCardK8s';
 import PipelineRunsNumbersChartK8s from './PipelineRunsNumbersChartK8s';
 import PipelineRunsTotalCardK8s from './PipelineRunsTotalCardK8s';
@@ -19,36 +19,36 @@ import { K8sDataLimitationAlert } from './K8sDataLimitationAlert';
 import { FLAGS } from '../../types';
 import { ALL_NAMESPACES_KEY } from '../../consts';
 import AllProjectsPage from '../projects-list/AllProjectsPage';
+import {
+  usePersistedTimespanWithUrl,
+  usePersistedIntervalWithUrl,
+} from '../hooks/usePersistedFiltersForPipelineOverview';
 import './PipelinesOverview.scss';
 
 const PipelinesOverviewPageK8s: React.FC = () => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
   const canListNS = useFlag(FLAGS.CAN_LIST_NS);
   const [activeNamespace, setActiveNamespace] = useActiveNamespace();
-  const [timespan, setTimespan] = React.useState(parsePrometheusDuration('1d'));
-  const [interval, setInterval] = React.useState(
-    parsePrometheusDuration('30s'),
+
+  const [timespan, setTimespan] = usePersistedTimespanWithUrl(
+    parsePrometheusDuration('1d'),
+    {
+      options: TimeRangeOptionsK8s(),
+      displayFormat: formatPrometheusDuration,
+      loadFormat: parsePrometheusDuration,
+    },
+    activeNamespace,
   );
 
-  useQueryParams({
-    key: 'refreshinterval',
-    value: interval,
-    setValue: setInterval,
-    defaultValue: parsePrometheusDuration('30s'),
-    options: { ...IntervalOptions(), off: 'OFF_KEY' },
-    displayFormat: (v) => (v ? formatPrometheusDuration(v) : 'off'),
-    loadFormat: (v) => (v == 'off' ? null : parsePrometheusDuration(v)),
-  });
-
-  useQueryParams({
-    key: 'timerange',
-    value: timespan,
-    setValue: setTimespan,
-    defaultValue: parsePrometheusDuration('1w'),
-    options: TimeRangeOptionsK8s(),
-    displayFormat: formatPrometheusDuration,
-    loadFormat: parsePrometheusDuration,
-  });
+  const [interval, setInterval] = usePersistedIntervalWithUrl(
+    parsePrometheusDuration('30s'),
+    {
+      options: { ...IntervalOptions(), off: 'OFF_KEY' },
+      displayFormat: (v) => (v ? formatPrometheusDuration(v) : 'off'),
+      loadFormat: (v) => (v == 'off' ? null : parsePrometheusDuration(v)),
+    },
+    activeNamespace,
+  );
 
   if (!canListNS && activeNamespace === ALL_NAMESPACES_KEY) {
     return <AllProjectsPage pageTitle={t('Overview')} />;

--- a/src/components/pipelines-overview/__tests__/PipelinesOverview.spec.tsx
+++ b/src/components/pipelines-overview/__tests__/PipelinesOverview.spec.tsx
@@ -7,6 +7,10 @@ import {
   useActiveNamespace,
   useFlag,
 } from '@openshift-console/dynamic-plugin-sdk';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useDispatch, useSelector } from 'react-redux';
+import { useLocation } from 'react-router-dom-v5-compat';
 import PipelinesOverviewPage from '../PipelinesOverviewPage';
 import { getResultsSummary } from '../../utils/summary-api';
 import * as utils from '../utils';
@@ -27,6 +31,13 @@ jest.mock('../../utils/tekton-results', () => ({
 jest.mock('../../utils/summary-api', () => ({
   getResultsSummary: jest.fn(),
 }));
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+jest.mock('react-router-dom-v5-compat', () => ({
+  useLocation: jest.fn(),
+}));
 (VirtualizedTable as jest.Mock).mockImplementation((props) => {
   virtualizedTableRenderProps(props);
   return null;
@@ -40,6 +51,9 @@ const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
 const useActiveColumnsMock = useActiveColumns as jest.Mock;
 const getResultsSummaryMock = getResultsSummary as jest.Mock;
 const useFlagMock = useFlag as jest.Mock;
+const useDispatchMock = useDispatch as jest.Mock;
+const useSelectorMock = useSelector as jest.Mock;
+const useLocationMock = useLocation as jest.Mock;
 
 describe('Pipeline Overview page', () => {
   beforeEach(() => {
@@ -52,6 +66,9 @@ describe('Pipeline Overview page', () => {
     useActiveColumnsMock.mockReturnValue([[]]);
     getResultsSummaryMock.mockReturnValue(Promise.resolve({}));
     useFlagMock.mockReturnValue(true);
+    useDispatchMock.mockReturnValue(jest.fn());
+    useSelectorMock.mockReturnValue(null);
+    useLocationMock.mockReturnValue({ search: '', pathname: '/' });
   });
 
   it('should render Pipeline Overview', async () => {

--- a/src/redux/actions/pipelines-overview-filters.ts
+++ b/src/redux/actions/pipelines-overview-filters.ts
@@ -1,0 +1,12 @@
+import { ActionType } from '../reducers/pipelines-overview-filters';
+
+export const setTimespan = (timespan: number) => ({
+  type: ActionType.SET_TIMESPAN,
+  payload: { timespan },
+});
+
+export const setInterval = (interval: number) => ({
+  type: ActionType.SET_INTERVAL,
+  payload: { interval },
+});
+

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -1,0 +1,3 @@
+export * from './actions/pipelines-overview-filters';
+export * from './reducers/pipelines-overview-filters';
+export * from './selectors/pipelines-overview-filters';

--- a/src/redux/reducers/pipelines-overview-filters.ts
+++ b/src/redux/reducers/pipelines-overview-filters.ts
@@ -1,0 +1,37 @@
+export type PipelinesOverviewFiltersState = {
+  timespan: number | null;
+  interval: number | null;
+};
+
+export enum ActionType {
+  SET_TIMESPAN = 'SET_PIPELINES_OVERVIEW_TIMESPAN',
+  SET_INTERVAL = 'SET_PIPELINES_OVERVIEW_INTERVAL',
+}
+
+type Action = {
+  type: ActionType;
+  payload?: {
+    timespan?: number;
+    interval?: number;
+  };
+};
+
+const initialState: PipelinesOverviewFiltersState = {
+  timespan: null,
+  interval: null,
+};
+
+export const pipelinesOverviewFiltersReducer = (
+  state: PipelinesOverviewFiltersState = initialState,
+  action: Action,
+): PipelinesOverviewFiltersState => {
+  switch (action.type) {
+    case ActionType.SET_TIMESPAN:
+      return { ...state, timespan: action.payload?.timespan ?? null };
+    case ActionType.SET_INTERVAL:
+      return { ...state, interval: action.payload?.interval ?? null };
+    default:
+      return state;
+  }
+};
+

--- a/src/redux/selectors/pipelines-overview-filters.ts
+++ b/src/redux/selectors/pipelines-overview-filters.ts
@@ -1,0 +1,14 @@
+import { PipelinesOverviewFiltersState } from '../reducers/pipelines-overview-filters';
+
+export const getPipelinesOverviewTimespan = (state: {
+  plugins?: { pipelinesOverviewFilters?: PipelinesOverviewFiltersState };
+}): number | null => {
+  return state.plugins?.pipelinesOverviewFilters?.timespan ?? null;
+};
+
+export const getPipelinesOverviewInterval = (state: {
+  plugins?: { pipelinesOverviewFilters?: PipelinesOverviewFiltersState };
+}): number | null => {
+  return state.plugins?.pipelinesOverviewFilters?.interval ?? null;
+};
+


### PR DESCRIPTION
## PR Description

### Summary
Implements filter persistence for the Pipeline Overview page to maintain user selections (Time Range and Refresh Interval) across navigation and page refreshes.

### Problem
Users lost their filter selections when navigating away from the Pipeline Overview page and returning, leading to a disruptive experience where they had to reconfigure their view each time.

### Solution
- Added Redux state management for Time Range and Refresh Interval filters
- Implemented dual persistence strategy: Redux store + URL query parameters
- Created custom hooks (`usePersistedTimespanWithUrl`, `usePersistedIntervalWithUrl`) to manage filter state
- Priority order for value initialization: URL → Redux → Default value

### Technical Changes
- **Redux Layer**: Created reducer, actions, and selectors for `pipelinesOverviewFilters`
- **Custom Hooks**: Refactored filter management to use persistence-aware hooks

### Behavior
- Filters persist across navigation and page refreshes
- Filters reset to defaults when switching namespaces (provides clean slate per namespace)
- Namespace persistence handled by OpenShift Console SDK (unchanged)

### Testing
- Verify Time Range selection persists after navigation
- Verify Refresh Interval selection (including "off") persists after navigation  
- Verify filters persist after page refresh
- Verify filters reset when switching namespaces

### Screen recording before
Tekton Results
https://github.com/user-attachments/assets/4a6d2d27-005d-493e-b6b7-5f8f1da69d2c

Prometheus
https://github.com/user-attachments/assets/bf31d323-6ce8-4b39-ac62-f07275aeed7f

### Screen recording after
Tekton Results
https://github.com/user-attachments/assets/328d689b-3b34-4759-9cf8-03737d44b4a9

Prometheus
https://github.com/user-attachments/assets/4b9ce288-0a18-4c41-98e4-1ddecff351ca

