### PR TITLE
SRVKP-11533: included missing z-index for TaskSideBar

### DIFF
--- a/src/components/pipeline-builder/task-sidebar/TaskSidebar.scss
+++ b/src/components/pipeline-builder/task-sidebar/TaskSidebar.scss
@@ -8,6 +8,7 @@ $overview-sidebar-width: 550px;
   right: 0;
   height: 100%;
   box-shadow: var(--pf-v5-global--BoxShadow--md);
+  z-index: var(--pf-t--global--z-index--xs);
 
   &__header {
     // Hack for Popper to go under the header


### PR DESCRIPTION
### **Summary**
Fixes a CSS regression in the Pipeline Builder's TaskSidebar that was introduced as a side effect of the static plugin deprecation. The z-index property for the .opp-task-sidebar element was present in the static plugin's stylesheet but was not carried over to the dynamic plugin's SCSS, causing the sidebar to render behind other page elements.

### **Changes**

- Adds a missing z-index CSS property to the .opp-task-sidebar element in the Pipeline Builder's TaskSidebar component.
- Without this, the sidebar panel could render behind other absolutely/relatively positioned elements on the page, causing it to be visually obscured or unclickable.


Screen Recording - Before

https://github.com/user-attachments/assets/12648ef7-a731-4b57-9ae1-fde79d1d6ca6

Screen Recording - After Fix

https://github.com/user-attachments/assets/87933968-2a78-4090-a843-f250de11673f