### PR TITLE
SRVKP-9712: migrate EventListeners and TriggerTemplates tabs to ConsoleDataView

### DIFF
--- a/src/components/list-pages/DefaultListPageRow.tsx
+++ b/src/components/list-pages/DefaultListPageRow.tsx
@@ -1,0 +1,120 @@
+import type { FC, Ref } from 'react';
+import { useState } from 'react';
+import {
+  getGroupVersionKindForModel,
+  K8sResourceCommon,
+  ResourceLink,
+  Timestamp,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { KEBAB_BUTTON_ID } from '../../consts';
+import {
+  Dropdown,
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
+import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
+import { K8sCommonKebabMenu } from '../utils/k8s-common-kebab-menu';
+import { getResourceModelFromBindingKind } from '../utils/pipeline-augment';
+import { GetDataViewRows } from '@openshift-console/dynamic-plugin-sdk/lib/api/internal-types';
+import { defaultTableColumnInfo as tableColumnInfo } from './useDefaultColumns';
+import { NamespaceModel } from '../../models';
+import { t } from '../utils/common-utils';
+import {
+  actionsCellProps,
+  getNameCellProps,
+} from '@openshift-console/dynamic-plugin-sdk-internal';
+
+type DefaultKebabProps = {
+  obj: K8sResourceCommon;
+};
+
+const DefaultKebab: FC<DefaultKebabProps> = ({ obj }) => {
+  const model = getResourceModelFromBindingKind(obj?.kind);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const onSelect = () => {
+    setIsOpen(false);
+  };
+
+  const dropdownItems = K8sCommonKebabMenu(obj, model);
+
+  return (
+    <Dropdown
+      onSelect={onSelect}
+      onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
+      toggle={(toggleRef: Ref<MenuToggleElement>) => (
+        <MenuToggle
+          ref={toggleRef}
+          aria-label="kebab menu"
+          variant="plain"
+          onClick={onToggle}
+          isExpanded={isOpen}
+          id={KEBAB_BUTTON_ID}
+          data-test={KEBAB_BUTTON_ID}
+        >
+          <EllipsisVIcon />
+        </MenuToggle>
+      )}
+      isOpen={isOpen}
+      isPlain={false}
+      popperProps={{ position: 'right' }}
+    >
+      <DropdownList>{dropdownItems}</DropdownList>
+    </Dropdown>
+  );
+};
+
+export const getDefaultListPageDataViewRows: GetDataViewRows<
+  K8sResourceCommon
+> = (data, columns) => {
+  return data.map(({ obj }) => {
+    const model = getResourceModelFromBindingKind(obj?.kind);
+    const rowCells = {
+      [tableColumnInfo[0].id]: {
+        cell: (
+          <ResourceLink
+            groupVersionKind={getGroupVersionKindForModel(model)}
+            name={obj.metadata.name}
+            namespace={obj.metadata.namespace}
+          />
+        ),
+        props: {
+          ...getNameCellProps(`${obj?.kind}-list`),
+          modifier: 'nowrap',
+        },
+      },
+      [tableColumnInfo[1].id]: {
+        cell: obj?.metadata?.namespace ? (
+          <ResourceLink
+            groupVersionKind={getGroupVersionKindForModel(NamespaceModel)}
+            name={obj.metadata.namespace}
+          />
+        ) : (
+          t('None')
+        ),
+      },
+      [tableColumnInfo[2].id]: {
+        cell: <Timestamp timestamp={obj.metadata.creationTimestamp} />,
+      },
+      [tableColumnInfo[3].id]: {
+        cell: <DefaultKebab obj={obj} />,
+        props: { ...actionsCellProps },
+      },
+    };
+
+    return columns.map(({ id }) => {
+      const cell = rowCells[id]?.cell;
+      const props = rowCells[id]?.props;
+      return {
+        id,
+        props,
+        cell,
+      };
+    });
+  });
+};

--- a/src/components/list-pages/useDefaultColumns.tsx
+++ b/src/components/list-pages/useDefaultColumns.tsx
@@ -1,35 +1,40 @@
 import { useTranslation } from 'react-i18next';
-import { sortable } from '@patternfly/react-table';
 import {
   K8sResourceCommon,
   TableColumn,
 } from '@openshift-console/dynamic-plugin-sdk';
+
+export const defaultTableColumnInfo = [
+  { id: 'name' },
+  { id: 'namespace' },
+  { id: 'created' },
+  { id: 'action' },
+];
 
 export const useDefaultColumns = () => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
 
   const columns: TableColumn<K8sResourceCommon>[] = [
     {
-      id: 'name',
+      id: defaultTableColumnInfo[0].id,
       sort: 'metadata.name',
       title: t('Name'),
-      transforms: [sortable],
+      props: { width: 30, isStickyColumn: true },
     },
     {
-      id: 'namespace',
+      id: defaultTableColumnInfo[1].id,
       sort: 'metadata.namespace',
       title: t('Namespace'),
-      transforms: [sortable],
+      props: { width: 30 },
     },
     {
-      id: 'created',
+      id: defaultTableColumnInfo[2].id,
       sort: 'metadata.creationTimestamp',
       title: t('Created'),
-      transforms: [sortable],
+      props: { width: 30 },
     },
     {
-      id: '',
-      props: { className: 'dropdown-kebab-pf pf-v6-c-table__action' },
+      id: defaultTableColumnInfo[3].id,
       title: '',
     },
   ];

--- a/src/components/pipelineRuns-list/PipelineRunsRow.tsx
+++ b/src/components/pipelineRuns-list/PipelineRunsRow.tsx
@@ -185,7 +185,7 @@ export const getPipelineRunsListDataViewRows: GetDataViewRows<
 
     return columns.map(({ id }) => {
       const cell = rowCells[id]?.cell;
-      const props = rowCells[id]?.props || undefined;
+      const props = rowCells[id]?.props;
       return {
         id,
         props,

--- a/src/components/pipelines-list/PipelineRow.tsx
+++ b/src/components/pipelines-list/PipelineRow.tsx
@@ -102,7 +102,7 @@ export const getPipelineListDataViewRows: GetDataViewRows<
 
     return columns.map(({ id }) => {
       const cell = rowCells[id]?.cell;
-      const props = rowCells[id]?.props || undefined;
+      const props = rowCells[id]?.props;
       return {
         id,
         props,

--- a/src/components/triggers-list/ClusterTriggerBindingsList.tsx
+++ b/src/components/triggers-list/ClusterTriggerBindingsList.tsx
@@ -8,7 +8,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDefaultColumns } from '../list-pages/default-resources';
+import { useDefaultColumns } from '../list-pages/useDefaultColumns';
 import { ClusterTriggerBindingModel } from '../../models';
 import EventListenersRow from './EventListenersRow';
 import { ListPageFilter } from '../list-pages/ListPageFilter';

--- a/src/components/triggers-list/EventListenersList.tsx
+++ b/src/components/triggers-list/EventListenersList.tsx
@@ -1,18 +1,18 @@
 import {
   getGroupVersionKindForModel,
-  K8sResourceCommon,
   ListPageBody,
   useK8sWatchResource,
-  useListPageFilter,
-  VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
-import { useDefaultColumns } from '../list-pages/default-resources';
+import { useDefaultColumns } from '../list-pages/useDefaultColumns';
 import { EventListenerModel } from '../../models';
-import EventListenersRow from './EventListenersRow';
-import { ListPageFilter } from '../list-pages/ListPageFilter';
+import { DataViewFilterToolbar } from '../common/DataViewFilterToolbar';
+import { ConsoleDataView } from '@openshift-console/dynamic-plugin-sdk-internal';
+import { useDataViewFilter } from '../hooks/useDataViewFilter';
+import { getDefaultListPageDataViewRows } from '../list-pages/DefaultListPageRow';
+import { EventListenerKind } from '../../types';
 
 type EventListenersListProps = {
   namespace?: string;
@@ -28,34 +28,34 @@ const EventListenersList: FC<EventListenersListProps> = ({
   namespace = namespace || ns;
   const columns = useDefaultColumns();
   const [eventListeners, eventListenersLoaded, eventListenersLoadError] =
-    useK8sWatchResource<K8sResourceCommon[]>({
+    useK8sWatchResource<EventListenerKind[]>({
       groupVersionKind: getGroupVersionKindForModel(EventListenerModel),
       isList: true,
       namespace,
     });
-  const [staticData, filteredData, onFilterChange] =
-    useListPageFilter(eventListeners);
+  const { filterValues, onFilterChange, onClearAll, filteredData } =
+    useDataViewFilter<EventListenerKind>({
+      data: eventListeners || [],
+    });
   return (
     <ListPageBody>
-      <ListPageFilter
-        data={staticData}
-        onFilterChange={onFilterChange}
-        loaded={eventListenersLoaded}
-        hideColumnManagement
-        hideNameLabelFilters={hideNameLabelFilters}
-      />
-      <VirtualizedTable
+      {!hideNameLabelFilters && (
+        <DataViewFilterToolbar
+          filterValues={filterValues}
+          onFilterChange={onFilterChange}
+          onClearAll={onClearAll}
+        />
+      )}
+      <ConsoleDataView<EventListenerKind>
+        label={t('EventListeners')}
         columns={columns}
         data={filteredData}
         loaded={eventListenersLoaded}
         loadError={eventListenersLoadError}
-        Row={EventListenersRow}
-        unfilteredData={staticData}
-        EmptyMsg={() => (
-          <div className="cp-text-align-center" id="no-resource-msg">
-            {t('Not found')}
-          </div>
-        )}
+        getDataViewRows={getDefaultListPageDataViewRows}
+        hideColumnManagement
+        hideNameLabelFilters
+        showNamespaceOverride
       />
     </ListPageBody>
   );

--- a/src/components/triggers-list/EventListenersRow.tsx
+++ b/src/components/triggers-list/EventListenersRow.tsx
@@ -41,7 +41,7 @@ const EventListenersKebab: FC<EventListenersKebabProps> = ({ obj }) => {
   const dropdownItems = K8sCommonKebabMenu(obj, model);
 
   return (
-    (<Dropdown
+    <Dropdown
       onSelect={onSelect}
       onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
       toggle={(toggleRef: Ref<MenuToggleElement>) => (
@@ -62,7 +62,7 @@ const EventListenersKebab: FC<EventListenersKebabProps> = ({ obj }) => {
       popperProps={{ position: 'right' }}
     >
       <DropdownList>{dropdownItems}</DropdownList>
-    </Dropdown>)
+    </Dropdown>
   );
 };
 
@@ -103,3 +103,4 @@ const EventListenersRow: FC<RowProps<K8sResourceCommon>> = ({
 };
 
 export default EventListenersRow;
+//TODO:: Remove this file after completing ConsoleDataView migration

--- a/src/components/triggers-list/TriggerBindingsList.tsx
+++ b/src/components/triggers-list/TriggerBindingsList.tsx
@@ -9,7 +9,7 @@ import {
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
-import { useDefaultColumns } from '../list-pages/default-resources';
+import { useDefaultColumns } from '../list-pages/useDefaultColumns';
 import { TriggerBindingModel } from '../../models';
 import EventListenersRow from './EventListenersRow';
 import { ListPageFilter } from '../list-pages/ListPageFilter';

--- a/src/components/triggers-list/TriggerTemplatesList.tsx
+++ b/src/components/triggers-list/TriggerTemplatesList.tsx
@@ -1,18 +1,18 @@
 import {
   getGroupVersionKindForModel,
-  K8sResourceCommon,
   ListPageBody,
   useK8sWatchResource,
-  useListPageFilter,
-  VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
-import { useDefaultColumns } from '../list-pages/default-resources';
+import { useDefaultColumns } from '../list-pages/useDefaultColumns';
 import { TriggerTemplateModel } from '../../models';
-import EventListenersRow from './EventListenersRow';
-import { ListPageFilter } from '../list-pages/ListPageFilter';
+import { ConsoleDataView } from '@openshift-console/dynamic-plugin-sdk-internal';
+import { TriggerTemplateKind } from 'src/types';
+import { DataViewFilterToolbar } from '../common/DataViewFilterToolbar';
+import { useDataViewFilter } from '../hooks/useDataViewFilter';
+import { getDefaultListPageDataViewRows } from '../list-pages/DefaultListPageRow';
 
 type TriggerTemplatesListProps = {
   namespace?: string;
@@ -28,34 +28,34 @@ const TriggerTemplatesList: FC<TriggerTemplatesListProps> = ({
   namespace = namespace || ns;
   const columns = useDefaultColumns();
   const [triggerTemplates, triggerTemplatesLoaded, triggerTemplatesLoadError] =
-    useK8sWatchResource<K8sResourceCommon[]>({
+    useK8sWatchResource<TriggerTemplateKind[]>({
       groupVersionKind: getGroupVersionKindForModel(TriggerTemplateModel),
       isList: true,
       namespace,
     });
-  const [staticData, filteredData, onFilterChange] =
-    useListPageFilter(triggerTemplates);
+  const { filterValues, onFilterChange, onClearAll, filteredData } =
+    useDataViewFilter<TriggerTemplateKind>({
+      data: triggerTemplates || [],
+    });
   return (
     <ListPageBody>
-      <ListPageFilter
-        data={staticData}
-        onFilterChange={onFilterChange}
-        loaded={triggerTemplatesLoaded}
-        hideColumnManagement
-        hideNameLabelFilters={hideNameLabelFilters}
-      />
-      <VirtualizedTable
+      {!hideNameLabelFilters && (
+        <DataViewFilterToolbar
+          filterValues={filterValues}
+          onFilterChange={onFilterChange}
+          onClearAll={onClearAll}
+        />
+      )}
+      <ConsoleDataView<TriggerTemplateKind>
+        label={t('TriggerTemplate')}
         columns={columns}
         data={filteredData}
         loaded={triggerTemplatesLoaded}
         loadError={triggerTemplatesLoadError}
-        Row={EventListenersRow}
-        unfilteredData={staticData}
-        EmptyMsg={() => (
-          <div className="cp-text-align-center" id="no-resource-msg">
-            {t('Not found')}
-          </div>
-        )}
+        getDataViewRows={getDefaultListPageDataViewRows}
+        hideColumnManagement
+        hideNameLabelFilters
+        showNamespaceOverride
       />
     </ListPageBody>
   );


### PR DESCRIPTION
### **Summary**

- Migrates EventListenersList and TriggerTemplatesList from the legacy VirtualizedTable + ListPageFilter pattern to the new ConsoleDataView + DataViewFilterToolbar pattern.
- Introduces a reusable DefaultListPageRow component with getDefaultListPageDataViewRows that provides a generic row renderer for any K8sResourceCommon resource — eliminating the need for per-resource row components for simple list pages.
- Refactors column definitions from default-resources.tsx into useDefaultColumns.tsx, adding a shared defaultTableColumnInfo array that co-locates column IDs and CSS class names in a single source of truth for both column headers and row cells.
- Updates import paths in ClusterTriggerBindingsList and TriggerBindingsList to point to the renamed column hook (these tabs will be migrated in a follow-up).

### **Changes**

1. `list-pages/DefaultListPageRow.tsx ` - Generic DataViewRows renderer with a DefaultKebab action menu
2. `list-pages/useDefaultColumns.tsx` (replaces default-resources.tsx) - Column hook + shared defaultTableColumnInfo metadata
3. `list-pages/default-resources.tsx` - Superseded by useDefaultColumns.tsx
4. `triggers-list/EventListenersList.tsx` -  Migrated to ConsoleDataView + useDataViewFilter
5. `triggers-list/TriggerTemplatesList.tsx` - Migrated to ConsoleDataView + useDataViewFilter
6. `triggers-list/EventListenersRow.tsx` - marked for removal after migration completes
7. `triggers-list/ClusterTriggerBindingsList.tsx` - Import path update only
8. `triggers-list/TriggerBindingsList.tsx` - Import path update only

### **ScreenRecordings - EventListenersList**

https://github.com/user-attachments/assets/ef0afa93-033c-441c-97cb-62829a1f5aee

### **ScreenRecordings - EventListenersDetailsPage**

https://github.com/user-attachments/assets/ce987f53-a9e5-4141-9a90-2cd6435cdc4e

### **ScreenRecordings - TriggerTemplatesList**

https://github.com/user-attachments/assets/f2661594-ac91-42cb-bc01-6c2efe64d3a3
