### PR TITLE
SRVKP-11394: conditionally navigate to details page on PLR re-run action

### DIFF
--- a/src/components/pipelineRuns-details/PipelineRunDetails.tsx
+++ b/src/components/pipelineRuns-details/PipelineRunDetails.tsx
@@ -6,6 +6,7 @@ import { PipelineRunModel } from '../../models';
 import PipelineRunVisualization from './PipelineRunVisualization';
 import PipelineRunCustomDetails from './PipelineRunCustomDetails';
 import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
+import { Loading } from '../Loading';
 
 type PipelineRunDetailsProps = {
   obj: PipelineRunKind;
@@ -15,8 +16,12 @@ const PipelineRunDetails: FC<PipelineRunDetailsProps> = ({
   obj: pipelineRun,
 }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
+  if (!pipelineRun) {
+    return <Loading />;
+  }
+
   return (
-    <PageSection hasBodyWrapper={false} isFilled >
+    <PageSection hasBodyWrapper={false} isFilled>
       <Title headingLevel="h2">{t('PipelineRun details')}</Title>
       <PipelineRunVisualization pipelineRun={pipelineRun} />
       <Grid hasGutter>

--- a/src/utils/pipelineRun-actions-provider.tsx
+++ b/src/utils/pipelineRun-actions-provider.tsx
@@ -7,7 +7,7 @@ import {
   useDeleteModal,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { PipelineRunModel } from '../models';
 import { PipelineRunKind } from '../types';
 import { returnValidPipelineRunModel } from '../components/utils/pipeline-utils';
@@ -29,6 +29,7 @@ import { useGetActiveUser } from '../components/hooks/hooks';
 export const usePipelineRunActionsProvider = (resource: PipelineRunKind) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
   const navigate = useNavigate();
+  const location = useLocation();
   const currentUser = useGetActiveUser();
   const launchErrorModal = useErrorModal();
 
@@ -97,18 +98,21 @@ export const usePipelineRunActionsProvider = (resource: PipelineRunKind) => {
         disabledTooltip: t('Insufficient permissions to create PipelineRun'),
         cta: () => {
           if (namespace && hasPipelineRef) {
+            const isPipelineRunDetailsPage = location.pathname.includes(name);
             k8sCreate({
               model: returnValidPipelineRunModel(resource),
               data: getPipelineRunData(null, currentUser, resource),
             })
               .then((plr) => {
-                navigate(
-                  resourcePathFromModel(
-                    PipelineRunModel,
-                    plr.metadata.name,
-                    plr.metadata.namespace,
-                  ),
-                );
+                if (isPipelineRunDetailsPage) {
+                  navigate(
+                    resourcePathFromModel(
+                      PipelineRunModel,
+                      plr.metadata.name,
+                      plr.metadata.namespace,
+                    ),
+                  );
+                }
               })
               .catch((err) => {
                 launchErrorModal({ error: err.message });
@@ -200,6 +204,7 @@ export const usePipelineRunActionsProvider = (resource: PipelineRunKind) => {
     namespace,
     resource,
     currentUser,
+    location,
     hasPipelineRef,
     hidePLRStop,
     hidePLRCancel,


### PR DESCRIPTION
### **Summary**

- When a user triggers the "Rerun" action on a PipelineRun, the app now only navigates to the new PipelineRun's details page if the user is already on a PipelineRun details page. Previously, the re-run action always navigated to the new run's details page regardless of the current context (from the list page), which was disruptive.
- Added a loading state to PipelineRunDetails to gracefully handle the brief moment when the pipelineRun object is not yet available (e.g., after navigation to a newly created run).

### **Changes**

1. `pipelineRun-actions-provider.tsx `
     Uses useLocation to detect if the user is on a PipelineRun details page; conditionally navigates to the new run's details only when re-running from the details view
     
2. `PipelineRunDetails.tsx` - Returns a Loading spinner when pipelineRun is not yet available, preventing render errors during navigation


### **Screen Recording Before**

https://github.com/user-attachments/assets/14a2517b-a9f8-414b-95c7-59018c26b05b


### **Screen Recording After**

https://github.com/user-attachments/assets/6cf4750e-b5d7-4a2c-8a9b-f18fce0bf4a1
