### PR TITLE
SRVKP-10306: Upgrade react-router from v5 to v7 to align with console

### DIFF
--- a/__mocks__/textEncoderDecoder.ts
+++ b/__mocks__/textEncoderDecoder.ts
@@ -1,0 +1,14 @@
+// See https://github.com/jsdom/jsdom/issues/2524
+
+import { TextEncoder, TextDecoder } from 'util';
+
+if (
+  typeof global.TextEncoder !== 'undefined' ||
+  typeof global.TextDecoder !== 'undefined'
+) {
+  throw new Error(
+    'Hello future me. Remove __mocks__/textEncoderDecoder.ts now please',
+  );
+}
+
+Object.assign(global, { TextDecoder, TextEncoder });

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -129,7 +129,11 @@ const config: Config.InitialOptions = {
   // runner: "jest-runner",
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-  setupFiles: ['./__mocks__/serverFlags.js', 'jest-canvas-mock'],
+  setupFiles: [
+    './__mocks__/textEncoderDecoder.ts',
+    './__mocks__/serverFlags.js',
+    'jest-canvas-mock',
+  ],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
   // setupFilesAfterEnv: [],
@@ -174,7 +178,7 @@ const config: Config.InitialOptions = {
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
   transformIgnorePatterns: [
-    '<rootDir>/node_modules/(?!(@patternfly(-\\S+)?|d3(-\\S+)?|delaunator|robust-predicates|internmap|cheerio|lodash-es|@openshift-console|@novnc|@spice-project|@popperjs|i18next(-\\S+)?|@babel/runtime)/.*)',
+    '<rootDir>/node_modules/(?!(@patternfly(-\\S+)?|d3(-\\S+)?|delaunator|robust-predicates|internmap|cheerio|lodash-es|@openshift-console|@novnc|@spice-project|@popperjs|i18next(-\\S+)?|@babel/runtime|react-router|cookie|set-cookie-parser)/.*)',
   ],
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them

--- a/package.json
+++ b/package.json
@@ -104,8 +104,6 @@
     "react-redux": "~9.2.0",
     "react-rnd": "^10.3.4",
     "react-router": "~7.13.1",
-    "react-router-dom": "5.3.x",
-    "react-router-dom-v5-compat": "^6.11.2",
     "react-transition-group": "2.3.x",
     "react-virtualized": "9.x",
     "resolve-url-loader": "5.0.0",

--- a/src/components/approval-tasks/ApprovalTasksList.tsx
+++ b/src/components/approval-tasks/ApprovalTasksList.tsx
@@ -15,7 +15,7 @@ import {
 } from '../utils/pipeline-approval-utils';
 import { ApprovalStatus } from '../../types';
 import { useApprovalTasks, usePipelineRuns } from '../hooks/useTaskRuns';
-import { useParams } from 'react-router-dom-v5-compat';
+import { useParams } from 'react-router';
 import useApprovalsColumns from './useApprovalsColumns';
 import ApprovalRow from './ApprovalRow';
 import { ListPageFilter } from '../list-pages/ListPageFilter';

--- a/src/components/approval-tasks/modal/Approval.tsx
+++ b/src/components/approval-tasks/modal/Approval.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Formik, FormikValues, FormikHelpers } from 'formik';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import {
   Modal,
   ModalHeader,

--- a/src/components/approval-tasks/modal/__tests__/Approval.spec.tsx
+++ b/src/components/approval-tasks/modal/__tests__/Approval.spec.tsx
@@ -28,8 +28,8 @@ jest.mock('react-i18next', () => ({
   }),
 }));
 
