### PR TITLE
SRVKP-10037: Fixed task node status in pipeline run topology which was not updating in real time

### DIFF
--- a/src/components/hooks/useTektonResults.ts
+++ b/src/components/hooks/useTektonResults.ts
@@ -15,9 +15,6 @@ export const useTRRuns = <Kind extends K8sResourceCommon>(
   isTektonResultEnabled?: boolean,
   skipFetch?: boolean,
 ): [Kind[], boolean, Error | undefined] => {
-  if (!isTektonResultEnabled) {
-    return [[] as Kind[], true, undefined];
-  }
   const isDevConsoleProxyAvailable = useFlag(FLAGS.DEVCONSOLE_PROXY);
   const fetchedRef = useRef(false);
   const [results, setResults] = useState<[Kind[], boolean, Error | undefined]>([
@@ -52,7 +49,7 @@ export const useTRRuns = <Kind extends K8sResourceCommon>(
         }
       }
     };
-    !skipFetch && fetchResults();
+    !skipFetch && isTektonResultEnabled && fetchResults();
     return () => {
       fetchedRef.current = false;
     };
@@ -62,7 +59,10 @@ export const useTRRuns = <Kind extends K8sResourceCommon>(
     isDevConsoleProxyAvailable,
     stableOptions,
     skipFetch,
+    isTektonResultEnabled,
   ]);
-
+  if (!isTektonResultEnabled) {
+    return [[], true, undefined];
+  }
   return results;
 };

--- a/src/components/pipeline-topology/PipelineTaskNode.tsx
+++ b/src/components/pipeline-topology/PipelineTaskNode.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react';
-import { useRef, useMemo, memo } from 'react';
+import { useRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tooltip } from '@patternfly/react-core';
 import {
@@ -15,9 +15,9 @@ import {
   WhenDecorator,
   WithContextMenuProps,
   WithSelectionProps,
+  observer,
 } from '@patternfly/react-topology';
 import classNames from 'classnames';
-import { observer } from 'mobx-react';
 import { Link } from 'react-router';
 import { NodeType } from './const';
 import { PipelineRunModel, TaskModel } from '../../models';
@@ -223,4 +223,4 @@ const PipelineTaskNode: FunctionComponent<PipelineTaskNodeProps> = ({
   );
 };
 
-export default memo(observer(PipelineTaskNode));
+export default observer(PipelineTaskNode);

--- a/src/components/utils/__tests__/pipeline-utils.spec.ts
+++ b/src/components/utils/__tests__/pipeline-utils.spec.ts
@@ -320,7 +320,7 @@ describe('pipeline-utils ', () => {
     const testTaskRuns = Object.keys(
       pipelineRunWithoutStatus.status.taskRuns,
     ).map((trName) => ({
-      apiVersion: 'v1alpha1',
+      apiVersion: 'v1',
       kind: 'TaskRun',
       metadata: {
         labels: {
@@ -332,15 +332,12 @@ describe('pipeline-utils ', () => {
       spec: {},
       pipelineTaskName:
         pipelineRunWithoutStatus.status.taskRuns[trName].pipelineTaskName,
-      status: pipelineRunWithoutStatus.status.taskRuns[trName].status,
+      status: _.omit(pipelineRunWithoutStatus.status.taskRuns[trName].status, [
+        'conditions',
+        'startTime',
+        'completionTime',
+      ]),
     }));
-    _.forIn(pipelineRunWithoutStatus.status.taskRuns, (taskRun, name) => {
-      pipelineRunWithoutStatus.status.taskRuns[name] = _.omit(taskRun, [
-        'status.conditions',
-        'status.startTime',
-        'status.completionTime',
-      ]);
-    });
     const taskList = appendPipelineRunStatus(
       pipeline,
       pipelineRunWithoutStatus,

--- a/src/components/utils/pipeline-utils.ts
+++ b/src/components/utils/pipeline-utils.ts
@@ -150,14 +150,17 @@ export const appendPipelineRunStatus = (
       if (
         pipelineRun.spec.status === SucceedConditionReason.PipelineRunCancelled
       ) {
-        return _.merge(task, { status: { reason: ComputedStatus.Cancelled } });
+        return { ...task, status: { reason: ComputedStatus.Cancelled } };
       }
       if (
         pipelineRun.spec.status === SucceedConditionReason.PipelineRunPending
       ) {
-        return _.merge(task, { status: { reason: ComputedStatus.Idle } });
+        return { ...task, status: { reason: ComputedStatus.Idle } };
       }
-      return _.merge(task, { status: { reason: ComputedStatus.Failed } });
+      if (pipelineRunStatus(pipelineRun) === ComputedStatus.Failed) {
+        return { ...task, status: { reason: ComputedStatus.Failed } };
+      }
+      return { ...task, status: { reason: ComputedStatus.Pending } };
     }
 
     const taskRun = _.find(
@@ -167,16 +170,10 @@ export const appendPipelineRunStatus = (
     );
     const taskStatus: TaskRunStatus = taskRun?.status;
 
-    const mTask = _.merge(task, {
-      status: pipelineRun?.status?.taskRuns
-        ? _.get(
-            _.find(pipelineRun.status.taskRuns, {
-              pipelineTaskName: task.name,
-            }),
-            'status',
-          )
-        : taskStatus,
-    });
+    const mTask = {
+      ...task,
+      status: taskStatus ? { ...taskStatus } : undefined,
+    };
     // append task duration
     if (mTask.status && mTask.status.completionTime && mTask.status.startTime) {
       const date =
@@ -187,9 +184,9 @@ export const appendPipelineRunStatus = (
     // append task status
     if (!mTask.status) {
       mTask.status = { reason: ComputedStatus.Pending };
-    } else if (mTask.status && mTask.status.conditions) {
+    } else if (mTask.status.conditions) {
       mTask.status.reason = pipelineRunStatus(mTask) || ComputedStatus.Pending;
-    } else if (mTask.status && !mTask.status.reason) {
+    } else if (!mTask.status.reason) {
       mTask.status.reason = ComputedStatus.Pending;
     }
     return mTask;


### PR DESCRIPTION
## Summary

Pipeline topology task nodes were not reflecting live TaskRun status updates — statuses only appeared after hovering on a node or switching tabs. This was caused by a dual MobX instance problem: `PipelineTaskNode` imported `observer` from the plugin-bundled `mobx-react`, while `@patternfly/react-topology` (a shared module loaded from the host console) uses its own MobX instance. The mismatched instances meant observable changes on topology elements were invisible to the plugin's `observer`. 
Additionally, the task status derivation logic in `appendPipelineRunStatus` had issues with mutation, a deprecated Tekton v0 field lookup, and incorrect failure defaults. The `useTRRuns` hook also violated React's rules of hooks with a conditional early return before hook calls.

## Changes

- **`PipelineTaskNode.tsx`**: Import `observer` from `@patternfly/react-topology` instead of `mobx-react` to use the host console's MobX instance, ensuring topology observable changes trigger re-renders. This essentially fixed the main issue we were encountering. Removed redundant `memo` wrapper.

- **`pipeline-utils.ts` (`appendPipelineRunStatus`)**: Replaced `_.merge` with immutable object spreads to prevent stale status persisting via direct mutation of `pipeline.spec.tasks`. 

Removed deprecated `pipelineRun.status.taskRuns` lookup (not present in Tekton v1 — status is now sourced from individual `TaskRun` objects resolved via `childReferences`). 

Fixed fallback logic so tasks default to `Pending` instead of `Failed` when TaskRuns haven't been fetched yet; tasks are only marked `Failed` when the PipelineRun itself has failed.

- **`useTektonResults.ts` (`useTRRuns`)**: Moved the `!isTektonResultEnabled` early return below all hook calls to comply with React's rules of hooks. The guard is now applied inside the `useEffect` condition instead.


## Screen Recording Before

https://github.com/user-attachments/assets/29e3ef89-9582-4d50-9f34-f80367bce2b3

## Screen Recording After

https://github.com/user-attachments/assets/388a4ce5-2de2-411f-acde-a8cb44b69478