-// Mock react-router-dom-v5-compat
-jest.mock('react-router-dom-v5-compat', () => ({
+// Mock react-router
+jest.mock('react-router', () => ({
   Link: ({ children, to }: { children: ReactNode; to: string }) => (
     <a href={to}>{children}</a>
   ),

--- a/src/components/common/LinkTo.tsx
+++ b/src/components/common/LinkTo.tsx
@@ -1,4 +1,4 @@
-import { Link, LinkProps } from 'react-router-dom-v5-compat';
+import { Link, LinkProps } from 'react-router';
 
 /**
  * A helper which creates a `Link` component that **only**
@@ -6,7 +6,7 @@ import { Link, LinkProps } from 'react-router-dom-v5-compat';
  *
  * This is needed to bypass PatternFly `DropdownItem`
  * forcing the `to` prop to pass as `href`, which breaks
- * `react-router-dom` routing and causes a hard reload.
+ * `react-router` routing and causes a hard reload.
  *
  * @param href - The location to link to.
  * @param extraLinkProps - Any additional props to pass to the `Link` component.

--- a/src/components/details-page/breadcrumbs/BreadCrumbs.tsx
+++ b/src/components/details-page/breadcrumbs/BreadCrumbs.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, PropsWithChildren, FC } from 'react';
 import { isValidElement, Fragment } from 'react';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 
 type BreadCrumbsProps = {

--- a/src/components/details-page/label-list.tsx
+++ b/src/components/details-page/label-list.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import { Component } from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import classNames from 'classnames';
 import * as _ from 'lodash-es';
 import {

--- a/src/components/details-page/router.ts
+++ b/src/components/details-page/router.ts
@@ -1,19 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { createBrowserHistory, createMemoryHistory, History } from 'history';
-
-let createHistory;
-
-try {
-  if (process.env.NODE_ENV === 'test') {
-    // Running in node. Can't use browser history
-    createHistory = createMemoryHistory;
-  } else {
-    createHistory = createBrowserHistory;
-  }
-} catch (unused) {
-  createHistory = createBrowserHistory;
-}
-
-export const history: History = createHistory({
-  basename: (window as any).SERVER_FLAGS.basePath,
-});
+export const history = {
+  push: (url: string) => {
+    window.history.pushState(window.history.state, '', url);
+  },
+  replace: (url: string) => {
+    window.history.replaceState(window.history.state, '', url);
+  },
+  back: () => window.history.back(),
+};

--- a/src/components/details-page/selector.tsx
+++ b/src/components/details-page/selector.tsx
@@ -1,7 +1,7 @@
 import * as _ from 'lodash-es';
 import type { FC } from 'react';
 import { SearchIcon } from '@patternfly/react-icons/dist/esm/icons/search-icon';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { selectorToString } from '../utils/k8s-utils';
 

--- a/src/components/hooks/useDataViewFilter.ts
+++ b/src/components/hooks/useDataViewFilter.ts
@@ -4,7 +4,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSearchParams } from 'react-router-dom-v5-compat';
+import { useSearchParams } from 'react-router';
 import { FLAG_PIPELINE_TEKTON_RESULT_INSTALLED } from '../../consts';
 import type {
   CheckboxFilterConfig,

--- a/src/components/hooks/usePersistedFiltersForPipelineOverview.ts
+++ b/src/components/hooks/usePersistedFiltersForPipelineOverview.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router';
 import {
   setInterval as setIntervalAction,
   setTimespan as setTimespanAction,

--- a/src/components/multi-tab-list/MultiTabListPage.tsx
+++ b/src/components/multi-tab-list/MultiTabListPage.tsx
@@ -1,13 +1,17 @@
 import type { ReactNode, FC } from 'react';
-import { ActionList, ActionListGroup, ActionListItem, Button } from '@patternfly/react-core';
+import {
+  ActionList,
+  ActionListGroup,
+  ActionListItem,
+  Button,
+} from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { Link, useParams } from 'react-router-dom-v5-compat';
+import { Link, useParams, useNavigate } from 'react-router';
 import {
   MenuActions,
   MenuAction,
   SecondaryButtonAction,
 } from './multi-tab-list-page-types';
-import { useNavigate } from 'react-router-dom-v5-compat';
 import { getReferenceForModel } from '../pipelines-overview/utils';
 import {
   HorizontalNav,

--- a/src/components/pac/PacPage.tsx
+++ b/src/components/pac/PacPage.tsx
@@ -4,7 +4,7 @@ import {
   useParams,
   useLocation,
   useNavigate,
-} from 'react-router-dom-v5-compat';
+} from 'react-router';
 
 import { usePacData } from './hooks/usePacData';
 import PacForm from './PacForm';

--- a/src/components/pac/__tests__/PacForm.spec.tsx
+++ b/src/components/pac/__tests__/PacForm.spec.tsx
@@ -1,5 +1,5 @@
 import { configure, render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { usePacGHManifest } from '../hooks/usePacGHManifest';
 import PacForm from '../PacForm';

--- a/src/components/pac/__tests__/PacPage.spec.tsx
+++ b/src/components/pac/__tests__/PacPage.spec.tsx
@@ -5,7 +5,7 @@ import {
   useFlag,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { usePacData } from '../hooks/usePacData';
-import { MemoryRouter } from 'react-router-dom-v5-compat';
+import { MemoryRouter } from 'react-router';
 import { sampleSecretData } from '../../../test-data/pac-data';
 
 // Mocks
@@ -15,8 +15,8 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   useAccessReview: jest.fn(),
   useFlag: jest.fn(),
 }));
-jest.mock('react-router-dom-v5-compat', () => ({
-  ...jest.requireActual('react-router-dom-v5-compat'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({ ns: 'openshift-pipelines' }),
   useLocation: () => ({
     pathname: '/pac/ns/openshift-pipelines',

--- a/src/components/pipeline-builder/PipelineBuilderEditPage.tsx
+++ b/src/components/pipeline-builder/PipelineBuilderEditPage.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 import { useState, useEffect } from 'react';
 import { Alert } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { Link, useParams } from 'react-router-dom-v5-compat';
+import { Link, useParams } from 'react-router';
 import { PipelineModel } from '../../models';
 import { PipelineKind } from '../../types';
 import PipelineBuilderPage from './PipelineBuilderPage';

--- a/src/components/pipeline-builder/PipelineBuilderPage.tsx
+++ b/src/components/pipeline-builder/PipelineBuilderPage.tsx
@@ -19,7 +19,7 @@ import { validationSchema } from './validation-utils';
 import { DocumentTitle, k8sCreate, k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 import { returnValidPipelineModel } from '../utils/pipeline-utils';
 import { getReferenceForModel } from '../pipelines-overview/utils';
-import { useNavigate, useParams } from 'react-router-dom-v5-compat';
+import { useNavigate, useParams } from 'react-router';
 
 import './PipelineBuilderPage.scss';
 

--- a/src/components/pipeline-overview/PipelineOverview.spec.tsx
+++ b/src/components/pipeline-overview/PipelineOverview.spec.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps } from 'react';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { setPipelineNotStarted } from './pipeline-overview-utils';
 import PipelinesOverview from './PipelineOverview';

--- a/src/components/pipeline-overview/PipelineOverview.tsx
+++ b/src/components/pipeline-overview/PipelineOverview.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   isPipelineNotStarted,
   removePipelineNotStarted,

--- a/src/components/pipeline-overview/PipelineRunItem.tsx
+++ b/src/components/pipeline-overview/PipelineRunItem.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import { Grid, GridItem } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { useTaskRuns } from '../hooks/useTaskRuns';
 import { useMultiClusterProxyService } from '../hooks/useMultiClusterProxyService';
 import { resourcePath } from '../utils/resource-link';

--- a/src/components/pipeline-topology/ApprovalTaskNode.tsx
+++ b/src/components/pipeline-topology/ApprovalTaskNode.tsx
@@ -3,7 +3,7 @@ import { useRef, useMemo, memo } from 'react';
 import classnames from 'classnames';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { Tooltip } from '@patternfly/react-core';
 import {
   observer,

--- a/src/components/pipeline-topology/CustomTaskNode.tsx
+++ b/src/components/pipeline-topology/CustomTaskNode.tsx
@@ -3,7 +3,7 @@ import { useRef, useMemo, memo } from 'react';
 import cx from 'classnames';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { Tooltip } from '@patternfly/react-core';
 import QuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
 import { t_chart_color_black_500 as customTaskColor } from "@patternfly/react-tokens/dist/js/t_chart_color_black_500";

--- a/src/components/pipeline-topology/PipelineTaskNode.tsx
+++ b/src/components/pipeline-topology/PipelineTaskNode.tsx
@@ -18,7 +18,7 @@ import {
 } from '@patternfly/react-topology';
 import classNames from 'classnames';
 import { observer } from 'mobx-react';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { NodeType } from './const';
 import { PipelineRunModel, TaskModel } from '../../models';
 import { getReferenceForModel } from '../pipelines-overview/utils';

--- a/src/components/pipelineRuns-details/LogURLRedirect.tsx
+++ b/src/components/pipelineRuns-details/LogURLRedirect.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { Navigate, useLocation, useParams } from 'react-router-dom-v5-compat';
+import { Navigate, useLocation, useParams } from 'react-router';
 
 const createLogURL = (pathname: string, taskName: string): string => {
   const basePath = pathname.replace(/\/$/, '');

--- a/src/components/pipelineRuns-details/PipelineRunCustomDetails.tsx
+++ b/src/components/pipelineRuns-details/PipelineRunCustomDetails.tsx
@@ -7,7 +7,7 @@ import {
   DescriptionListTerm,
 } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { getPLRLogSnippet } from '../logs/pipelineRunLogSnippet';
 import RunDetailsErrorLog from '../logs/RunDetailsErrorLog';
 import { getReferenceForModel } from '../pipelines-overview/utils';

--- a/src/components/pipelineRuns-details/PipelineRunDetailsPage.tsx
+++ b/src/components/pipelineRuns-details/PipelineRunDetailsPage.tsx
@@ -10,7 +10,7 @@ import {
   ContentVariants,
   Tooltip,
 } from '@patternfly/react-core';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { navFactory } from '../utils/horizontal-nav';
 import PipelineRunDetails from './PipelineRunDetails';

--- a/src/components/pipelineRuns-details/PipelineRunEvents.tsx
+++ b/src/components/pipelineRuns-details/PipelineRunEvents.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useParams } from 'react-router-dom-v5-compat';
+import { useParams } from 'react-router';
 import { PipelineRunKind } from '../../types';
 import { ResourcesEventStream } from '../pipelines-tasks/tasks-details-pages/events/events';
 import { usePipelineRunFilters } from '../pipelines-tasks/tasks-details-pages/events/event-utils';

--- a/src/components/pipelineRuns-details/PipelineRunLogs.tsx
+++ b/src/components/pipelineRuns-details/PipelineRunLogs.tsx
@@ -4,7 +4,7 @@ import { Nav, NavItem, NavList, Alert, Banner } from '@patternfly/react-core';
 import { LogViewer } from '@patternfly/react-log-viewer';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { Link, useLocation } from 'react-router-dom-v5-compat';
+import { Link, useLocation } from 'react-router';
 import {
   WatchK8sResource,
   useOverlay,

--- a/src/components/pipelineRuns-details/RepositoryLinkList.tsx
+++ b/src/components/pipelineRuns-details/RepositoryLinkList.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import {
   ClipboardCopy,
   ClipboardCopyVariant,

--- a/src/components/pipelineRuns-list/PipelineRunsList.tsx
+++ b/src/components/pipelineRuns-list/PipelineRunsList.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import { useEffect, useMemo, useRef } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom-v5-compat';
+import { useParams, useSearchParams } from 'react-router';
 import { ListPageBody } from '@openshift-console/dynamic-plugin-sdk';
 import usePipelineRunsColumns from './usePipelineRunsColumns';
 import { PipelineRunKind } from '../../types';

--- a/src/components/pipelines-details/PipelineDetailsPage.tsx
+++ b/src/components/pipelines-details/PipelineDetailsPage.tsx
@@ -4,7 +4,7 @@ import {
   ContentVariants,
 } from '@patternfly/react-core';
 import { useMemo, useCallback } from 'react';
-import { Link, useParams } from 'react-router-dom-v5-compat';
+import { Link, useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   getGroupVersionKindForModel,

--- a/src/components/pipelines-details/PipelineVisualizationTask.tsx
+++ b/src/components/pipelines-details/PipelineVisualizationTask.tsx
@@ -6,7 +6,7 @@ import { Tooltip } from '@patternfly/react-core';
 import { createSvgIdUrl, useHover } from '@patternfly/react-topology';
 import cx from 'classnames';
 import * as _ from 'lodash';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 
 import {
   createStepStatus,

--- a/src/components/pipelines-list/PipelinesList.tsx
+++ b/src/components/pipelines-list/PipelinesList.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom-v5-compat';
+import { useParams, useSearchParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   ListPageBody,

--- a/src/components/pipelines-list/PipelinesTabbedPage.tsx
+++ b/src/components/pipelines-list/PipelinesTabbedPage.tsx
@@ -27,7 +27,7 @@ import {
 } from '../multi-tab-list/multi-tab-list-page-types';
 import { MultiTabListPage } from '../multi-tab-list';
 import AllProjectsPage from '../projects-list/AllProjectsPage';
-import { useLocation, useParams } from 'react-router-dom-v5-compat';
+import { useLocation, useParams } from 'react-router';
 import { ApprovalTasksList } from '../approval-tasks';
 import { useK8sGet } from '../hooks/use-k8sGet-hook';
 import { SecretKind } from '../../types';

--- a/src/components/pipelines-list/status/LinkedPipelineRunTaskStatus.tsx
+++ b/src/components/pipelines-list/status/LinkedPipelineRunTaskStatus.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { PipelineRunKind, TaskRunKind } from '../../../types';
 import { PipelineBars, PipelineBarsForTaskRunsStatus } from './PipelineBars';
 import { LoadingInline } from '../../Loading';

--- a/src/components/pipelines-list/status/PipelineRunStatus.tsx
+++ b/src/components/pipelines-list/status/PipelineRunStatus.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { PipelineRunModel } from '../../../models';
 import { PipelineRunKind, TaskRunKind } from '../../../types';
 import PipelineResourceStatus from './PipelineResourceStatus';

--- a/src/components/pipelines-overview/__tests__/PipelinesOverview.spec.tsx
+++ b/src/components/pipelines-overview/__tests__/PipelinesOverview.spec.tsx
@@ -6,10 +6,8 @@ import {
   useActiveNamespace,
   useFlag,
 } from '@openshift-console/dynamic-plugin-sdk';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router';
 import PipelinesOverviewPage from '../PipelinesOverviewPage';
 import { getResultsSummary } from '../../utils/summary-api';
 import * as utils from '../utils';
@@ -34,7 +32,7 @@ jest.mock('react-redux', () => ({
   useDispatch: jest.fn(),
   useSelector: jest.fn(),
 }));
-jest.mock('react-router-dom-v5-compat', () => ({
+jest.mock('react-router', () => ({
   useLocation: jest.fn(),
 }));
 (VirtualizedTable as jest.Mock).mockImplementation((props) => {
@@ -50,8 +48,8 @@ const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
 const useActiveColumnsMock = useActiveColumns as jest.Mock;
 const getResultsSummaryMock = getResultsSummary as jest.Mock;
 const useFlagMock = useFlag as jest.Mock;
-const useDispatchMock = useDispatch as jest.Mock;
-const useSelectorMock = useSelector as jest.Mock;
+const useDispatchMock = useDispatch as unknown as jest.Mock;
+const useSelectorMock = useSelector as unknown as jest.Mock;
 const useLocationMock = useLocation as jest.Mock;
 
 describe('Pipeline Overview page', () => {

--- a/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesRow.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesRow.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { FC } from 'react';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import {
   SummaryProps,
   getReferenceForModel,

--- a/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesRowK8s.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesRowK8s.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { FC } from 'react';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { Tooltip } from '@patternfly/react-core';
 import {

--- a/src/components/pipelines-overview/list-pages/PipelineRunsForRepositoriesRow.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsForRepositoriesRow.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import {
   ResourceLink,
   RowProps,

--- a/src/components/pipelines-overview/utils.ts
+++ b/src/components/pipelines-overview/utils.ts
@@ -6,7 +6,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useState, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate } from 'react-router';
 import { ALL_NAMESPACES_KEY } from '../../consts';
 import { adjustToStartOfWeek } from '../pipelines-metrics/utils';
 

--- a/src/components/pipelines-tasks/TaskRunStatus.tsx
+++ b/src/components/pipelines-tasks/TaskRunStatus.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { TaskRunKind } from '../../types';
 import { TektonResourceLabel } from '../../consts';
 import PipelineResourceStatus from '../status/PipelineResourceStatus';

--- a/src/components/pipelines-tasks/TaskRunsList.tsx
+++ b/src/components/pipelines-tasks/TaskRunsList.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import { useEffect, useRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams, useSearchParams } from 'react-router-dom-v5-compat';
+import { useParams, useSearchParams } from 'react-router';
 import { SortByDirection } from '@patternfly/react-table';
 import {
   K8sResourceCommon,

--- a/src/components/pipelines-tasks/TasksList.tsx
+++ b/src/components/pipelines-tasks/TasksList.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom-v5-compat';
+import { useParams } from 'react-router';
 import {
   ResourceLink,
   RowProps,

--- a/src/components/pipelines-tasks/tasks-details-pages/TaskRunDetailsPage.tsx
+++ b/src/components/pipelines-tasks/tasks-details-pages/TaskRunDetailsPage.tsx
@@ -4,9 +4,9 @@ import {
   ContentVariants,
   Tooltip,
 } from '@patternfly/react-core';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { useMemo } from 'react';
-import { useParams } from 'react-router-dom-v5-compat';
+import { useParams } from 'react-router';
 import { ArchiveIcon } from '@patternfly/react-icons';
 import { ResourceStatus } from '@openshift-console/dynamic-plugin-sdk';
 import DetailsPage from '../../details-page/DetailsPage';

--- a/src/components/pipelines-tasks/tasks-details-pages/TaskRunLogsTab.tsx
+++ b/src/components/pipelines-tasks/tasks-details-pages/TaskRunLogsTab.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router';
 import { taskRunStatus } from '../../utils/pipeline-utils';
 import TaskRunLogs from './TaskRunLogs';
 import { TaskRunKind } from '../../../types';

--- a/src/components/pipelines-tasks/tasks-details-pages/events/TaskRunEvents.tsx
+++ b/src/components/pipelines-tasks/tasks-details-pages/events/TaskRunEvents.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useParams } from 'react-router-dom-v5-compat';
+import { useParams } from 'react-router';
 import { PageSection } from '@patternfly/react-core';
 import { useTaskRunFilters } from './event-utils';
 import { ResourcesEventStream } from './events';

--- a/src/components/pipelines-tasks/tasks-details-pages/events/events.jsx
+++ b/src/components/pipelines-tasks/tasks-details-pages/events/events.jsx
@@ -3,7 +3,7 @@ import { useState, useRef, useMemo, useEffect } from 'react';
 import { PageSection } from '@patternfly/react-core';
 import classNames from 'classnames';
 import * as PropTypes from 'prop-types';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { Trans, useTranslation } from 'react-i18next';
 import {
   isGroupVersionKind,

--- a/src/components/projects-list/ProjectsRow.tsx
+++ b/src/components/projects-list/ProjectsRow.tsx
@@ -10,7 +10,7 @@ import Status from '@openshift-console/dynamic-plugin-sdk/lib/app/components/sta
 import _ from 'lodash';
 import type { MouseEvent, FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useLocation, useSearchParams } from 'react-router-dom-v5-compat';
+import { Link, useLocation, useSearchParams } from 'react-router';
 import { formatNamespaceRoute } from '../pipelines-overview/utils';
 
 const getDisplayName = (obj) =>

--- a/src/components/quick-search/QuickSearchDetails.tsx
+++ b/src/components/quick-search/QuickSearchDetails.tsx
@@ -5,7 +5,7 @@ import {
   Content,
   Title,
 } from '@patternfly/react-core';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { CatalogItem } from '@openshift-console/dynamic-plugin-sdk';
 import CatalogBadges from '../catalog/CatalogBadges';

--- a/src/components/quick-search/QuickSearchList.tsx
+++ b/src/components/quick-search/QuickSearchList.tsx
@@ -15,7 +15,7 @@ import {
 } from '@patternfly/react-core';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { CatalogItem } from '@openshift-console/dynamic-plugin-sdk';
 import { CatalogLinkData } from './utils/quick-search-types';
 import { handleCta } from './utils/quick-search-utils';
@@ -23,7 +23,7 @@ import { getIconProps } from '../catalog/catalog-utils';
 import { CatalogType } from '../catalog/types';
 
 import './QuickSearchList.scss';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 
 interface QuickSearchListProps {
   listItems: CatalogItem[];

--- a/src/components/quick-search/QuickSearchModalBody.tsx
+++ b/src/components/quick-search/QuickSearchModalBody.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode, SetStateAction, Dispatch, FC, FormEvent } from 'react';
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { debounce } from 'lodash-es';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 import { ResizeDirection } from 're-resizable';
 import { Rnd } from 'react-rnd';
 import { CatalogItem, useFlag } from '@openshift-console/dynamic-plugin-sdk';

--- a/src/components/repositories-list/RepositoriesList.tsx
+++ b/src/components/repositories-list/RepositoriesList.tsx
@@ -11,7 +11,7 @@ import { PipelineRunKind, RepositoryKind } from '../../types';
 import useRepositoriesColumns from './useRepositoriesColumns';
 import RepositoriesRow from './RepositoriesRow';
 import { useGetTaskRuns } from '../hooks/useTektonResult';
-import { useParams } from 'react-router-dom-v5-compat';
+import { useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { ListPageFilter } from '../list-pages/ListPageFilter';
 

--- a/src/components/repositories-list/RepositoriesRow.tsx
+++ b/src/components/repositories-list/RepositoriesRow.tsx
@@ -8,7 +8,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import type { FC } from 'react';
 import { PipelineRunKind, RepositoryKind, TaskRunKind } from '../../types';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { PipelineRunModel, RepositoryModel } from '../../models';
 import { getLatestRun } from '../utils/pipeline-augment';
 import { getTaskRunsOfPipelineRun } from '../hooks/useTaskRuns';

--- a/src/components/repositories/RepositoryForm.tsx
+++ b/src/components/repositories/RepositoryForm.tsx
@@ -14,7 +14,7 @@ import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { getReferenceForModel } from '../pipelines-overview/utils';
 import { FlexForm, FormBody } from '../pipeline-builder/form-utils';
 import FormFooter from '../pipelines-details/multi-column-field/FormFooter';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 
 type RepositoryFormProps = FormikProps<FormikValues & RepositoryFormValues>;
 

--- a/src/components/repositories/RepositoryFormPage.tsx
+++ b/src/components/repositories/RepositoryFormPage.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 import { useState, useEffect } from 'react';
 import { Formik } from 'formik';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom-v5-compat';
+import { useParams } from 'react-router';
 import { history } from '../utils/router';
 
 import { RepositoryForm } from './RepositoryForm';

--- a/src/components/repositories/__tests__/RepositoryLinkList.spec.tsx
+++ b/src/components/repositories/__tests__/RepositoryLinkList.spec.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import { render } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom-v5-compat';
+import { MemoryRouter } from 'react-router';
 import { PipeLineRunWithRepoMetadata } from '../../../test-data/pipeline-data';
 import { getLabelValue, sanitizeBranchName } from '../../utils/repository-utils';
 import RepositoryLinkList from '../../pipelineRuns-details/RepositoryLinkList';

--- a/src/components/status/PipelineRunStatusPopoverContent.tsx
+++ b/src/components/status/PipelineRunStatusPopoverContent.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { PipelineRunModel } from '../../models';
 import { ComputedStatus, PipelineRunKind } from '../../types';
 import { useTaskRuns } from '../hooks/useTaskRuns';

--- a/src/components/task-quicksearch/PipelineQuickSearchDetails.tsx
+++ b/src/components/task-quicksearch/PipelineQuickSearchDetails.tsx
@@ -17,7 +17,7 @@ import {
 import { CheckCircleIcon } from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 import { debounce } from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { getArtifactHubTaskDetails } from '../catalog/apis/artifactHub';
 import {

--- a/src/components/task-quicksearch/__tests__/PipelineQuicksearchDetails.spec.tsx
+++ b/src/components/task-quicksearch/__tests__/PipelineQuicksearchDetails.spec.tsx
@@ -30,7 +30,7 @@ jest.mock('@console/shared/src/hooks/useTelemetry', () => ({
   useTelemetry: () => {},
 }));
 
-jest.mock('react-router-dom-v5-compat', () => ({
+jest.mock('react-router', () => ({
   useNavigate: jest.fn(() => jest.fn()),
 }));
 

--- a/src/components/tasks/TaskDetailsPage.tsx
+++ b/src/components/tasks/TaskDetailsPage.tsx
@@ -6,7 +6,7 @@ import {
   Content,
   ContentVariants,
 } from '@patternfly/react-core';
-import { Link, useParams } from 'react-router-dom-v5-compat';
+import { Link, useParams } from 'react-router';
 import {
   getGroupVersionKindForModel,
   useK8sWatchResource,

--- a/src/components/topology/Decorator.tsx
+++ b/src/components/topology/Decorator.tsx
@@ -1,6 +1,6 @@
 import type { FunctionComponent, MouseEvent, ReactNode, Ref } from 'react';
 import { Decorator as PfDecorator } from '@patternfly/react-topology';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { CustomSVGDefsProvider } from './CustomSVGDefsProvider';
 
 import './Decorator.scss';

--- a/src/components/topology/build-decorators/PipelineRunDecorator.tsx
+++ b/src/components/topology/build-decorators/PipelineRunDecorator.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import { useRef } from 'react';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   AccessReviewResourceAttributes,
   useAccessReview,

--- a/src/components/topology/build-decorators/__tests__/PipelineRunDecorator.spec.tsx
+++ b/src/components/topology/build-decorators/__tests__/PipelineRunDecorator.spec.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { SVGDefsProvider } from '@patternfly/react-topology';
 import { useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
 import { ConnectedPipelineRunDecorator } from '../PipelineRunDecorator';

--- a/src/components/triggers-list/EventListenersList.tsx
+++ b/src/components/triggers-list/EventListenersList.tsx
@@ -8,7 +8,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom-v5-compat';
+import { useParams } from 'react-router';
 import { useDefaultColumns } from '../list-pages/default-resources';
 import { EventListenerModel } from '../../models';
 import EventListenersRow from './EventListenersRow';

--- a/src/components/triggers-list/TriggerBindingsList.tsx
+++ b/src/components/triggers-list/TriggerBindingsList.tsx
@@ -8,7 +8,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom-v5-compat';
+import { useParams } from 'react-router';
 import { useDefaultColumns } from '../list-pages/default-resources';
 import { TriggerBindingModel } from '../../models';
 import EventListenersRow from './EventListenersRow';

--- a/src/components/triggers-list/TriggerTemplatesList.tsx
+++ b/src/components/triggers-list/TriggerTemplatesList.tsx
@@ -8,7 +8,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom-v5-compat';
+import { useParams } from 'react-router';
 import { useDefaultColumns } from '../list-pages/default-resources';
 import { TriggerTemplateModel } from '../../models';
 import EventListenersRow from './EventListenersRow';

--- a/src/components/utils/k8s-common-kebab-menu.tsx
+++ b/src/components/utils/k8s-common-kebab-menu.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { DropdownItem } from '@patternfly/react-core';
 import {

--- a/src/components/utils/resource-link.tsx
+++ b/src/components/utils/resource-link.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode, FC } from 'react';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import cx from 'classnames';
 import { getReference } from '../pipelines-overview/utils';
 import {

--- a/src/components/utils/router.ts
+++ b/src/components/utils/router.ts
@@ -1,35 +1,16 @@
-import { createBrowserHistory, createMemoryHistory, History } from 'history';
 import * as _ from 'lodash-es';
 
-let createHistory;
+const replaceUrl = (url: string) => {
+  window.history.replaceState(window.history.state, '', url);
+};
 
-try {
-  if (process.env.NODE_ENV === 'test') {
-    // Running in node. Can't use browser history
-    createHistory = createMemoryHistory;
-  } else {
-    createHistory = createBrowserHistory;
-  }
-} catch (unused) {
-  createHistory = createBrowserHistory;
-}
-
-export const history: History = createHistory({
-  basename: (window as any).SERVER_FLAGS.basePath,
-});
-
-const removeBasePath = (url = '/') =>
-  _.startsWith(url, (window as any).SERVER_FLAGS.basePath)
-    ? url.slice((window as any).SERVER_FLAGS.basePath.length - 1)
-    : url;
-
-// Monkey patch history to slice off the base path
-(history as any).__replace__ = history.replace;
-history.replace = (url: string) =>
-  (history as any).__replace__(removeBasePath(url));
-
-(history as any).__push__ = history.push;
-history.push = (url: string) => (history as any).__push__(removeBasePath(url));
+export const history = {
+  push: (url: string) => {
+    window.history.pushState(window.history.state, '', url);
+  },
+  replace: replaceUrl,
+  back: () => window.history.back(),
+};
 
 export const getQueryArgument = (arg: string) =>
   new URLSearchParams(window.location.search).get(arg);
@@ -39,7 +20,7 @@ export const setQueryArgument = (k: string, v: string) => {
   if (params.get(k) !== v) {
     params.set(k, v);
     const url = new URL(window.location.href);
-    history.replace(`${url.pathname}?${params.toString()}${url.hash}`);
+    replaceUrl(`${url.pathname}?${params.toString()}${url.hash}`);
   }
 };
 
@@ -54,7 +35,7 @@ export const setQueryArguments = (newParams: { [k: string]: string }) => {
   });
   if (update) {
     const url = new URL(window.location.href);
-    history.replace(`${url.pathname}?${params.toString()}${url.hash}`);
+    replaceUrl(`${url.pathname}?${params.toString()}${url.hash}`);
   }
 };
 
@@ -69,7 +50,7 @@ export const setAllQueryArguments = (newParams: { [k: string]: string }) => {
   });
   if (update) {
     const url = new URL(window.location.href);
-    history.replace(`${url.pathname}?${params.toString()}${url.hash}`);
+    replaceUrl(`${url.pathname}?${params.toString()}${url.hash}`);
   }
 };
 
@@ -78,7 +59,7 @@ export const removeQueryArgument = (k: string) => {
   if (params.has(k)) {
     params.delete(k);
     const url = new URL(window.location.href);
-    history.replace(`${url.pathname}?${params.toString()}${url.hash}`);
+    replaceUrl(`${url.pathname}?${params.toString()}${url.hash}`);
   }
 };
 
@@ -93,7 +74,7 @@ export const removeQueryArguments = (...keys: string[]) => {
   });
   if (update) {
     const url = new URL(window.location.href);
-    history.replace(`${url.pathname}?${params.toString()}${url.hash}`);
+    replaceUrl(`${url.pathname}?${params.toString()}${url.hash}`);
   }
 };
 

--- a/src/utils/default-actions-provider.ts
+++ b/src/utils/default-actions-provider.ts
@@ -8,7 +8,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 import { getReferenceForModel } from '../components/pipelines-overview/utils';
 import {
   ClusterTriggerBindingModel,

--- a/src/utils/pipeline-actions-provider.ts
+++ b/src/utils/pipeline-actions-provider.ts
@@ -10,7 +10,7 @@ import {
 import * as _ from 'lodash';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 import { useGetActiveUser } from '../components/hooks/hooks';
 import { useErrorModal } from '../components/modals/error-modal';
 import {

--- a/src/utils/pipelineRun-actions-provider.tsx
+++ b/src/utils/pipelineRun-actions-provider.tsx
@@ -7,7 +7,7 @@ import {
   useDeleteModal,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 import { PipelineRunModel } from '../models';
 import { PipelineRunKind } from '../types';
 import { returnValidPipelineRunModel } from '../components/utils/pipeline-utils';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,7 +1351,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.26.10, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2, @babel/runtime@npm:latest":
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.26.10, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2, @babel/runtime@npm:latest":
   version: 7.29.2
   resolution: "@babel/runtime@npm:7.29.2"
   checksum: 10c0/30b80a0140d16467792e1bbeb06f655b0dab70407da38dfac7fedae9c859f9ae9d846ef14ad77bd3814c064295fe9b1bc551f1541ea14646ae9f22b71a8bc17a
@@ -1568,30 +1568,30 @@ __metadata:
   linkType: hard
 
 "@emnapi/core@npm:^1.4.3":
-  version: 1.9.1
-  resolution: "@emnapi/core@npm:1.9.1"
+  version: 1.9.2
+  resolution: "@emnapi/core@npm:1.9.2"
   dependencies:
-    "@emnapi/wasi-threads": "npm:1.2.0"
+    "@emnapi/wasi-threads": "npm:1.2.1"
     tslib: "npm:^2.4.0"
-  checksum: 10c0/00e7a99a2bc3ad908ca8272ba861a934da87dffa8797a41316c4a3b571a1e4d2743e2fa14b1a0f131fa4a3c2018ddb601cd2a8cb7f574fa940af696df3c2fe8d
+  checksum: 10c0/5500393f953951bad0768fafaa9191f2d938956b20c6d6a79e5ab696a613a25ce6ad23422bc18e86e6ce8deb147619d8d0d7d413a69f84adc01a6633cc353cd9
   languageName: node
   linkType: hard
 
 "@emnapi/runtime@npm:^1.4.3":
-  version: 1.9.1
-  resolution: "@emnapi/runtime@npm:1.9.1"
+  version: 1.9.2
+  resolution: "@emnapi/runtime@npm:1.9.2"
   dependencies:
     tslib: "npm:^2.4.0"
-  checksum: 10c0/750edca117e0363ab2de10622f8ee60e57d8690c2f29c49704813da5cd627c641798d7f3cb0d953c62fdc71688e02e333ddbf2c1204f38b47e3e40657332a6f5
+  checksum: 10c0/61c3a59e0c36784558b8d58eb02bd04815aa5fb0dbfbaf84d1b3050a78aa0cc63ea129ae806bd1e48062bfeb7fc36eb0e5431740d62f64ea51bdf426404b8caa
   languageName: node
   linkType: hard
 
-"@emnapi/wasi-threads@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@emnapi/wasi-threads@npm:1.2.0"
+"@emnapi/wasi-threads@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@emnapi/wasi-threads@npm:1.2.1"
   dependencies:
     tslib: "npm:^2.4.0"
-  checksum: 10c0/1e3724b5814b06c14782fda87eee9b9aa68af01576c81ffeaefdf621ddb74386e419d5b3b1027b6a8172397729d95a92f814fc4b8d3c224376428faa07a6a01a
+  checksum: 10c0/32fcfa81ab396533b2ec1f4082b1ff779a05d9c836bbbd3f4398405b0e6814c0d9503b7993130e37bc6941dbc1ded49f55e9700ae9ca4e803bab2b5bc5deb331
   languageName: node
   linkType: hard
 
@@ -3090,9 +3090,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-core@npm:^6.0.0, @patternfly/react-core@npm:^6.0.0-prerelease.21, @patternfly/react-core@npm:^6.4.0, @patternfly/react-core@npm:^6.4.1":
-  version: 6.4.1
-  resolution: "@patternfly/react-core@npm:6.4.1"
+"@patternfly/react-core@npm:^6.0.0, @patternfly/react-core@npm:^6.0.0-prerelease.21, @patternfly/react-core@npm:^6.4.0, @patternfly/react-core@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "@patternfly/react-core@npm:6.4.2"
   dependencies:
     "@patternfly/react-icons": "npm:^6.4.0"
     "@patternfly/react-styles": "npm:^6.4.0"
@@ -3103,25 +3103,25 @@ __metadata:
   peerDependencies:
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
-  checksum: 10c0/204b2b9f2990b0f0f5d907ba9d63f4f78f8691c8a4c7c292318978c5d4ea2dea89dab962be20e97bc3f2fd5172f2ee44abc17683c2c96f8f7eeb8ad357ba9326
+  checksum: 10c0/e6a30591bf29bfa0295cf94c546c6aa31e2643d022db48b49dabaaca928a916177aa200c4d01cb8deece8f9e1bd66d91a20b2348f0fbd84fad204a51c7919aa8
   languageName: node
   linkType: hard
 
 "@patternfly/react-drag-drop@npm:^6.0.0":
-  version: 6.4.1
-  resolution: "@patternfly/react-drag-drop@npm:6.4.1"
+  version: 6.4.2
+  resolution: "@patternfly/react-drag-drop@npm:6.4.2"
   dependencies:
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/modifiers": "npm:^9.0.0"
     "@dnd-kit/sortable": "npm:^10.0.0"
-    "@patternfly/react-core": "npm:^6.4.1"
+    "@patternfly/react-core": "npm:^6.4.2"
     "@patternfly/react-icons": "npm:^6.4.0"
     "@patternfly/react-styles": "npm:^6.4.0"
     resize-observer-polyfill: "npm:^1.5.1"
   peerDependencies:
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
-  checksum: 10c0/0a2334b0982efc607d5a50aa13d036771a582590a1cd4b9f47603d3173cf30d3725a8a7162f39fd0df76441ed4c9c26fb0ea076bf1300a0561ec4cd9f467edc4
+  checksum: 10c0/09970d154e9ad91994c9d7c6c9bed97ee0d24322cb98f91488a9eb7099a62d890fb57044ed30bea48c9cc84d350ac1f693423a4d89b62c545aba8dbbd18b140d
   languageName: node
   linkType: hard
 
@@ -3158,10 +3158,10 @@ __metadata:
   linkType: hard
 
 "@patternfly/react-table@npm:^6.0.0, @patternfly/react-table@npm:^6.4.0":
-  version: 6.4.1
-  resolution: "@patternfly/react-table@npm:6.4.1"
+  version: 6.4.2
+  resolution: "@patternfly/react-table@npm:6.4.2"
   dependencies:
-    "@patternfly/react-core": "npm:^6.4.1"
+    "@patternfly/react-core": "npm:^6.4.2"
     "@patternfly/react-icons": "npm:^6.4.0"
     "@patternfly/react-styles": "npm:^6.4.0"
     "@patternfly/react-tokens": "npm:^6.4.0"
@@ -3170,7 +3170,7 @@ __metadata:
   peerDependencies:
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
-  checksum: 10c0/9808a71211a70d7b5e6aead5eff49e06021bf621798e752e4c8490c1bc40a99292be877c8403fc89266aadd7299dcd3731b1354b806793b5d2e5a5db5e7d4706
+  checksum: 10c0/87517f3cb13dbb1c3a9d3bdabcf3469b2fb0fbdc55f1642dcc0f62029caded02ebc3822d6aa373ebc40f4782e012d0f1fc292653d438f9042c6f3ff50f4bf98b
   languageName: node
   linkType: hard
 
@@ -3409,13 +3409,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.23.2":
-  version: 1.23.2
-  resolution: "@remix-run/router@npm:1.23.2"
-  checksum: 10c0/7096b7f2086b2cd80c9e06873b71a8317e04858c01edc06a6fed187b660408a90f47c8e120e8af4c369cf1fa6b6a316a66b0917f42b6eb8a566e98b277c50449
-  languageName: node
-  linkType: hard
-
 "@sinclair/typebox@npm:^0.27.8":
   version: 0.27.10
   resolution: "@sinclair/typebox@npm:0.27.10"
@@ -3424,9 +3417,9 @@ __metadata:
   linkType: hard
 
 "@sinclair/typebox@npm:^0.34.0":
-  version: 0.34.48
-  resolution: "@sinclair/typebox@npm:0.34.48"
-  checksum: 10c0/e09f26d8ad471a07ee64004eea7c4ec185349a1f61c03e87e71ea33cbe98e97959940076c2e52968a955ffd4c215bf5ba7035e77079511aac7935f25e989e29d
+  version: 0.34.49
+  resolution: "@sinclair/typebox@npm:0.34.49"
+  checksum: 10c0/16b7d87f039a49b68c10bb4cdcae2ce5242b2472228851fd6483731616aba4ef977690aa517b230a8d20da8185bb416eb34e326f30568b3963c1cf26b05d1ad8
   languageName: node
   linkType: hard
 
@@ -3440,11 +3433,11 @@ __metadata:
   linkType: hard
 
 "@sinonjs/fake-timers@npm:^15.0.0":
-  version: 15.1.1
-  resolution: "@sinonjs/fake-timers@npm:15.1.1"
+  version: 15.3.0
+  resolution: "@sinonjs/fake-timers@npm:15.3.0"
   dependencies:
     "@sinonjs/commons": "npm:^3.0.1"
-  checksum: 10c0/8eaaa1c9db91256dfe31f3503cdd844ea031ffd16276b3bcd95457432d666d6d027453af5f884e010dba4ebe264b50ac0aac049e192c5f370158da9b291206b9
+  checksum: 10c0/172d21f5200069727f2aa90b35ab60068c1f0652c7d2a43f03bd6c2c2d75b87f4daa9fc7f1402f8c10e0849bb888d15d3364a194339b62307abd3a60cefbb929
   languageName: node
   linkType: hard
 
@@ -4101,20 +4094,20 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 25.5.0
-  resolution: "@types/node@npm:25.5.0"
+  version: 25.5.2
+  resolution: "@types/node@npm:25.5.2"
   dependencies:
     undici-types: "npm:~7.18.0"
-  checksum: 10c0/70c508165b6758c4f88d4f91abca526c3985eee1985503d4c2bd994dbaf588e52ac57e571160f18f117d76e963570ac82bd20e743c18987e82564312b3b62119
+  checksum: 10c0/11e41a85401724cd1a4de6fb7bd4264ec46db10c09fc8cf8d41de4ede0a7063db458348f859ead4ec0929906aa26aaf45a5fef3aa59742ca0521cda9cee52377
   languageName: node
   linkType: hard
 
 "@types/node@npm:22.x":
-  version: 22.19.15
-  resolution: "@types/node@npm:22.19.15"
+  version: 22.19.17
+  resolution: "@types/node@npm:22.19.17"
   dependencies:
     undici-types: "npm:~6.21.0"
-  checksum: 10c0/f17eaf3d0d1da5e93ad9e287efb78201f8a5282973c004c5f70d91675c5c6b926a23acaa7b158a42b3d7e27e36b349d65a531710c91c308fca53dd7fa280ef98
+  checksum: 10c0/b66c484c0a9f6d88b1ef360b0f487717234ee1a482cb2551ff73d9f3c43a42a777daf4c8a5eee970960728f8fe1f3877d3d8c6ffabcbca74cb401a59db700fa4
   languageName: node
   linkType: hard
 
@@ -5492,12 +5485,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"baseline-browser-mapping@npm:^2.9.0":
-  version: 2.10.11
-  resolution: "baseline-browser-mapping@npm:2.10.11"
+"baseline-browser-mapping@npm:^2.10.12":
+  version: 2.10.15
+  resolution: "baseline-browser-mapping@npm:2.10.15"
   bin:
     baseline-browser-mapping: dist/cli.cjs
-  checksum: 10c0/6ae44b653c26de8ea7b75a109c0771c95c9676c32a11aff25f7c10b2ddeb864d2c387243a0ec083dffe3b76a7aacf2d777fa7e5a6df16e3a2624c1573e116285
+  checksum: 10c0/0bbcdefe842e79a1bcded41f7ffd6cca7a89edc035cfabae84ed80f19a0318de3f909ee64e184c39165cef12213eba89335745b101eeace2a4eaf290680d3af2
   languageName: node
   linkType: hard
 
@@ -5596,7 +5589,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.2":
+"brace-expansion@npm:^5.0.5":
   version: 5.0.5
   resolution: "brace-expansion@npm:5.0.5"
   dependencies:
@@ -5655,17 +5648,17 @@ __metadata:
   linkType: hard
 
 "browserslist@npm:^4.24.0, browserslist@npm:^4.28.1":
-  version: 4.28.1
-  resolution: "browserslist@npm:4.28.1"
+  version: 4.28.2
+  resolution: "browserslist@npm:4.28.2"
   dependencies:
-    baseline-browser-mapping: "npm:^2.9.0"
-    caniuse-lite: "npm:^1.0.30001759"
-    electron-to-chromium: "npm:^1.5.263"
-    node-releases: "npm:^2.0.27"
-    update-browserslist-db: "npm:^1.2.0"
+    baseline-browser-mapping: "npm:^2.10.12"
+    caniuse-lite: "npm:^1.0.30001782"
+    electron-to-chromium: "npm:^1.5.328"
+    node-releases: "npm:^2.0.36"
+    update-browserslist-db: "npm:^1.2.3"
   bin:
     browserslist: cli.js
-  checksum: 10c0/545a5fa9d7234e3777a7177ec1e9134bb2ba60a69e6b95683f6982b1473aad347c77c1264ccf2ac5dea609a9731fbfbda6b85782bdca70f80f86e28a402504bd
+  checksum: 10c0/c0228b6330f785b7fa59d2d360124ec6d9322f96ed9f3ee1f873e33ecc9503a6f0ffc3b71191a28c4ff6e930b753b30043da1c33844a9548f3018d491f09ce60
   languageName: node
   linkType: hard
 
@@ -5821,10 +5814,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001759":
-  version: 1.0.30001781
-  resolution: "caniuse-lite@npm:1.0.30001781"
-  checksum: 10c0/79e77d8759a55e90f0f5db96ab9e7925c7b2e3021f77852e647e45f64f7dc701954174188438e84b810824afc16d706c64a38f20f9c1ed9ac174b6362d33325f
+"caniuse-lite@npm:^1.0.30001782":
+  version: 1.0.30001786
+  resolution: "caniuse-lite@npm:1.0.30001786"
+  checksum: 10c0/9895f0add1991eefb91cfae98e7baa9daffc6b862b0996c983d30e6be90ef679b6aef32dcb6eca312977fb67c2636ee575820f101213e69c1e0dbffd6ee8e09e
   languageName: node
   linkType: hard
 
@@ -7193,10 +7186,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.5.263":
-  version: 1.5.328
-  resolution: "electron-to-chromium@npm:1.5.328"
-  checksum: 10c0/284a642ee800f5e1968696a3b00dcc070f556b6a49d0a7df1aa8cf95558344a300724356c060e911c238a683c30ee01596cefc4664744f6a565555c4238b72e6
+"electron-to-chromium@npm:^1.5.328":
+  version: 1.5.331
+  resolution: "electron-to-chromium@npm:1.5.331"
+  checksum: 10c0/a7687f3bb4df4640bfeac08d1586531624917452bbbbeb67ccf2b07f111e584321e60945da080df664cbb57f272307d7867c8b93e279150ce8385f13d5178c96
   languageName: node
   linkType: hard
 
@@ -8702,7 +8695,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.7.8":
+"handlebars@npm:^4.7.9":
   version: 4.7.9
   resolution: "handlebars@npm:4.7.9"
   dependencies:
@@ -8810,30 +8803,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"history@npm:^4.9.0":
-  version: 4.10.1
-  resolution: "history@npm:4.10.1"
-  dependencies:
-    "@babel/runtime": "npm:^7.1.2"
-    loose-envify: "npm:^1.2.0"
-    resolve-pathname: "npm:^3.0.0"
-    tiny-invariant: "npm:^1.0.2"
-    tiny-warning: "npm:^1.0.0"
-    value-equal: "npm:^1.0.1"
-  checksum: 10c0/35377694e4f10f2cf056a9cb1a8ee083e04e4b4717a63baeee4afd565658a62c7e73700bf9e82aa53dbe1ec94e0a25a83c080d63bad8ee6b274a98d2fbc5ed4c
-  languageName: node
-  linkType: hard
-
-"history@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "history@npm:5.3.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.7.6"
-  checksum: 10c0/812ec839386222d6437bd78d9f05db32e47d105ada0ad8834b32626919dd2fee7a10001bc489510f93a8069d02f118214bd8d42a82f7cf9daf8e84fbcbbb2016
-  languageName: node
-  linkType: hard
-
-"hoist-non-react-statics@npm:^3.1.0, hoist-non-react-statics@npm:^3.2.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
+"hoist-non-react-statics@npm:^3.2.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -9658,13 +9628,6 @@ __metadata:
   dependencies:
     is-inside-container: "npm:^1.0.0"
   checksum: 10c0/7e5023522bfb8f27de4de960b0d82c4a8146c0bddb186529a3616d78b5bbbfc19ef0c5fc60d0b3a3cc0bf95a415fbdedc18454310ea3049587c879b07ace5107
-  languageName: node
-  linkType: hard
-
-"isarray@npm:0.0.1":
-  version: 0.0.1
-  resolution: "isarray@npm:0.0.1"
-  checksum: 10c0/ed1e62da617f71fe348907c71743b5ed550448b455f8d269f89a7c7ddb8ae6e962de3dab6a74a237b06f5eb7f6ece7a45ada8ce96d87fe972926530f91ae3311
   languageName: node
   linkType: hard
 
@@ -10930,7 +10893,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.1.0, loose-envify@npm:^1.2.0, loose-envify@npm:^1.3.1, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.1.0, loose-envify@npm:^1.3.1, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -10949,9 +10912,9 @@ __metadata:
   linkType: hard
 
 "lru-cache@npm:^11.0.0, lru-cache@npm:^11.1.0, lru-cache@npm:^11.2.1":
-  version: 11.2.7
-  resolution: "lru-cache@npm:11.2.7"
-  checksum: 10c0/549cdb59488baa617135fc12159cafb1a97f91079f35093bb3bcad72e849fc64ace636d244212c181dfdf1a99bbfa90757ff303f98561958ee4d0f885d9bd5f7
+  version: 11.3.0
+  resolution: "lru-cache@npm:11.3.0"
+  checksum: 10c0/f50d32064c07b17390e7bf89fa09fcf05c19018d8cb03359a04dad3e16e4213812958af32eb0e29a92239a1f13631b58c26c007367f99946defcf4e495c1c123
   languageName: node
   linkType: hard
 
@@ -11197,11 +11160,11 @@ __metadata:
   linkType: hard
 
 "minimatch@npm:^10.2.2":
-  version: 10.2.4
-  resolution: "minimatch@npm:10.2.4"
+  version: 10.2.5
+  resolution: "minimatch@npm:10.2.5"
   dependencies:
-    brace-expansion: "npm:^5.0.2"
-  checksum: 10c0/35f3dfb7b99b51efd46afd378486889f590e7efb10e0f6a10ba6800428cf65c9a8dedb74427d0570b318d749b543dc4e85f06d46d2858bc8cac7e1eb49a95945
+    brace-expansion: "npm:^5.0.5"
+  checksum: 10c0/6bb058bd6324104b9ec2f763476a35386d05079c1f5fe4fbf1f324a25237cd4534d6813ecd71f48208f4e635c1221899bef94c3c89f7df55698fe373aaae20fd
   languageName: node
   linkType: hard
 
@@ -11536,10 +11499,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.27":
-  version: 2.0.36
-  resolution: "node-releases@npm:2.0.36"
-  checksum: 10c0/85d8d7f4b6248c8372831cbcc3829ce634cb2b01dbd85e55705cefc8a9eda4ce8121bd218b9629cf2579aef8a360541bad409f3925a35675c825b9471a49d7e9
+"node-releases@npm:^2.0.36":
+  version: 2.0.37
+  resolution: "node-releases@npm:2.0.37"
+  checksum: 10c0/306df89190b3225d0cb001260de52f0befd225a782ec85311ce97b0aa3b2e22f5e4e4c00395c6dc9bc9ef440c64723f6205fe1e27d32b8dd1d140891fbadf901
   languageName: node
   linkType: hard
 
@@ -11997,15 +11960,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^1.7.0":
-  version: 1.9.0
-  resolution: "path-to-regexp@npm:1.9.0"
-  dependencies:
-    isarray: "npm:0.0.1"
-  checksum: 10c0/de9ddb01b84d9c2c8e2bed18630d8d039e2d6f60a6538595750fa08c7a6482512257464c8da50616f266ab2cdd2428387e85f3b089e4c3f25d0c537e898a0751
-  languageName: node
-  linkType: hard
-
 "path-to-regexp@npm:~0.1.12":
   version: 0.1.13
   resolution: "path-to-regexp@npm:0.1.13"
@@ -12132,8 +12086,6 @@ __metadata:
     react-redux: "npm:~9.2.0"
     react-rnd: "npm:^10.3.4"
     react-router: "npm:~7.13.1"
-    react-router-dom: "npm:5.3.x"
-    react-router-dom-v5-compat: "npm:^6.11.2"
     react-transition-group: "npm:2.3.x"
     react-virtualized: "npm:9.x"
     resolve-url-loader: "npm:5.0.0"
@@ -12666,7 +12618,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1, react-is@npm:^16.6.0, react-is@npm:^16.7.0":
+"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 10c0/33977da7a5f1a287936a0c85639fec6ca74f4f15ef1e59a6bc20338fc73dc69555381e211f7a3529b8150a1f71e4225525b41b60b52965bda53ce7d47377ada1
@@ -12784,68 +12736,6 @@ __metadata:
     react: ">=16.3.0"
     react-dom: ">=16.3.0"
   checksum: 10c0/9f65397150adc472ee96c0f257fa0f8301afb010d4e6ed97df793347ce7cd7c84bac980b7977cfc70314b9da3bd9a96c1ca5171b3c5e03fe2392832550307cb7
-  languageName: node
-  linkType: hard
-
-"react-router-dom-v5-compat@npm:^6.11.2":
-  version: 6.30.3
-  resolution: "react-router-dom-v5-compat@npm:6.30.3"
-  dependencies:
-    "@remix-run/router": "npm:1.23.2"
-    history: "npm:^5.3.0"
-    react-router: "npm:6.30.3"
-  peerDependencies:
-    react: ">=16.8"
-    react-dom: ">=16.8"
-    react-router-dom: 4 || 5
-  checksum: 10c0/875b6b3659cb4af6efbb01f979f0ed99ec152a15fe76c7bb4fb3ae7273bfc10f44ccc8c16c8ddb55991c534d42834864b6f1703865cf7fb1c057debd946a51a5
-  languageName: node
-  linkType: hard
-
-"react-router-dom@npm:5.3.x":
-  version: 5.3.4
-  resolution: "react-router-dom@npm:5.3.4"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.13"
-    history: "npm:^4.9.0"
-    loose-envify: "npm:^1.3.1"
-    prop-types: "npm:^15.6.2"
-    react-router: "npm:5.3.4"
-    tiny-invariant: "npm:^1.0.2"
-    tiny-warning: "npm:^1.0.0"
-  peerDependencies:
-    react: ">=15"
-  checksum: 10c0/f04f727e2ed2e9d1d3830af02cc61690ff67b1524c0d18690582bfba0f4d14142ccc88fb6da6befad644fddf086f5ae4c2eb7048c67da8a0b0929c19426421b0
-  languageName: node
-  linkType: hard
-
-"react-router@npm:5.3.4":
-  version: 5.3.4
-  resolution: "react-router@npm:5.3.4"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.13"
-    history: "npm:^4.9.0"
-    hoist-non-react-statics: "npm:^3.1.0"
-    loose-envify: "npm:^1.3.1"
-    path-to-regexp: "npm:^1.7.0"
-    prop-types: "npm:^15.6.2"
-    react-is: "npm:^16.6.0"
-    tiny-invariant: "npm:^1.0.2"
-    tiny-warning: "npm:^1.0.0"
-  peerDependencies:
-    react: ">=15"
-  checksum: 10c0/e15c00dfef199249b4c6e6d98e5e76cc352ce66f3270f13df37cc069ddf7c05e43281e8c308fc407e4435d72924373baef1d2890e0f6b0b1eb423cf47315a053
-  languageName: node
-  linkType: hard
-
-"react-router@npm:6.30.3":
-  version: 6.30.3
-  resolution: "react-router@npm:6.30.3"
-  dependencies:
-    "@remix-run/router": "npm:1.23.2"
-  peerDependencies:
-    react: ">=16.8"
-  checksum: 10c0/a0a74bf5a933cf0abd47e0eac1d3a505cd66b866e3ee8f20d8016885d3b4361ba3ba72dee026248c6125e631b191ba6ad109184c892281cea6cb747c71bf5940
   languageName: node
   linkType: hard
 
@@ -13079,13 +12969,13 @@ __metadata:
   linkType: hard
 
 "regjsparser@npm:^0.13.0":
-  version: 0.13.0
-  resolution: "regjsparser@npm:0.13.0"
+  version: 0.13.1
+  resolution: "regjsparser@npm:0.13.1"
   dependencies:
     jsesc: "npm:~3.1.0"
   bin:
     regjsparser: bin/parser
-  checksum: 10c0/4702f85cda09f67747c1b2fb673a0f0e5d1ba39d55f177632265a0be471ba59e3f320623f411649141f752b126b8126eac3ff4c62d317921e430b0472bfc6071
+  checksum: 10c0/1276c983f00de49e37ef76b181df4390699b46e3666fbe6b8b5512bd75919112574cf023f28ac720d427be158af60dba6a77cce9a8aaff14967263636e667356
   languageName: node
   linkType: hard
 
@@ -13167,13 +13057,6 @@ __metadata:
   dependencies:
     value-or-function: "npm:^4.0.0"
   checksum: 10c0/108f22186cad8748f1f0263944702a9949a12074e49442827845a52048f9156290781ceab8aee3e26ad868347266746704ee59a83a8f2fe2ce35228d054e325e
-  languageName: node
-  linkType: hard
-
-"resolve-pathname@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "resolve-pathname@npm:3.0.0"
-  checksum: 10c0/c6ec49b670dc35b9a303c47fa83ba9348a71e92d64a4c4bb85e1b659a29b407aa1ac1cb14a9b5b502982132ca77482bd80534bca147439d66880d35a137fe723
   languageName: node
   linkType: hard
 
@@ -13417,8 +13300,8 @@ __metadata:
   linkType: hard
 
 "sass@npm:^1.90.0":
-  version: 1.98.0
-  resolution: "sass@npm:1.98.0"
+  version: 1.99.0
+  resolution: "sass@npm:1.99.0"
   dependencies:
     "@parcel/watcher": "npm:^2.4.1"
     chokidar: "npm:^4.0.0"
@@ -13429,7 +13312,7 @@ __metadata:
       optional: true
   bin:
     sass: sass.js
-  checksum: 10c0/9e91daa20f970fefb364ac31289f070636da7aa7eaeb43e371ea98fa98085a6dbc2d3d058504226a02d07717faf0a4ce8d41b579ecb428c4a9d96b4dc1944a95
+  checksum: 10c0/83c54a8c6decb79fff50dd9500d7932cf1cb7c5d9be4bc42bd3d537402c37bbee062aea6efdbdf9fb0b8697b18177d60c72bf101872336b93b1c27a2dc3621e1
   languageName: node
   linkType: hard
 
@@ -13520,7 +13403,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.2, semver@npm:^7.7.3":
+"semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.7.4":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:
@@ -14502,14 +14385,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.0.2":
-  version: 1.3.3
-  resolution: "tiny-invariant@npm:1.3.3"
-  checksum: 10c0/65af4a07324b591a059b35269cd696aba21bef2107f29b9f5894d83cc143159a204b299553435b03874ebb5b94d019afa8b8eff241c8a4cfee95872c2e1c1c4a
-  languageName: node
-  linkType: hard
-
-"tiny-warning@npm:^1.0.0, tiny-warning@npm:^1.0.2":
+"tiny-warning@npm:^1.0.2":
   version: 1.0.3
   resolution: "tiny-warning@npm:1.0.3"
   checksum: 10c0/ef8531f581b30342f29670cb41ca248001c6fd7975ce22122bd59b8d62b4fc84ad4207ee7faa95cde982fa3357cd8f4be650142abc22805538c3b1392d7084fa
@@ -14650,16 +14526,16 @@ __metadata:
   linkType: hard
 
 "ts-jest@npm:^29.3.1":
-  version: 29.4.6
-  resolution: "ts-jest@npm:29.4.6"
+  version: 29.4.9
+  resolution: "ts-jest@npm:29.4.9"
   dependencies:
     bs-logger: "npm:^0.2.6"
     fast-json-stable-stringify: "npm:^2.1.0"
-    handlebars: "npm:^4.7.8"
+    handlebars: "npm:^4.7.9"
     json5: "npm:^2.2.3"
     lodash.memoize: "npm:^4.1.2"
     make-error: "npm:^1.3.6"
-    semver: "npm:^7.7.3"
+    semver: "npm:^7.7.4"
     type-fest: "npm:^4.41.0"
     yargs-parser: "npm:^21.1.1"
   peerDependencies:
@@ -14669,7 +14545,7 @@ __metadata:
     babel-jest: ^29.0.0 || ^30.0.0
     jest: ^29.0.0 || ^30.0.0
     jest-util: ^29.0.0 || ^30.0.0
-    typescript: ">=4.3 <6"
+    typescript: ">=4.3 <7"
   peerDependenciesMeta:
     "@babel/core":
       optional: true
@@ -14685,13 +14561,13 @@ __metadata:
       optional: true
   bin:
     ts-jest: cli.js
-  checksum: 10c0/013dda99ac938cd4b94bae9323ed1b633cd295976c256d596d01776866188078fe7b82b8b3ebd05deb401b27b5618d9d76208eded2568661240ecf9694a5c933
+  checksum: 10c0/901eb382817d1f48fc56b6c9b82de989f176660295695ae1fcd55f06f71d2c107766e1413ab24a59fa964c2ef79a60dd23ac1f382b05ae04f2b454fb4eb5ad4f
   languageName: node
   linkType: hard
 
 "ts-loader@npm:^9.3.1":
-  version: 9.5.4
-  resolution: "ts-loader@npm:9.5.4"
+  version: 9.5.7
+  resolution: "ts-loader@npm:9.5.7"
   dependencies:
     chalk: "npm:^4.1.0"
     enhanced-resolve: "npm:^5.0.0"
@@ -14701,7 +14577,7 @@ __metadata:
   peerDependencies:
     typescript: "*"
     webpack: ^5.0.0
-  checksum: 10c0/f0982404b43628c335d3b3a60ac3f1738385da7b97c3f04cb5ad2ebad791597be39b25c8a4e158a66173f9bd9f5aa72e285b046b0573e4beed8ecd032d418e4d
+  checksum: 10c0/e68d997962046afc40fbb6131a5f329128691917bf288d18df4f95719ca1557e72f614bf078e06544ab0c970f734495a356f3eeb5f11ca18459944237b3635a1
   languageName: node
   linkType: hard
 
@@ -14994,9 +14870,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^7.19.0":
-  version: 7.24.6
-  resolution: "undici@npm:7.24.6"
-  checksum: 10c0/0f5413ccb20bafe27637a3a02cada731c53ee75f1df79029099db3af1eaaed410488489d9f430c09bd30bf0b925cb75fc30c39dff0689f656fd6fb7d75ded95f
+  version: 7.24.7
+  resolution: "undici@npm:7.24.7"
+  checksum: 10c0/779c67e81677324763ea00ea547ba74757472ebe2625d046d592434ee19d9d148fe0eaef7006c0185096614249ac0f179e7f559b202b518af8d587e9548559b6
   languageName: node
   linkType: hard
 
@@ -15136,7 +15012,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.2.0":
+"update-browserslist-db@npm:^1.2.3":
   version: 1.2.3
   resolution: "update-browserslist-db@npm:1.2.3"
   dependencies:
@@ -15226,13 +15102,6 @@ __metadata:
     spdx-correct: "npm:^3.0.0"
     spdx-expression-parse: "npm:^3.0.0"
   checksum: 10c0/7b91e455a8de9a0beaa9fe961e536b677da7f48c9a493edf4d4d4a87fd80a7a10267d438723364e432c2fcd00b5650b5378275cded362383ef570276e6312f4f
-  languageName: node
-  linkType: hard
-
-"value-equal@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "value-equal@npm:1.0.1"
-  checksum: 10c0/79068098355483ef29f4d3753999ad880875b87625d7e9055cad9346ea4b7662aad3a66f87976801b0dd7a6f828ba973d28b1669ebcd37eaf88cc5f687c1a691
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Replaced `react-router 5.3.x`, `react-router-dom 5.3.x`, and `react-router-dom-v5-compat ^6.11.2` with `react-router ~7.13.1` to match the console's version.
- Updated `@openshift-console/dynamic-plugin-sdk{,-internal,-webpack}` from `4.22.0-prerelease.1` to `4.22.0-prerelease.2` (required — the older SDK validates shared modules against v5 and rejects v7).
- Updated `react-i18next` (`~15.1.4` → `~16.5.8`), `react-redux` (`8.1.3` → `~9.2.0`), and `@types/react-redux` (`6.0.2` → `^7.1.34`) to satisfy the new SDK's peer dependencies.
- Migrated all ~67 source files from `react-router-dom-v5-compat` / `react-router-dom` imports to `react-router`.
- Removed the `history` package dependency from `router.ts` utilities, replacing it with native `window.history` APIs.

## Why add `__mocks__/textEncoderDecoder.ts` setup file 

React Router v7 internally uses `TextEncoder` / `TextDecoder` (for cookie and URL handling). The jsdom test environment doesn't provide these globals, so importing `react-router` in any test causes `ReferenceError: TextEncoder is not defined`. The fix adds a `__mocks__/textEncoderDecoder.ts` setup file — matching the exact same approach used by the console project — that polyfills these globals from Node's `util` module before tests run. It also adds `react-router`, `cookie`, and `set-cookie-parser` to `transformIgnorePatterns` exceptions so `babel-jest` can transform their ESM source.

## Why the change in `src/components/utils/router.ts`

The old version of this file imported `createBrowserHistory`, `createMemoryHistory`, and the `History` type from the history npm package (v4). That package was a standalone dependency of `react-router v5` — it provided the browser history abstraction that react-router v5 was built on.
With `react-router v7`, the history package no longer exists as a separate dependency. Its functionality was absorbed into react-router's internals.

**What the old code did:**
Created a History instance via createBrowserHistory() (or createMemoryHistory() in tests), configured with the console's base path.

- Monkey-patched history.push and history.replace to strip the base path from URLs before navigating.
- Used history.replace() inside all the query parameter helpers (setQueryArgument, removeQueryArgument, etc.) to update the URL without a full page reload.

**What the new code does:**
It replaces the history package with the native browser window.history API:

- history.push → window.history.pushState()
- history.replace → window.history.replaceState()
- history.back → window.history.back()

The base-path stripping monkey-patch was also removed. It's no longer needed because callers of history.push (like `handlePipelineRunSubmit` in pipelines-actions.tsx) pass fully-qualified paths from `resourcePathFromModel`(), and the query parameter helpers only modify the query string of the current URL (they read window.location.href directly), so base path handling is irrelevant to them.

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` passes (47/47 suites, 1 skipped — unchanged from before)

## Screen Recording for verification in OCP 4.22 

https://github.com/user-attachments/assets/4e47f90e-92b5-49df-a4a9-9403c1caefde

https://github.com/user-attachments/assets/2d03eab5-a19c-4af6-b96d-b0275b9e2218

https://github.com/user-attachments/assets/8678c3d8-44cc-4980-a02a-9631c735654a


