### PR TITLE
SRVKP-11399: added consoledataview for pipeline overview page and modified styles for pipeline metrics page

### DIFF
--- a/locales/en/plugin__pipelines-console-plugin.json
+++ b/locales/en/plugin__pipelines-console-plugin.json
@@ -323,7 +323,6 @@
   "No owner": "No owner",
   "No parameters are associated with this Pipeline.": "No parameters are associated with this Pipeline.",
   "No parameters are associated with this PipelineRun.": "No parameters are associated with this PipelineRun.",
-  "No PipelineRuns found": "No PipelineRuns found",
   "No Projects found": "No Projects found",
   "No Properties found": "No Properties found",
   "No requester": "No requester",

--- a/src/components/pipelines-metrics/PipelinesAverageDuration.tsx
+++ b/src/components/pipelines-metrics/PipelinesAverageDuration.tsx
@@ -67,6 +67,14 @@ const getChartData = (
   return chartData;
 };
 
+const BOTTOM_PAD_DEFAULT = 35;
+const BOTTOM_PAD_ROTATED = 55;
+const BOTTOM_PAD_LABEL = 15;
+const CHART_BODY_TOP_OFFSET = 10;
+const CHART_BODY_MIN_HEIGHT = 50;
+const CHART_BODY_MAX_HEIGHT = 100;
+const CHART_ASPECT_RATIO = 5;
+
 const PipelinesAverageDuration: FC<PipelinesAverageDurationProps> = ({
   timespan,
   domain,
@@ -239,14 +247,19 @@ const PipelinesAverageDuration: FC<PipelinesAverageDurationProps> = ({
         verticalAnchor: 'end',
       },
     };
-    bottomPad = 55;
+    bottomPad = BOTTOM_PAD_ROTATED;
   } else {
-    bottomPad = 35;
+    bottomPad = BOTTOM_PAD_DEFAULT;
   }
-  if (showLabel) bottomPad += 15;
-  // Calculating height using this formula with the help of width and bottom padding
-  const chartHeight =
-    10 + Math.max(50, Math.min(100, Math.round(chartWidth / 5))) + bottomPad;
+  if (showLabel) bottomPad += BOTTOM_PAD_LABEL;
+  const chartBodyHeight = Math.max(
+    CHART_BODY_MIN_HEIGHT,
+    Math.min(
+      CHART_BODY_MAX_HEIGHT,
+      Math.round(chartWidth / CHART_ASPECT_RATIO),
+    ),
+  );
+  const chartHeight = CHART_BODY_TOP_OFFSET + chartBodyHeight + bottomPad;
 
   return (
     <>
@@ -275,7 +288,7 @@ const PipelinesAverageDuration: FC<PipelinesAverageDurationProps> = ({
               variant="danger"
               isInline
               title={t('Unable to load average duration')}
-              className="pf-v6-u-mb-md pf-v6-u-ml-lg pf-v6-u-mt-lg"
+              className="pf-v6-u-mb-md pf-v6-u-mt-lg"
             />
           ) : (
             <div

--- a/src/components/pipelines-metrics/PipelinesAverageDurationK8s.tsx
+++ b/src/components/pipelines-metrics/PipelinesAverageDurationK8s.tsx
@@ -78,6 +78,14 @@ const getChartData = (
   return chartData;
 };
 
+const BOTTOM_PAD_DEFAULT = 35;
+const BOTTOM_PAD_ROTATED = 55;
+const BOTTOM_PAD_LABEL = 15;
+const CHART_BODY_TOP_OFFSET = 10;
+const CHART_BODY_MIN_HEIGHT = 50;
+const CHART_BODY_MAX_HEIGHT = 100;
+const CHART_ASPECT_RATIO = 5;
+
 const PipelinesAverageDurationK8s: FC<PipelinesAverageDurationProps> = ({
   timespan,
   domain,
@@ -299,23 +307,29 @@ const PipelinesAverageDurationK8s: FC<PipelinesAverageDurationProps> = ({
         verticalAnchor: 'end',
       },
     };
-    bottomPad = 55;
+    bottomPad = BOTTOM_PAD_ROTATED;
   } else {
-    bottomPad = 35;
+    bottomPad = BOTTOM_PAD_DEFAULT;
   }
-  if (showLabel) bottomPad += 15;
-  // Calculating height using this formula with the help of width and bottom padding
-  const chartHeight =
-    10 + Math.max(50, Math.min(100, Math.round(chartWidth / 5))) + bottomPad;
+  if (showLabel) bottomPad += BOTTOM_PAD_LABEL;
+  const chartBodyHeight = Math.max(
+    CHART_BODY_MIN_HEIGHT,
+    Math.min(
+      CHART_BODY_MAX_HEIGHT,
+      Math.round(chartWidth / CHART_ASPECT_RATIO),
+    ),
+  );
+  const chartHeight = CHART_BODY_TOP_OFFSET + chartBodyHeight + bottomPad;
 
   return (
     <>
       <Card
-        className={classNames({
-          'pf-v6-u-h-100 pipeline-overview__min-width-full pipeline-overview__overflow-hidden pf-v6-u-display-flex pf-v6-u-flex-direction-column':
-            !averageDurationError,
-          'card-border': bordered,
-        })}
+        className={classNames(
+          'pipeline-overview__min-width-full pipeline-overview__overflow-hidden pf-v6-u-display-flex pf-v6-u-flex-direction-column pf-v6-u-h-100',
+          {
+            'card-border': bordered,
+          },
+        )}
       >
         <CardTitle className="pf-v6-u-pb-0">
           <span>{t('Average duration')}</span>
@@ -331,7 +345,7 @@ const PipelinesAverageDurationK8s: FC<PipelinesAverageDurationProps> = ({
               variant="danger"
               isInline
               title={t('Unable to load average duration')}
-              className="pf-v6-u-ml-lg"
+              className="pf-v6-u-mb-md pf-v6-u-mt-lg"
             />
           ) : (
             <div

--- a/src/components/pipelines-metrics/PipelinesMetricsPage.tsx
+++ b/src/components/pipelines-metrics/PipelinesMetricsPage.tsx
@@ -27,9 +27,7 @@ const PipelinesMetricsPage: FC<PipelinesMetricsPageProps> = ({ obj }) => {
     metadata: { namespace, name: parentName },
   } = obj;
   const [timespan, setTimespan] = useState(parsePrometheusDuration('1d'));
-  const [interval, setInterval] = useState(
-    parsePrometheusDuration('30s'),
-  );
+  const [interval, setInterval] = useState(parsePrometheusDuration('30s'));
 
   useQueryParams({
     key: 'refreshinterval',
@@ -62,7 +60,7 @@ const PipelinesMetricsPage: FC<PipelinesMetricsPageProps> = ({ obj }) => {
         </FlexItem>
       </Flex>
 
-      <div className="pf-v6-u-p-md" style={{backgroundColor: 'var(--pf-t--global--background--color--secondary--default)'}}>
+      <div className="pf-v6-u-p-md">
         <PipelineRunsStatusCard
           timespan={timespan}
           domain={{ y: [0, 100] }}
@@ -74,34 +72,49 @@ const PipelinesMetricsPage: FC<PipelinesMetricsPageProps> = ({ obj }) => {
         />
 
         <Grid hasGutter className="pf-v6-u-mt-md">
-          <GridItem span={12} md={6} lg={4} className="pf-v6-u-min-width pf-v6-u-w-100">
-              <PipelinesRunsNumbersChart
-                namespace={namespace}
-                parentName={parentName}
-                timespan={timespan}
-                interval={interval}
-                kind={obj.kind}
-                domain={{ y: [0, 500] }}
-              />
+          <GridItem
+            span={12}
+            md={6}
+            lg={4}
+            className="pf-v6-u-min-width pf-v6-u-w-100"
+          >
+            <PipelinesRunsNumbersChart
+              namespace={namespace}
+              parentName={parentName}
+              timespan={timespan}
+              interval={interval}
+              kind={obj.kind}
+              domain={{ y: [0, 500] }}
+            />
           </GridItem>
-          <GridItem span={12} md={6} lg={4} className="pf-v6-u-min-width pf-v6-u-w-100">
-              <PipelinesAverageDuration
-                timespan={timespan}
-                domain={{ y: [0, 5] }}
-                namespace={namespace}
-                parentName={parentName}
-                interval={interval}
-                kind={obj.kind}
-              />
+          <GridItem
+            span={12}
+            md={6}
+            lg={4}
+            className="pf-v6-u-min-width pf-v6-u-w-100"
+          >
+            <PipelinesAverageDuration
+              timespan={timespan}
+              domain={{ y: [0, 5] }}
+              namespace={namespace}
+              parentName={parentName}
+              interval={interval}
+              kind={obj.kind}
+            />
           </GridItem>
-          <GridItem span={12} md={12} lg={4} className="pf-v6-u-min-width pf-v6-u-w-100">
-              <PipelinesRunsDurationCard
-                namespace={namespace}
-                parentName={parentName}
-                timespan={timespan}
-                interval={interval}
-                kind={obj.kind}
-              />
+          <GridItem
+            span={12}
+            md={12}
+            lg={4}
+            className="pf-v6-u-min-width pf-v6-u-w-100"
+          >
+            <PipelinesRunsDurationCard
+              namespace={namespace}
+              parentName={parentName}
+              timespan={timespan}
+              interval={interval}
+              kind={obj.kind}
+            />
           </GridItem>
         </Grid>
       </div>

--- a/src/components/pipelines-metrics/PipelinesMetricsPageK8s.tsx
+++ b/src/components/pipelines-metrics/PipelinesMetricsPageK8s.tsx
@@ -23,16 +23,12 @@ type PipelinesMetricsPageProps = {
   obj: PipelineKind;
 };
 
-const PipelinesMetricsPageK8s: FC<PipelinesMetricsPageProps> = ({
-  obj,
-}) => {
+const PipelinesMetricsPageK8s: FC<PipelinesMetricsPageProps> = ({ obj }) => {
   const {
     metadata: { namespace, name: parentName },
   } = obj;
   const [timespan, setTimespan] = useState(parsePrometheusDuration('1d'));
-  const [interval, setInterval] = useState(
-    parsePrometheusDuration('30s'),
-  );
+  const [interval, setInterval] = useState(parsePrometheusDuration('30s'));
 
   useQueryParams({
     key: 'refreshinterval',
@@ -68,7 +64,7 @@ const PipelinesMetricsPageK8s: FC<PipelinesMetricsPageProps> = ({
         </FlexItem>
       </Flex>
 
-      <div className="pf-v6-u-p-md" style={{backgroundColor: 'var(--pf-t--global--background--color--secondary--default)'}}>
+      <div className="pf-v6-u-p-md">
         <PipelineRunsStatusCardK8s
           timespan={timespan}
           domain={{ y: [0, 100] }}
@@ -78,8 +74,13 @@ const PipelinesMetricsPageK8s: FC<PipelinesMetricsPageProps> = ({
           interval={interval}
         />
 
-        <Grid hasGutter className='pf-v6-u-mt-md'>
-          <GridItem span={12} md={6} lg={4} className='pf-v6-u-display-flex pf-v6-u-min-width pf-v6-u-w-100'>
+        <Grid hasGutter className="pf-v6-u-mt-md">
+          <GridItem
+            span={12}
+            md={6}
+            lg={4}
+            className="pf-v6-u-display-flex pf-v6-u-min-width pf-v6-u-w-100"
+          >
             <PipelineRunsNumbersChartK8s
               namespace={namespace}
               parentName={parentName}
@@ -88,7 +89,12 @@ const PipelinesMetricsPageK8s: FC<PipelinesMetricsPageProps> = ({
               domain={{ y: [0, 500] }}
             />
           </GridItem>
-          <GridItem span={12} md={6} lg={4} className='pf-v6-u-display-flex pf-v6-u-min-width pf-v6-u-w-100'>
+          <GridItem
+            span={12}
+            md={6}
+            lg={4}
+            className="pf-v6-u-display-flex pf-v6-u-min-width pf-v6-u-w-100"
+          >
             <PipelinesAverageDurationK8s
               timespan={timespan}
               domain={{ y: [0, 5] }}
@@ -97,7 +103,12 @@ const PipelinesMetricsPageK8s: FC<PipelinesMetricsPageProps> = ({
               interval={interval}
             />
           </GridItem>
-          <GridItem span={12} md={12} lg={4} className='pf-v6-u-display-flex pf-v6-u-min-width pf-v6-u-w-100'>
+          <GridItem
+            span={12}
+            md={12}
+            lg={4}
+            className="pf-v6-u-display-flex pf-v6-u-min-width pf-v6-u-w-100"
+          >
             <PipelineRunsDurationCardK8s
               namespace={namespace}
               parentName={parentName}

--- a/src/components/pipelines-overview/PipelineRunsDurationCardK8s.tsx
+++ b/src/components/pipelines-overview/PipelineRunsDurationCardK8s.tsx
@@ -187,17 +187,17 @@ const PipelineRunsDurationCardK8s: FC<PipelinesRunsDurationProps> = ({
     <>
       <Card
         className={classNames(
-          'pf-v6-u-h-100 pipeline-overview__min-width-full pf-v6-u-font-size-lg',
+          'pf-v6-u-h-100 pipeline-overview__min-width-full',
           {
             'card-border': bordered,
           },
         )}
       >
-        <CardTitle className="pf-v6-u-font-size-xl">
+        <CardTitle>
           <span>{t('Duration')}</span>
         </CardTitle>
         <Divider />
-        <CardBody className="pf-v6-u-font-size-lg pipeline-overview__min-width-min-content">
+        <CardBody>
           {pipelineRunsDurationError ? (
             <Alert
               variant="danger"
@@ -207,16 +207,16 @@ const PipelineRunsDurationCardK8s: FC<PipelinesRunsDurationProps> = ({
             />
           ) : (
             <>
-              <Grid hasGutter className="pf-v6-u-mb-sm pf-v6-u-font-size-lg">
+              <Grid hasGutter className="pf-v6-u-mb-sm">
                 <GridItem span={9} className="pf-v6-u-mb-sm">
-                  <span className="pf-v6-u-font-size-lg">
+                  <span>
                     <MonitoringIcon className="pf-v6-u-mr-sm" />
                     {t('Average duration')}
                   </span>
                 </GridItem>
                 <GridItem
                   span={3}
-                  className="pf-v6-u-text-align-end pf-v6-u-font-size-lg pipeline-overview__chart-color-blue"
+                  className="pf-v6-u-text-align-end pipeline-overview__chart-color-blue"
                 >
                   {loadingPipelineRunsCount ? (
                     <Loading isInline={true} />
@@ -225,30 +225,30 @@ const PipelineRunsDurationCardK8s: FC<PipelinesRunsDurationProps> = ({
                   )}
                 </GridItem>
               </Grid>
-              <Grid hasGutter className="pf-v6-u-mb-sm pf-v6-u-font-size-lg">
+              <Grid hasGutter className="pf-v6-u-mb-sm">
                 <GridItem span={9} className="pf-v6-u-mb-sm">
-                  <span className="pf-v6-u-font-size-lg">
+                  <span>
                     <InfoCircleIcon className="pf-v6-u-mr-sm pipeline-overview__chart-color-blue" />
                     {t('Maximum')}
                   </span>
                 </GridItem>
                 <GridItem
                   span={3}
-                  className="pf-v6-u-text-align-end pf-v6-u-font-size-lg pipeline-overview__chart-color-blue"
+                  className="pf-v6-u-text-align-end pipeline-overview__chart-color-blue"
                 >
                   {loadingPipelineRunsCount ? <Loading isInline={true} /> : '-'}
                 </GridItem>
               </Grid>
-              <Grid hasGutter className="pf-v6-u-font-size-lg">
+              <Grid hasGutter>
                 <GridItem span={9}>
-                  <span className="pf-v6-u-font-size-lg">
+                  <span>
                     <HistoryIcon className="pf-v6-u-mr-sm" />
                     {t('Total duration')}
                   </span>
                 </GridItem>
                 <GridItem
                   span={3}
-                  className="pf-v6-u-text-align-end pf-v6-u-font-size-lg pipeline-overview__chart-color-blue"
+                  className="pf-v6-u-text-align-end pipeline-overview__chart-color-blue"
                 >
                   {loadingPipelineRunsDuration ? (
                     <Loading isInline={true} />

--- a/src/components/pipelines-overview/PipelineRunsNumbersChart.tsx
+++ b/src/components/pipelines-overview/PipelineRunsNumbersChart.tsx
@@ -66,6 +66,14 @@ const getChartData = (
   return chartData;
 };
 
+const BOTTOM_PAD_DEFAULT = 35;
+const BOTTOM_PAD_ROTATED = 55;
+const BOTTOM_PAD_LABEL = 15;
+const CHART_BODY_TOP_OFFSET = 10;
+const CHART_BODY_MIN_HEIGHT = 50;
+const CHART_BODY_MAX_HEIGHT = 100;
+const CHART_ASPECT_RATIO = 5;
+
 const PipelinesRunsNumbersChart: FC<PipelinesRunsNumbersChartProps> = ({
   namespace,
   timespan,
@@ -235,92 +243,92 @@ const PipelinesRunsNumbersChart: FC<PipelinesRunsNumbersChartProps> = ({
         verticalAnchor: 'end',
       },
     };
-    bottomPad = 55;
+    bottomPad = BOTTOM_PAD_ROTATED;
   } else {
-    bottomPad = 35;
+    bottomPad = BOTTOM_PAD_DEFAULT;
   }
-  if (showLabel) bottomPad += 15;
-  // Calculating height using this formula with the help of width and bottom padding
-  const chartHeight =
-    10 + Math.max(50, Math.min(100, Math.round(chartWidth / 5))) + bottomPad;
+  if (showLabel) bottomPad += BOTTOM_PAD_LABEL;
+  const chartBodyHeight = Math.max(
+    CHART_BODY_MIN_HEIGHT,
+    Math.min(
+      CHART_BODY_MAX_HEIGHT,
+      Math.round(chartWidth / CHART_ASPECT_RATIO),
+    ),
+  );
+  const chartHeight = CHART_BODY_TOP_OFFSET + chartBodyHeight + bottomPad;
 
   return (
-    <>
-      <Card
-        className={classNames(
-          'pipeline-overview__min-width-full pipeline-overview__overflow-hidden pf-v6-u-display-flex pf-v6-u-flex-direction-column',
-          {
-            'pipeline-overview__number-of-plr-card': !pipelineRunsChartError,
-            'card-border': bordered,
-            'pf-v6-u-h-100': !pipelineRunsChartError,
-          },
-        )}
+    <Card
+      className={classNames(
+        'pipeline-overview__min-width-full pipeline-overview__overflow-hidden pf-v6-u-display-flex pf-v6-u-flex-direction-column pf-v6-u-h-100',
+        {
+          'pipeline-overview__number-of-plr-card': !pipelineRunsChartError,
+          'card-border': bordered,
+        },
+      )}
+    >
+      <CardTitle className="pf-v6-u-pb-0">
+        <span>{t('Number of PipelineRuns')}</span>
+      </CardTitle>
+      <CardBody
+        className={classNames({
+          'pf-v6-u-flex-1 pipeline-overview__min-height-0 pf-v6-u-display-flex pf-v6-u-flex-direction-column pf-v6-u-justify-content-flex-end pf-v6-u-align-items-flex-start pf-v6-u-p-0':
+            !pipelineRunsChartError,
+        })}
       >
-        <CardTitle className="pf-v6-u-pb-0">
-          <span>{t('Number of PipelineRuns')}</span>
-        </CardTitle>
-        <CardBody
-          className={classNames({
-            'pf-v6-u-flex-1 pipeline-overview__min-height-0 pf-v6-u-display-flex pf-v6-u-flex-direction-column pf-v6-u-justify-content-flex-end pf-v6-u-align-items-flex-start pf-v6-u-p-0':
-              !pipelineRunsChartError,
-          })}
-        >
-          {pipelineRunsChartError ? (
-            <Alert
-              variant="danger"
-              isInline
-              title={t('Unable to load pipeline runs')}
-              className="pf-v6-u-mb-md pf-v6-u-ml-lg pf-v6-u-mt-lg"
-            />
-          ) : (
-            <div
-              ref={chartContainerRef}
-              className={`pf-v6-u-w-100 ${
-                chartWidth > 0 ? 'pf-v6-u-h-100' : ''
-              }`}
-            >
-              {loaded ? (
-                <Chart
-                  containerComponent={
-                    <ChartVoronoiContainer
-                      labels={({ datum }) => `${datum.y}`}
-                      constrainToVisibleArea
-                    />
-                  }
-                  scale={{ x: 'time', y: 'linear' }}
-                  domain={domainValue}
-                  domainPadding={{ x: [30, 25] }}
-                  height={chartHeight}
-                  width={chartWidth}
-                  padding={{
-                    top: 10,
-                    bottom: bottomPad,
-                    left: 40,
-                    right: 50,
-                  }}
-                  themeColor={ChartThemeColor.blue}
-                >
-                  <ChartAxis
-                    tickValues={tickValues}
-                    style={xAxisStyle}
-                    tickFormat={xTickFormat}
-                    label={showLabel ? dayLabel : ''}
+        {pipelineRunsChartError ? (
+          <Alert
+            variant="danger"
+            isInline
+            title={t('Unable to load pipeline runs')}
+            className="pf-v6-u-mb-md pf-v6-u-mt-lg"
+          />
+        ) : (
+          <div
+            ref={chartContainerRef}
+            className={`pf-v6-u-w-100 ${chartWidth > 0 ? 'pf-v6-u-h-100' : ''}`}
+          >
+            {loaded ? (
+              <Chart
+                containerComponent={
+                  <ChartVoronoiContainer
+                    labels={({ datum }) => `${datum.y}`}
+                    constrainToVisibleArea
                   />
-                  <ChartAxis dependentAxis style={yAxisStyle} />
-                  <ChartGroup>
-                    <ChartBar data={chartData} barWidth={18} />
-                  </ChartGroup>
-                </Chart>
-              ) : (
-                <div className="pf-v6-u-display-flex pf-v6-u-align-items-center pf-v6-u-justify-content-center pf-v6-u-h-100 pf-v6-u-p-md pf-v6-u-p-0-on-md">
-                  <Loading isInline={true} />
-                </div>
-              )}
-            </div>
-          )}
-        </CardBody>
-      </Card>
-    </>
+                }
+                scale={{ x: 'time', y: 'linear' }}
+                domain={domainValue}
+                domainPadding={{ x: [30, 25] }}
+                height={chartHeight}
+                width={chartWidth}
+                padding={{
+                  top: 20,
+                  bottom: bottomPad,
+                  left: 50,
+                  right: 40,
+                }}
+                themeColor={ChartThemeColor.blue}
+              >
+                <ChartAxis
+                  tickValues={tickValues}
+                  style={xAxisStyle}
+                  tickFormat={xTickFormat}
+                  label={showLabel ? dayLabel : ''}
+                />
+                <ChartAxis dependentAxis style={yAxisStyle} />
+                <ChartGroup>
+                  <ChartBar data={chartData} barWidth={18} />
+                </ChartGroup>
+              </Chart>
+            ) : (
+              <div className="pf-v6-u-display-flex pf-v6-u-align-items-center pf-v6-u-justify-content-center pf-v6-u-h-100 pf-v6-u-p-md pf-v6-u-p-0-on-md">
+                <Loading isInline={true} />
+              </div>
+            )}
+          </div>
+        )}
+      </CardBody>
+    </Card>
   );
 };
 

--- a/src/components/pipelines-overview/PipelineRunsNumbersChartK8s.tsx
+++ b/src/components/pipelines-overview/PipelineRunsNumbersChartK8s.tsx
@@ -105,6 +105,14 @@ const getChartData = (
   return chartData;
 };
 
+const BOTTOM_PAD_DEFAULT = 35;
+const BOTTOM_PAD_ROTATED = 55;
+const BOTTOM_PAD_LABEL = 15;
+const CHART_BODY_TOP_OFFSET = 10;
+const CHART_BODY_MIN_HEIGHT = 50;
+const CHART_BODY_MAX_HEIGHT = 100;
+const CHART_ASPECT_RATIO = 5;
+
 const PipelineRunsNumbersChartK8s: FC<PipelinesRunsNumbersChartProps> = ({
   namespace,
   timespan,
@@ -246,14 +254,19 @@ const PipelineRunsNumbersChartK8s: FC<PipelinesRunsNumbersChartProps> = ({
         verticalAnchor: 'end',
       },
     };
-    bottomPad = 55;
+    bottomPad = BOTTOM_PAD_ROTATED;
   } else {
-    bottomPad = 35;
+    bottomPad = BOTTOM_PAD_DEFAULT;
   }
-  if (showLabel) bottomPad += 15;
-  // Calculating height using this formula with the help of width and bottom padding
-  const chartHeight =
-    10 + Math.max(50, Math.min(100, Math.round(chartWidth / 5))) + bottomPad;
+  if (showLabel) bottomPad += BOTTOM_PAD_LABEL;
+  const chartBodyHeight = Math.max(
+    CHART_BODY_MIN_HEIGHT,
+    Math.min(
+      CHART_BODY_MAX_HEIGHT,
+      Math.round(chartWidth / CHART_ASPECT_RATIO),
+    ),
+  );
+  const chartHeight = CHART_BODY_TOP_OFFSET + chartBodyHeight + bottomPad;
 
   useEffect(() => {
     const hasNonAbortError =
@@ -266,79 +279,76 @@ const PipelineRunsNumbersChartK8s: FC<PipelinesRunsNumbersChartProps> = ({
   }, [runSuccessRatioError]);
 
   return (
-    <>
-      <Card
-        className={classNames({
-          'pf-v6-u-h-100 pipeline-overview__min-width-full pipeline-overview__overflow-hidden pf-v6-u-display-flex pf-v6-u-flex-direction-column':
-            !pipelineRunsChartError,
+    <Card
+      className={classNames(
+        'pipeline-overview__min-width-full pipeline-overview__overflow-hidden pf-v6-u-display-flex pf-v6-u-flex-direction-column pf-v6-u-h-100',
+        {
+          'pipeline-overview__number-of-plr-card': !pipelineRunsChartError,
           'card-border': bordered,
+        },
+      )}
+    >
+      <CardTitle className="pf-v6-u-pb-0">
+        <span>{t('Number of PipelineRuns')}</span>
+      </CardTitle>
+      <CardBody
+        className={classNames({
+          'pf-v6-u-flex-1 pipeline-overview__min-height-0 pf-v6-u-display-flex pf-v6-u-flex-direction-column pf-v6-u-justify-content-flex-end pf-v6-u-align-items-flex-start pf-v6-u-p-0':
+            !pipelineRunsChartError,
         })}
       >
-        <CardTitle className="pf-v6-u-pb-0">
-          <span>{t('Number of PipelineRuns')}</span>
-        </CardTitle>
-        <CardBody
-          className={classNames({
-            'pf-v6-u-flex-1 pipeline-overview__min-height-0 pf-v6-u-display-flex pf-v6-u-flex-direction-column pf-v6-u-justify-content-flex-end pf-v6-u-align-items-flex-start pf-v6-u-p-0':
-              !pipelineRunsChartError,
-          })}
-        >
-          {pipelineRunsChartError ? (
-            <Alert
-              variant="danger"
-              isInline
-              title={t('Unable to load pipeline runs')}
-              className="pf-v6-u-ml-lg"
-            />
-          ) : (
-            <div
-              ref={chartContainerRef}
-              className={`pf-v6-u-w-100 ${
-                chartWidth > 0 ? 'pf-v6-u-h-100' : ''
-              }`}
-            >
-              {loadingRunSuccessRatioData ? (
-                <div className="pf-v6-u-display-flex pf-v6-u-align-items-center pf-v6-u-justify-content-center pf-v6-u-h-100 pf-v6-u-p-md pf-v6-u-p-0-on-md">
-                  <Loading isInline={true} />
-                </div>
-              ) : (
-                <Chart
-                  containerComponent={
-                    <ChartVoronoiContainer
-                      labels={({ datum }) => `${datum.y}`}
-                      constrainToVisibleArea
-                    />
-                  }
-                  scale={{ x: 'time', y: 'linear' }}
-                  domain={domainValue}
-                  domainPadding={{ x: [30, 25] }}
-                  height={chartHeight}
-                  width={chartWidth}
-                  padding={{
-                    top: 10,
-                    bottom: bottomPad,
-                    left: 50,
-                    right: 50,
-                  }}
-                  themeColor={ChartThemeColor.blue}
-                >
-                  <ChartAxis
-                    tickValues={tickValues}
-                    style={xAxisStyle}
-                    tickFormat={xTickFormat}
-                    label={showLabel ? dayLabel : ''}
+        {pipelineRunsChartError ? (
+          <Alert
+            variant="danger"
+            isInline
+            title={t('Unable to load pipeline runs')}
+          />
+        ) : (
+          <div
+            ref={chartContainerRef}
+            className={`pf-v6-u-w-100 ${chartWidth > 0 ? 'pf-v6-u-h-100' : ''}`}
+          >
+            {loadingRunSuccessRatioData ? (
+              <div className="pf-v6-u-display-flex pf-v6-u-align-items-center pf-v6-u-justify-content-center pf-v6-u-h-100 pf-v6-u-p-md pf-v6-u-p-0-on-md">
+                <Loading isInline={true} />
+              </div>
+            ) : (
+              <Chart
+                containerComponent={
+                  <ChartVoronoiContainer
+                    labels={({ datum }) => `${datum.y}`}
+                    constrainToVisibleArea
                   />
-                  <ChartAxis dependentAxis style={yAxisStyle} />
-                  <ChartGroup>
-                    <ChartBar data={chartData} barWidth={18} />
-                  </ChartGroup>
-                </Chart>
-              )}
-            </div>
-          )}
-        </CardBody>
-      </Card>
-    </>
+                }
+                scale={{ x: 'time', y: 'linear' }}
+                domain={domainValue}
+                domainPadding={{ x: [30, 25] }}
+                height={chartHeight}
+                width={chartWidth}
+                padding={{
+                  top: 20,
+                  bottom: bottomPad,
+                  left: 50,
+                  right: 40,
+                }}
+                themeColor={ChartThemeColor.blue}
+              >
+                <ChartAxis
+                  tickValues={tickValues}
+                  style={xAxisStyle}
+                  tickFormat={xTickFormat}
+                  label={showLabel ? dayLabel : ''}
+                />
+                <ChartAxis dependentAxis style={yAxisStyle} />
+                <ChartGroup>
+                  <ChartBar data={chartData} barWidth={18} />
+                </ChartGroup>
+              </Chart>
+            )}
+          </div>
+        )}
+      </CardBody>
+    </Card>
   );
 };
 

--- a/src/components/pipelines-overview/PipelineRunsStatusCard.tsx
+++ b/src/components/pipelines-overview/PipelineRunsStatusCard.tsx
@@ -320,11 +320,13 @@ const PipelinesRunsStatusCard: FC<PipelinesRunsStatusCardProps> = ({
   let xAxisStyle: ChartAxisProps['style'] = {
     tickLabels: {
       fill: 'var(--pf-t--global--text--color--regular)',
+      fontSize: 12,
     },
   };
   const yAxisStyle: ChartAxisProps['style'] = {
     tickLabels: {
       fill: 'var(--pf-t--global--text--color--regular)',
+      fontSize: 12,
     },
   };
   if (tickValues?.length > 7) {

--- a/src/components/pipelines-overview/PipelineRunsStatusCardK8s.tsx
+++ b/src/components/pipelines-overview/PipelineRunsStatusCardK8s.tsx
@@ -441,11 +441,13 @@ const PipelineRunsStatusCardK8s: FC<PipelinesRunsStatusCardProps> = ({
   let xAxisStyle: ChartAxisProps['style'] = {
     tickLabels: {
       fill: 'var(--pf-t--global--text--color--regular)',
+      fontSize: 12,
     },
   };
   const yAxisStyle: ChartAxisProps['style'] = {
     tickLabels: {
       fill: 'var(--pf-t--global--text--color--regular)',
+      fontSize: 12,
     },
   };
   if (tickValues?.length > 7) {
@@ -532,7 +534,7 @@ const PipelineRunsStatusCardK8s: FC<PipelinesRunsStatusCardProps> = ({
           'card-border': bordered,
         })}
       >
-        <CardTitle className="pipeline-overview__pipelinerun-status-card__title">
+        <CardTitle>
           <span>
             {t('PipelineRun status')}{' '}
             <Popover

--- a/src/components/pipelines-overview/PipelineRunsTotalCardK8s.tsx
+++ b/src/components/pipelines-overview/PipelineRunsTotalCardK8s.tsx
@@ -88,18 +88,15 @@ const PipelineRunsTotalCardK8s: FC<PipelinesRunsDurationProps> = ({
   return (
     <>
       <Card
-        className={classNames(
-          'pf-v6-u-h-100 pipeline-overview__min-width-full pf-v6-u-font-size-lg',
-          {
-            'card-border': bordered,
-          },
-        )}
+        className={classNames('pf-v6-u-h-100', {
+          'card-border': bordered,
+        })}
       >
-        <CardTitle className="pf-v6-u-font-size-xl">
+        <CardTitle>
           <span>{t('Total runs')}</span>
         </CardTitle>
         <Divider />
-        <CardBody className="pf-v6-u-font-size-lg pipeline-overview__min-width-min-content">
+        <CardBody>
           {pipelineRunsTotalError ? (
             <Alert
               variant="danger"
@@ -109,16 +106,10 @@ const PipelineRunsTotalCardK8s: FC<PipelinesRunsDurationProps> = ({
             />
           ) : (
             <>
-              <Grid
-                hasGutter
-                className="pipeline-overview__totals-card__grid pf-v6-u-font-size-lg"
-              >
+              <Grid hasGutter>
                 <GridItem span={9} className="pf-v6-u-mb-sm">
-                  <span className="pf-v6-u-font-size-lg">
-                    <Label
-                      variant="outline"
-                      className="pipeline-overview__totals-card__label pf-v6-u-mr-sm"
-                    >
+                  <span>
+                    <Label variant="outline" className="pf-v6-u-mr-sm">
                       {PipelineModel.abbr}
                     </Label>
                     {t('Runs in pipelines')}
@@ -126,7 +117,7 @@ const PipelineRunsTotalCardK8s: FC<PipelinesRunsDurationProps> = ({
                 </GridItem>
                 <GridItem
                   span={3}
-                  className="pf-v6-u-text-align-end pf-v6-u-font-size-lg pipeline-overview__chart-color-blue"
+                  className="pf-v6-u-text-align-end pipeline-overview__chart-color-blue"
                 >
                   {loadingTotalPipelineRunsData ? (
                     <Loading isInline={true} />
@@ -135,16 +126,10 @@ const PipelineRunsTotalCardK8s: FC<PipelinesRunsDurationProps> = ({
                   )}
                 </GridItem>
               </Grid>
-              <Grid
-                hasGutter
-                className="pipeline-overview__totals-card__grid pf-v6-u-mb-sm pf-v6-u-font-size-lg"
-              >
+              <Grid hasGutter className="pf-v6-u-mb-sm">
                 <GridItem span={9}>
-                  <span className="pf-v6-u-font-size-lg">
-                    <Label
-                      variant="outline"
-                      className="pipeline-overview__totals-card__repo-label pf-v6-u-mr-sm"
-                    >
+                  <span>
+                    <Label variant="outline" className="pf-v6-u-mr-sm">
                       {RepositoryModel.abbr}
                     </Label>
                     {t('Runs in repositories')}
@@ -152,7 +137,7 @@ const PipelineRunsTotalCardK8s: FC<PipelinesRunsDurationProps> = ({
                 </GridItem>
                 <GridItem
                   span={3}
-                  className="pf-v6-u-text-align-end pf-v6-u-font-size-lg pipeline-overview__chart-color-blue"
+                  className="pf-v6-u-text-align-end pipeline-overview__chart-color-blue"
                 >
                   {loadingTotalPipelineRunsData ? (
                     <Loading isInline={true} />
@@ -161,16 +146,16 @@ const PipelineRunsTotalCardK8s: FC<PipelinesRunsDurationProps> = ({
                   )}
                 </GridItem>
               </Grid>
-              <Grid hasGutter className="pf-v6-u-font-size-lg">
+              <Grid hasGutter className="pf-v6-u-mb-sm">
                 <GridItem span={9}>
-                  <span className="pf-v6-u-font-size-lg">
+                  <span>
                     <CheckIcon className="pipeline-overview__totals-card__icon pf-v6-u-ml-sm pf-v6-u-mr-sm" />
                     {t('Total runs')}
                   </span>
                 </GridItem>
                 <GridItem
                   span={3}
-                  className="pf-v6-u-text-align-end pf-v6-u-font-size-lg pipeline-overview__chart-color-blue"
+                  className="pf-v6-u-text-align-end pipeline-overview__chart-color-blue"
                 >
                   {loadingTotalPipelineRunsData ? (
                     <Loading isInline={true} />

--- a/src/components/pipelines-overview/PipelinesOverviewPage.tsx
+++ b/src/components/pipelines-overview/PipelinesOverviewPage.tsx
@@ -104,7 +104,7 @@ const PipelinesOverviewPage: FC = () => {
               bordered={true}
             />
           </FlexItem>
-          <FlexItem flex={{ default: 'flexNone', xl: 'flex_2' }} className="pf-v6-u-w-100">
+          <FlexItem flex={{ default: 'flex_1', xl: 'flex_2' }}>
             <PipelinesRunsNumbersChart
               namespace={activeNamespace}
               timespan={timespan}

--- a/src/components/pipelines-overview/PipelinesOverviewPageK8s.tsx
+++ b/src/components/pipelines-overview/PipelinesOverviewPageK8s.tsx
@@ -108,10 +108,7 @@ const PipelinesOverviewPageK8s: FC = () => {
               bordered={true}
             />
           </FlexItem>
-          <FlexItem
-            flex={{ default: 'flexNone', xl: 'flex_2' }}
-            className="pf-v6-u-w-100"
-          >
+          <FlexItem flex={{ default: 'flex_1', xl: 'flex_2' }}>
             <PipelineRunsNumbersChartK8s
               namespace={activeNamespace}
               timespan={timespan}

--- a/src/components/pipelines-overview/SearchInput.tsx
+++ b/src/components/pipelines-overview/SearchInput.tsx
@@ -17,7 +17,6 @@ const SearchInputField: FC<SearchInputProps> = ({
   return (
     <SearchInput
       value={searchText}
-      className="pf-v6-u-ml-sm pf-v6-u-w-25"
       placeholder={
         pageFlag === 1
           ? t('Search by pipeline name')

--- a/src/components/pipelines-overview/__tests__/PipelinesOverview.spec.tsx
+++ b/src/components/pipelines-overview/__tests__/PipelinesOverview.spec.tsx
@@ -1,26 +1,25 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import {
-  VirtualizedTable,
   useK8sWatchResource,
-  useActiveColumns,
   useActiveNamespace,
   useFlag,
 } from '@openshift-console/dynamic-plugin-sdk';
+import { ConsoleDataView } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 import PipelinesOverviewPage from '../PipelinesOverviewPage';
 import { getResultsSummary } from '../../utils/summary-api';
 import * as utils from '../utils';
 
-const virtualizedTableRenderProps = jest.fn();
 const setActiveNamespace = jest.fn();
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   useK8sWatchResource: jest.fn(),
   useActiveNamespace: jest.fn(),
-  useActiveColumns: jest.fn(),
-  VirtualizedTable: jest.fn(),
   k8sGet: jest.fn(),
   useFlag: jest.fn(),
+}));
+jest.mock('@openshift-console/dynamic-plugin-sdk-internal', () => ({
+  ConsoleDataView: jest.fn(),
 }));
 jest.mock('../../utils/tekton-results', () => ({
   createTektonResultsSummaryUrl: jest.fn(),
@@ -35,17 +34,12 @@ jest.mock('react-redux', () => ({
 jest.mock('react-router', () => ({
   useLocation: jest.fn(),
 }));
-(VirtualizedTable as jest.Mock).mockImplementation((props) => {
-  virtualizedTableRenderProps(props);
-  return null;
-});
 
 jest.spyOn(utils, 'useQueryParams').mockReturnValue(null);
 
-const virtualizedTableMock = VirtualizedTable as jest.Mock;
+const consoleDataViewMock = ConsoleDataView as jest.Mock;
 const useActiveNamespaceMock = useActiveNamespace as jest.Mock;
 const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
-const useActiveColumnsMock = useActiveColumns as jest.Mock;
 const getResultsSummaryMock = getResultsSummary as jest.Mock;
 const useFlagMock = useFlag as jest.Mock;
 const useDispatchMock = useDispatch as unknown as jest.Mock;
@@ -54,13 +48,12 @@ const useLocationMock = useLocation as jest.Mock;
 
 describe('Pipeline Overview page', () => {
   beforeEach(() => {
-    virtualizedTableMock.mockReturnValue(<></>);
+    consoleDataViewMock.mockReturnValue(<></>);
     useActiveNamespaceMock.mockReturnValue([
       'active-namespace',
       setActiveNamespace,
     ]);
     useK8sWatchResourceMock.mockReturnValue([[], true]);
-    useActiveColumnsMock.mockReturnValue([[]]);
     getResultsSummaryMock.mockReturnValue(Promise.resolve({}));
     useFlagMock.mockReturnValue(true);
     useDispatchMock.mockReturnValue(jest.fn());

--- a/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesList.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesList.tsx
@@ -1,22 +1,20 @@
 import type { FC } from 'react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { EmptyState, EmptyStateVariant } from '@patternfly/react-core';
-import { sortable } from '@patternfly/react-table';
-import {
-  TableColumn,
-  VirtualizedTable,
-  useActiveColumns,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import { ConsoleDataView } from '@openshift-console/dynamic-plugin-sdk-internal';
 import {
   SummaryProps,
   sortByNumbers,
   sortByProperty,
   sortByTimestamp,
   sortTimeStrings,
-  listPageTableColumnClasses as tableColumnClasses,
 } from '../utils';
-import PipelineRunsForPipelinesRow from './PipelineRunsForPipelinesRow';
+import {
+  getPipelineRunsForPipelinesDataViewRows,
+  tableColumnInfo,
+} from './PipelineRunsForPipelinesRow';
+import { ALL_NAMESPACES_KEY } from '../../../consts';
 
 type PipelineRunsForPipelinesListProps = {
   summaryData: SummaryProps[];
@@ -25,56 +23,60 @@ type PipelineRunsForPipelinesListProps = {
   hideLastRunTime?: boolean;
 };
 
-const PipelineRunsForPipelinesList: FC<
-  PipelineRunsForPipelinesListProps
-> = ({ summaryData, summaryDataFiltered, loaded, hideLastRunTime }) => {
+const PipelineRunsForPipelinesList: FC<PipelineRunsForPipelinesListProps> = ({
+  summaryData,
+  summaryDataFiltered,
+  loaded,
+  hideLastRunTime,
+}) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
-  const EmptyMsg = () => (
-    <EmptyState variant={EmptyStateVariant.lg} headingLevel="h4" titleText={t('No PipelineRuns found')}>
-    </EmptyState>
-  );
+  const [activeNamespace] = useActiveNamespace();
 
-  const plrColumns = useMemo<TableColumn<SummaryProps>[]>(() => {
-    const columns: TableColumn<SummaryProps>[] = [
+  const columns = useMemo(() => {
+    const cols = [
       {
-        id: 'pipelineName',
+        id: tableColumnInfo[0].id,
         title: t('Pipeline'),
         sort: (summary, direction: 'asc' | 'desc') =>
           sortByProperty(summary, 'pipelineName', direction),
-        transforms: [sortable],
-        props: { className: tableColumnClasses[0] },
+        props: {
+          modifier: 'nowrap',
+          isStickyColumn: true,
+          hasRightBorder: true,
+          stickyMinWidth: '0',
+        },
       },
+      ...(activeNamespace === ALL_NAMESPACES_KEY
+        ? [
+            {
+              id: tableColumnInfo[1].id,
+              title: t('Project'),
+              sort: (summary, direction: 'asc' | 'desc') =>
+                sortByProperty(summary, 'namespace', direction),
+              props: { modifier: 'nowrap' },
+            },
+          ]
+        : []),
       {
-        id: 'namespace',
-        title: t('Project'),
-        sort: (summary, direction: 'asc' | 'desc') =>
-          sortByProperty(summary, 'namespace', direction),
-        transforms: [sortable],
-        props: { className: tableColumnClasses[1] },
-      },
-      {
-        id: 'total',
+        id: tableColumnInfo[2].id,
         title: t('Total Pipelineruns'),
         sort: 'total',
-        transforms: [sortable],
-        props: { className: tableColumnClasses[2] },
+        props: { modifier: 'nowrap' },
       },
       {
-        id: 'totalDuration',
+        id: tableColumnInfo[3].id,
         title: t('Total duration'),
         sort: (summary, direction: 'asc' | 'desc') =>
           sortTimeStrings(summary, 'total_duration', direction),
-        transforms: [sortable],
-        props: { className: tableColumnClasses[3] },
+        props: { modifier: 'nowrap' },
       },
       {
-        id: 'avgDuration',
+        id: tableColumnInfo[4].id,
         title: t('Average duration'),
         sort: (summary, direction: 'asc' | 'desc') =>
           sortTimeStrings(summary, 'avg_duration', direction),
-        transforms: [sortable],
         props: {
-          className: tableColumnClasses[4],
+          modifier: 'nowrap',
           info: {
             tooltip: t(
               'An average of the time taken to run PipelineRuns. The trending shown is based on the time range selected. This metric does not show runs that are running or pending.',
@@ -84,13 +86,12 @@ const PipelineRunsForPipelinesList: FC<
         },
       },
       {
-        id: 'successRate',
+        id: tableColumnInfo[5].id,
         title: t('Success rate'),
         sort: (summary, direction: 'asc' | 'desc') =>
           sortByNumbers(summary, 'succeeded', direction),
-        transforms: [sortable],
         props: {
-          className: tableColumnClasses[5],
+          modifier: 'nowrap',
           info: {
             tooltip: t(
               'Success rate measure the % of successfully completed pipeline runs in relation to the total number of pipeline runs',
@@ -100,44 +101,31 @@ const PipelineRunsForPipelinesList: FC<
         },
       },
     ];
+
     if (!hideLastRunTime) {
-      columns.push({
-        id: 'lastRunTime',
+      cols.push({
+        id: tableColumnInfo[6].id,
         title: t('Last run time'),
         sort: (summary, direction: 'asc' | 'desc') =>
           sortByTimestamp(summary, 'last_runtime', direction),
-        transforms: [sortable],
-        props: { className: tableColumnClasses[6] },
+        props: { modifier: 'nowrap' },
       });
     }
 
-    return columns;
-  }, [t, hideLastRunTime]);
-
-  const [columns] = useActiveColumns({
-    columns: plrColumns,
-    showNamespaceOverride: false,
-    columnManagementID: '',
-  });
-
-  const isEmptyData =
-    (!summaryDataFiltered || summaryDataFiltered.length === 0) &&
-    (!summaryData || summaryData.length === 0);
-
-  if (loaded && isEmptyData) {
-    return <EmptyMsg />;
-  }
+    return cols;
+  }, [hideLastRunTime, activeNamespace]);
 
   return (
-    <VirtualizedTable
+    <ConsoleDataView<SummaryProps>
+      label={t('PipelineRuns')}
       columns={columns}
-      Row={PipelineRunsForPipelinesRow}
       data={summaryDataFiltered || summaryData}
       loaded={loaded}
       loadError={false}
-      unfilteredData={summaryData}
-      EmptyMsg={EmptyMsg}
-      rowData={{ hideLastRunTime }}
+      getDataViewRows={getPipelineRunsForPipelinesDataViewRows}
+      customRowData={{ hideLastRunTime }}
+      hideColumnManagement
+      hideNameLabelFilters
     />
   );
 };

--- a/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesListK8s.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesListK8s.tsx
@@ -1,22 +1,20 @@
 import type { FC } from 'react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { EmptyState, EmptyStateVariant } from '@patternfly/react-core';
-import { sortable } from '@patternfly/react-table';
-import {
-  TableColumn,
-  VirtualizedTable,
-  useActiveColumns,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import { ConsoleDataView } from '@openshift-console/dynamic-plugin-sdk-internal';
 import {
   SummaryProps,
   sortByNumbers,
   sortByProperty,
   sortByTimestamp,
   sortTimeStrings,
-  listPageTableColumnClasses as tableColumnClasses,
 } from '../utils';
-import PipelineRunsForPipelinesRowK8s from './PipelineRunsForPipelinesRowK8s';
+import {
+  getPipelineRunsForPipelinesK8sDataViewRows,
+  tableColumnInfo,
+} from './PipelineRunsForPipelinesRowK8s';
+import { ALL_NAMESPACES_KEY } from '../../../consts';
 import { Project } from '../../../types';
 
 type PipelineRunsForPipelinesListProps = {
@@ -39,52 +37,53 @@ const PipelineRunsForPipelinesListK8s: FC<
   projectsLoaded,
 }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
-  const EmptyMsg = () => (
-    <EmptyState variant={EmptyStateVariant.lg} headingLevel="h4" titleText={t('No PipelineRuns found')}>
-    </EmptyState>
-  );
+  const [activeNamespace] = useActiveNamespace();
 
-  const plrColumns = useMemo<TableColumn<SummaryProps>[]>(() => {
-    const columns: TableColumn<SummaryProps>[] = [
+  const columns = useMemo(() => {
+    const cols = [
       {
-        id: 'pipelineName',
+        id: tableColumnInfo[0].id,
         title: t('Pipeline'),
         sort: (summary, direction: 'asc' | 'desc') =>
           sortByProperty(summary, 'pipelineName', direction),
-        transforms: [sortable],
-        props: { className: tableColumnClasses[0] },
+        props: {
+          modifier: 'nowrap',
+          isStickyColumn: true,
+          hasRightBorder: true,
+          stickyMinWidth: '0',
+        },
       },
+      ...(activeNamespace === ALL_NAMESPACES_KEY
+        ? [
+            {
+              id: tableColumnInfo[1].id,
+              title: t('Project'),
+              sort: (summary, direction: 'asc' | 'desc') =>
+                sortByProperty(summary, 'namespace', direction),
+              props: { modifier: 'nowrap' },
+            },
+          ]
+        : []),
       {
-        id: 'namespace',
-        title: t('Project'),
-        sort: (summary, direction: 'asc' | 'desc') =>
-          sortByProperty(summary, 'namespace', direction),
-        transforms: [sortable],
-        props: { className: tableColumnClasses[1] },
-      },
-      {
-        id: 'total',
+        id: tableColumnInfo[2].id,
         title: t('Total Pipelineruns'),
         sort: 'total',
-        transforms: [sortable],
-        props: { className: tableColumnClasses[2] },
+        props: { modifier: 'nowrap' },
       },
       {
-        id: 'totalDuration',
+        id: tableColumnInfo[3].id,
         title: t('Total duration'),
         sort: (summary, direction: 'asc' | 'desc') =>
           sortTimeStrings(summary, 'total_duration', direction),
-        transforms: [sortable],
-        props: { className: tableColumnClasses[3] },
+        props: { modifier: 'nowrap' },
       },
       {
-        id: 'avgDuration',
+        id: tableColumnInfo[4].id,
         title: t('Average duration'),
         sort: (summary, direction: 'asc' | 'desc') =>
           sortTimeStrings(summary, 'avg_duration', direction),
-        transforms: [sortable],
         props: {
-          className: tableColumnClasses[4],
+          modifier: 'nowrap',
           info: {
             tooltip: t(
               'An average of the time taken to run PipelineRuns. The trending shown is based on the time range selected. This metric does not show runs that are running or pending.',
@@ -94,13 +93,12 @@ const PipelineRunsForPipelinesListK8s: FC<
         },
       },
       {
-        id: 'successRate',
+        id: tableColumnInfo[5].id,
         title: t('Success rate'),
         sort: (summary, direction: 'asc' | 'desc') =>
           sortByNumbers(summary, 'succeeded', direction),
-        transforms: [sortable],
         props: {
-          className: tableColumnClasses[5],
+          modifier: 'nowrap',
           info: {
             tooltip: t(
               'Success rate measure the % of successfully completed pipeline runs in relation to the total number of pipeline runs',
@@ -110,43 +108,31 @@ const PipelineRunsForPipelinesListK8s: FC<
         },
       },
     ];
+
     if (!hideLastRunTime) {
-      columns.push({
-        id: 'lastRunTime',
+      cols.push({
+        id: tableColumnInfo[6].id,
         title: t('Last run time'),
         sort: (summary, direction: 'asc' | 'desc') =>
           sortByTimestamp(summary, 'last_runtime', direction),
-        transforms: [sortable],
-        props: { className: tableColumnClasses[6] },
+        props: { modifier: 'nowrap' },
       });
     }
 
-    return columns;
-  }, [t, hideLastRunTime]);
+    return cols;
+  }, [hideLastRunTime, activeNamespace]);
 
-  const [columns] = useActiveColumns({
-    columns: plrColumns,
-    showNamespaceOverride: false,
-    columnManagementID: '',
-  });
-
-  const isEmptyData =
-    (!summaryDataFiltered || summaryDataFiltered.length === 0) &&
-    (!summaryData || summaryData.length === 0);
-
-  if (loaded && isEmptyData) {
-    return <EmptyMsg />;
-  }
   return (
-    <VirtualizedTable
+    <ConsoleDataView<SummaryProps>
+      label={t('PipelineRuns')}
       columns={columns}
-      Row={PipelineRunsForPipelinesRowK8s}
       data={summaryDataFiltered || summaryData}
       loaded={loaded}
       loadError={false}
-      unfilteredData={summaryData}
-      EmptyMsg={EmptyMsg}
-      rowData={{ hideLastRunTime, projects, projectsLoaded }}
+      getDataViewRows={getPipelineRunsForPipelinesK8sDataViewRows}
+      customRowData={{ hideLastRunTime, projects, projectsLoaded }}
+      hideColumnManagement
+      hideNameLabelFilters
     />
   );
 };

--- a/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesRow.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesRow.tsx
@@ -1,75 +1,96 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { FC } from 'react';
 import { Link } from 'react-router';
 import {
-  SummaryProps,
-  getReferenceForModel,
-  listPageTableColumnClasses as tableColumnClasses,
-} from '../utils';
-import {
   ResourceLink,
-  RowProps,
   getGroupVersionKindForModel,
-  useActiveNamespace,
 } from '@openshift-console/dynamic-plugin-sdk';
+import type { ReactNode } from 'react';
+import { GetDataViewRows } from '@openshift-console/dynamic-plugin-sdk-internal/lib/api/internal-types';
 import { formatTime, formatTimeLastRunTime } from '../dateTime';
-import { ALL_NAMESPACES_KEY } from '../../../consts';
+import { SummaryProps, getReferenceForModel } from '../utils';
 import { PipelineModel, PipelineModelV1Beta1 } from '../../../models';
 
-const PipelineRunsForPipelinesRow: FC<
-  RowProps<
-    SummaryProps,
-    {
-      hideLastRunTime?: boolean;
-    }
-  >
-> = ({ obj, rowData: { hideLastRunTime } }) => {
-  const [activeNamespace] = useActiveNamespace();
-  const [namespace, name] = obj.group_value.split('/');
+type RowCell = { cell: ReactNode; props?: Record<string, unknown> };
+
+const getClusterVersion = () => {
   const clusterVersion = (window as any).SERVER_FLAGS?.releaseVersion;
-  const isV1SupportCluster =
-    clusterVersion?.split('.')[0] === '4' &&
-    clusterVersion?.split('.')[1] > '13';
-  const pipelineReference = getReferenceForModel(
-    isV1SupportCluster ? PipelineModel : PipelineModelV1Beta1,
-  );
   return (
-    <>
-      <td className={tableColumnClasses[0]}>
-        <ResourceLink
-          groupVersionKind={
-            isV1SupportCluster
-              ? getGroupVersionKindForModel(PipelineModel)
-              : getGroupVersionKindForModel(PipelineModelV1Beta1)
-          }
-          name={name}
-          namespace={namespace}
-        />
-      </td>
-      {activeNamespace === ALL_NAMESPACES_KEY && (
-        <td className={tableColumnClasses[1]}>
-          <ResourceLink kind="Namespace" name={namespace} />
-        </td>
-      )}
-      <td className={tableColumnClasses[2]}>
-        <Link to={`/k8s/ns/${namespace}/${pipelineReference}/${name}/Runs`}>
-          {obj.total}
-        </Link>
-      </td>
-      <td className={tableColumnClasses[3]}>
-        {formatTime(obj.total_duration)}
-      </td>
-      <td className={tableColumnClasses[4]}>{formatTime(obj.avg_duration)}</td>
-      <td className={tableColumnClasses[5]}>{`${Math.round(
-        (100 * obj.succeeded) / obj.total,
-      )}%`}</td>
-      {!hideLastRunTime && (
-        <td className={tableColumnClasses[6]}>{`${formatTimeLastRunTime(
-          obj.last_runtime,
-        )}`}</td>
-      )}
-    </>
+    clusterVersion?.split('.')[0] === '4' &&
+    clusterVersion?.split('.')[1] > '13'
   );
 };
 
-export default PipelineRunsForPipelinesRow;
+export const tableColumnInfo = [
+  { id: 'pipelineName' },
+  { id: 'namespace' },
+  { id: 'total' },
+  { id: 'totalDuration' },
+  { id: 'avgDuration' },
+  { id: 'successRate' },
+  { id: 'lastRunTime' },
+];
+
+export const getPipelineRunsForPipelinesDataViewRows: GetDataViewRows<
+  SummaryProps,
+  { hideLastRunTime?: boolean }
+> = (data, columns) => {
+  return data.map(({ obj, rowData }) => {
+    const [namespace, name] = obj.group_value.split('/');
+    const isV1SupportCluster = getClusterVersion();
+    const pipelineReference = getReferenceForModel(
+      isV1SupportCluster ? PipelineModel : PipelineModelV1Beta1,
+    );
+
+    const rowCells: Record<string, RowCell> = {
+      [tableColumnInfo[0].id]: {
+        cell: (
+          <ResourceLink
+            /* needs to be removed when we update console-extension.json */
+            groupVersionKind={
+              isV1SupportCluster
+                ? getGroupVersionKindForModel(PipelineModel)
+                : getGroupVersionKindForModel(PipelineModelV1Beta1)
+            }
+            name={name}
+            namespace={namespace}
+          />
+        ),
+        props: {
+          isStickyColumn: true,
+          hasRightBorder: true,
+          stickyMinWidth: '0',
+        },
+      },
+      [tableColumnInfo[1].id]: {
+        cell: <ResourceLink kind="Namespace" name={namespace} />,
+      },
+      [tableColumnInfo[2].id]: {
+        cell: (
+          <Link to={`/k8s/ns/${namespace}/${pipelineReference}/${name}/Runs`}>
+            {obj.total}
+          </Link>
+        ),
+      },
+      [tableColumnInfo[3].id]: {
+        cell: formatTime(obj.total_duration),
+      },
+      [tableColumnInfo[4].id]: {
+        cell: formatTime(obj.avg_duration),
+      },
+      [tableColumnInfo[5].id]: {
+        cell: `${Math.round((100 * obj.succeeded) / obj.total)}%`,
+      },
+      [tableColumnInfo[6].id]: {
+        cell: !rowData?.hideLastRunTime
+          ? formatTimeLastRunTime(obj.last_runtime)
+          : null,
+      },
+    };
+
+    return columns.map(({ id }) => ({
+      id,
+      props: rowCells[id]?.props,
+      cell: rowCells[id]?.cell,
+    }));
+  });
+};

--- a/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesRowK8s.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsForPipelinesRowK8s.tsx
@@ -1,66 +1,74 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { FC } from 'react';
 import { Link } from 'react-router';
-import { useTranslation } from 'react-i18next';
 import { Tooltip } from '@patternfly/react-core';
-import {
-  SummaryProps,
-  getReferenceForModel,
-  listPageTableColumnClasses as tableColumnClasses,
-} from '../utils';
 import {
   ResourceIcon,
   ResourceLink,
-  RowProps,
   getGroupVersionKindForModel,
-  useActiveNamespace,
 } from '@openshift-console/dynamic-plugin-sdk';
+import type { ReactNode } from 'react';
+import { GetDataViewRows } from '@openshift-console/dynamic-plugin-sdk-internal/lib/api/internal-types';
 import { formatTime, formatTimeLastRunTime } from '../dateTime';
-import { ALL_NAMESPACES_KEY } from '../../../consts';
+import { SummaryProps, getReferenceForModel } from '../utils';
+
+type RowCell = { cell: ReactNode; props?: Record<string, unknown> };
 import {
+  NamespaceModel,
   PipelineModel,
   PipelineModelV1Beta1,
   ProjectModel,
 } from '../../../models';
 import { Project } from '../../../types';
+import { t } from '../../utils/common-utils';
 
-const PipelineRunsForPipelinesRowK8s: FC<
-  RowProps<
-    SummaryProps,
-    {
-      hideLastRunTime?: boolean;
-      projects: Project[];
-      projectsLoaded: boolean;
-    }
-  >
-> = ({ obj, rowData: { hideLastRunTime, projects, projectsLoaded } }) => {
-  const { t } = useTranslation('plugin__pipelines-console-plugin');
-  const [activeNamespace] = useActiveNamespace();
-  const [namespace, name] = obj.group_value.split('/');
+const getClusterVersion = () => {
   const clusterVersion = (window as any).SERVER_FLAGS?.releaseVersion;
-  const isV1SupportCluster =
-    clusterVersion?.split('.')[0] === '4' &&
-    clusterVersion?.split('.')[1] > '13';
-  const pipelineReference = getReferenceForModel(
-    isV1SupportCluster ? PipelineModel : PipelineModelV1Beta1,
-  );
-  const projectReference = getReferenceForModel(ProjectModel);
-
-  const isNamespaceExists = (namespaceName: string) => {
-    if (!projectsLoaded) {
-      return false;
-    }
-    return projects.some(
-      (project) =>
-        project?.metadata && project?.metadata?.name === namespaceName,
-    );
-  };
-
   return (
-    <>
-      <td className={tableColumnClasses[0]}>
-        {isNamespaceExists(namespace) ? (
+    clusterVersion?.split('.')[0] === '4' &&
+    clusterVersion?.split('.')[1] > '13'
+  );
+};
+
+export const tableColumnInfo = [
+  { id: 'pipelineName' },
+  { id: 'namespace' },
+  { id: 'total' },
+  { id: 'totalDuration' },
+  { id: 'avgDuration' },
+  { id: 'successRate' },
+  { id: 'lastRunTime' },
+];
+
+export const getPipelineRunsForPipelinesK8sDataViewRows: GetDataViewRows<
+  SummaryProps,
+  {
+    hideLastRunTime?: boolean;
+    projects?: Project[];
+    projectsLoaded?: boolean;
+  }
+> = (data, columns) => {
+  return data.map(({ obj, rowData }) => {
+    const [namespace, name] = obj.group_value.split('/');
+    const isV1SupportCluster = getClusterVersion();
+    const pipelineReference = getReferenceForModel(
+      isV1SupportCluster ? PipelineModel : PipelineModelV1Beta1,
+    );
+    const projectReference = getReferenceForModel(ProjectModel);
+
+    const isNamespaceExists = (namespaceName: string) => {
+      if (!rowData?.projectsLoaded) return false;
+      return rowData?.projects?.some(
+        (project) => project?.metadata?.name === namespaceName,
+      );
+    };
+
+    const nsExists = isNamespaceExists(namespace);
+
+    const rowCells: Record<string, RowCell> = {
+      [tableColumnInfo[0].id]: {
+        cell: nsExists ? (
           <ResourceLink
+            /* needs to be removed when we update console-extension.json */
             groupVersionKind={
               isV1SupportCluster
                 ? getGroupVersionKindForModel(PipelineModel)
@@ -76,45 +84,57 @@ const PipelineRunsForPipelinesRowK8s: FC<
               {name}
             </span>
           </Tooltip>
-        )}
-      </td>
-      {activeNamespace === ALL_NAMESPACES_KEY && (
-        <td className={tableColumnClasses[1]}>
-          {isNamespaceExists(namespace) ? (
-            <ResourceLink kind="Namespace" name={namespace} />
-          ) : (
-            <Tooltip content={t('Resource is deleted.')}>
-              <span>
-                <ResourceIcon kind={projectReference} />
-                {namespace}
-              </span>
-            </Tooltip>
-          )}
-        </td>
-      )}
-      <td className={tableColumnClasses[2]}>
-        {isNamespaceExists(namespace) ? (
+        ),
+        props: {
+          isStickyColumn: true,
+          hasRightBorder: true,
+          stickyMinWidth: '0',
+        },
+      },
+      [tableColumnInfo[1].id]: {
+        cell: nsExists ? (
+          <ResourceLink
+            groupVersionKind={getGroupVersionKindForModel(NamespaceModel)}
+            name={namespace}
+          />
+        ) : (
+          <Tooltip content={t('Resource is deleted.')}>
+            <span>
+              <ResourceIcon kind={projectReference} />
+              {namespace}
+            </span>
+          </Tooltip>
+        ),
+      },
+      [tableColumnInfo[2].id]: {
+        cell: nsExists ? (
           <Link to={`/k8s/ns/${namespace}/${pipelineReference}/${name}/Runs`}>
             {obj.total}
           </Link>
         ) : (
           <span>{obj.total}</span>
-        )}
-      </td>
-      <td className={tableColumnClasses[3]}>
-        {formatTime(obj.total_duration)}
-      </td>
-      <td className={tableColumnClasses[4]}>{formatTime(obj.avg_duration)}</td>
-      <td className={tableColumnClasses[5]}>{`${Math.round(
-        (100 * obj.succeeded) / obj.total,
-      )}%`}</td>
-      {!hideLastRunTime && (
-        <td className={tableColumnClasses[6]}>{`${formatTimeLastRunTime(
-          obj.last_runtime,
-        )}`}</td>
-      )}
-    </>
-  );
-};
+        ),
+      },
+      [tableColumnInfo[3].id]: {
+        cell: formatTime(obj.total_duration),
+      },
+      [tableColumnInfo[4].id]: {
+        cell: formatTime(obj.avg_duration),
+      },
+      [tableColumnInfo[5].id]: {
+        cell: `${Math.round((100 * obj.succeeded) / obj.total)}%`,
+      },
+      [tableColumnInfo[6].id]: {
+        cell: !rowData?.hideLastRunTime
+          ? formatTimeLastRunTime(obj.last_runtime)
+          : null,
+      },
+    };
 
-export default PipelineRunsForPipelinesRowK8s;
+    return columns.map(({ id }) => ({
+      id,
+      props: rowCells[id]?.props,
+      cell: rowCells[id]?.cell,
+    }));
+  });
+};

--- a/src/components/pipelines-overview/list-pages/PipelineRunsForRepositoriesList.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsForRepositoriesList.tsx
@@ -1,22 +1,20 @@
 import type { FC } from 'react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { EmptyState, EmptyStateVariant } from '@patternfly/react-core';
-import { sortable } from '@patternfly/react-table';
-import {
-  TableColumn,
-  VirtualizedTable,
-  useActiveColumns,
-} from '@openshift-console/dynamic-plugin-sdk';
-import PipelineRunsForRepositoriesRow from './PipelineRunsForRepositoriesRow';
+import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import { ConsoleDataView } from '@openshift-console/dynamic-plugin-sdk-internal';
 import {
   SummaryProps,
   sortByNumbers,
   sortByProperty,
   sortByTimestamp,
   sortTimeStrings,
-  listPageTableColumnClasses as tableColumnClasses,
 } from '../utils';
+import {
+  getPipelineRunsForRepositoriesDataViewRows,
+  tableColumnInfo,
+} from './PipelineRunsForRepositoriesRow';
+import { ALL_NAMESPACES_KEY } from '../../../consts';
 
 type PipelineRunsForRepositoriesListProps = {
   summaryData: SummaryProps[];
@@ -28,52 +26,53 @@ const PipelineRunsForRepositoriesList: FC<
   PipelineRunsForRepositoriesListProps
 > = ({ summaryData, summaryDataFiltered, loaded }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
-  const EmptyMsg = () => (
-    <EmptyState variant={EmptyStateVariant.lg} headingLevel="h4" titleText={t('No PipelineRuns found')}>
-    </EmptyState>
-  );
+  const [activeNamespace] = useActiveNamespace();
 
-  const plrColumns = useMemo<TableColumn<SummaryProps>[]>(
+  const columns = useMemo(
     () => [
       {
-        id: 'repoName',
+        id: tableColumnInfo[0].id,
         title: t('Repository'),
         sort: (summary, direction: 'asc' | 'desc') =>
           sortByProperty(summary, 'repoName', direction),
-        transforms: [sortable],
-        props: { className: tableColumnClasses[0] },
+        props: {
+          modifier: 'nowrap',
+          isStickyColumn: true,
+          hasRightBorder: true,
+          stickyMinWidth: '0',
+        },
       },
+      ...(activeNamespace === ALL_NAMESPACES_KEY
+        ? [
+            {
+              id: tableColumnInfo[1].id,
+              title: t('Project'),
+              sort: (summary, direction: 'asc' | 'desc') =>
+                sortByProperty(summary, 'namespace', direction),
+              props: { modifier: 'nowrap' },
+            },
+          ]
+        : []),
       {
-        id: 'namespace',
-        title: t('Project'),
-        sort: (summary, direction: 'asc' | 'desc') =>
-          sortByProperty(summary, 'namespace', direction),
-        transforms: [sortable],
-        props: { className: tableColumnClasses[1] },
-      },
-      {
-        id: 'total',
+        id: tableColumnInfo[2].id,
         title: t('Total Pipelineruns'),
         sort: 'total',
-        transforms: [sortable],
-        props: { className: tableColumnClasses[2] },
+        props: { modifier: 'nowrap' },
       },
       {
-        id: 'totalDuration',
+        id: tableColumnInfo[3].id,
         title: t('Total duration'),
         sort: (summary, direction: 'asc' | 'desc') =>
           sortTimeStrings(summary, 'total_duration', direction),
-        transforms: [sortable],
-        props: { className: tableColumnClasses[3] },
+        props: { modifier: 'nowrap' },
       },
       {
-        id: 'avgDuration',
+        id: tableColumnInfo[4].id,
         title: t('Average duration'),
         sort: (summary, direction: 'asc' | 'desc') =>
           sortTimeStrings(summary, 'avg_duration', direction),
-        transforms: [sortable],
         props: {
-          className: tableColumnClasses[4],
+          modifier: 'nowrap',
           info: {
             tooltip: t(
               'An average of the time taken to run PipelineRuns. The trending shown is based on the time range selected. This metric does not show runs that are running or pending.',
@@ -83,13 +82,12 @@ const PipelineRunsForRepositoriesList: FC<
         },
       },
       {
-        id: 'successRate',
+        id: tableColumnInfo[5].id,
         title: t('Success rate'),
         sort: (summary, direction: 'asc' | 'desc') =>
           sortByNumbers(summary, 'succeeded', direction),
-        transforms: [sortable],
         props: {
-          className: tableColumnClasses[5],
+          modifier: 'nowrap',
           info: {
             tooltip: t(
               'Success rate measure the % of successfully completed pipeline runs in relation to the total number of pipeline runs',
@@ -99,40 +97,26 @@ const PipelineRunsForRepositoriesList: FC<
         },
       },
       {
-        id: 'lastRunTime',
+        id: tableColumnInfo[6].id,
         title: t('Last run time'),
         sort: (summary, direction: 'asc' | 'desc') =>
           sortByTimestamp(summary, 'last_runtime', direction),
-        transforms: [sortable],
-        props: { className: tableColumnClasses[6] },
+        props: { modifier: 'nowrap' },
       },
     ],
-    [t],
+    [t, activeNamespace],
   );
 
-  const [columns] = useActiveColumns({
-    columns: plrColumns,
-    showNamespaceOverride: false,
-    columnManagementID: '',
-  });
-
-  const isEmptyData =
-    (!summaryDataFiltered || summaryDataFiltered.length === 0) &&
-    (!summaryData || summaryData.length === 0);
-
-  if (isEmptyData) {
-    return <EmptyMsg />;
-  }
-
   return (
-    <VirtualizedTable
+    <ConsoleDataView<SummaryProps>
+      label={t('PipelineRuns')}
       columns={columns}
-      Row={PipelineRunsForRepositoriesRow}
       data={summaryDataFiltered || summaryData}
       loaded={loaded}
       loadError={false}
-      unfilteredData={summaryData}
-      EmptyMsg={EmptyMsg}
+      getDataViewRows={getPipelineRunsForRepositoriesDataViewRows}
+      hideColumnManagement
+      hideNameLabelFilters
     />
   );
 };

--- a/src/components/pipelines-overview/list-pages/PipelineRunsForRepositoriesRow.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsForRepositoriesRow.tsx
@@ -1,58 +1,83 @@
-import type { FC } from 'react';
 import { Link } from 'react-router';
 import {
+  getGroupVersionKindForModel,
   ResourceLink,
-  RowProps,
-  useActiveNamespace,
 } from '@openshift-console/dynamic-plugin-sdk';
-import {
-  SummaryProps,
-  getReferenceForModel,
-  listPageTableColumnClasses as tableColumnClasses,
-} from '../utils';
+import type { ReactNode } from 'react';
+import { GetDataViewRows } from '@openshift-console/dynamic-plugin-sdk-internal/lib/api/internal-types';
 import { formatTime, formatTimeLastRunTime } from '../dateTime';
-import { ALL_NAMESPACES_KEY } from '../../../consts';
-import { RepositoryModel } from '../../../models';
+import { SummaryProps, getReferenceForModel } from '../utils';
+import { NamespaceModel, RepositoryModel } from '../../../models';
+
+type RowCell = { cell: ReactNode; props?: Record<string, unknown> };
 
 const repositoryReference = getReferenceForModel(RepositoryModel);
 
-const PipelineRunsForRepositoriesRow: FC<RowProps<SummaryProps>> = ({
-  obj,
-}) => {
-  const [activeNamespace] = useActiveNamespace();
-  const [namespace, name] = obj.group_value.split('/');
+export const tableColumnInfo = [
+  { id: 'repoName' },
+  { id: 'namespace' },
+  { id: 'total' },
+  { id: 'totalDuration' },
+  { id: 'avgDuration' },
+  { id: 'successRate' },
+  { id: 'lastRunTime' },
+];
 
-  return (
-    <>
-      <td className={tableColumnClasses[0]}>
-        <ResourceLink
-          kind={repositoryReference}
-          name={name}
-          namespace={namespace}
-        />
-      </td>
-      {activeNamespace === ALL_NAMESPACES_KEY && (
-        <td className={tableColumnClasses[1]}>
-          <ResourceLink kind="Namespace" name={namespace} />
-        </td>
-      )}
-      <td className={tableColumnClasses[2]}>
-        <Link to={`/k8s/ns/${namespace}/${repositoryReference}/${name}/Runs`}>
-          {obj.total}
-        </Link>
-      </td>
-      <td className={tableColumnClasses[3]}>
-        {formatTime(obj.total_duration)}
-      </td>
-      <td className={tableColumnClasses[4]}>{formatTime(obj.avg_duration)}</td>
-      <td className={tableColumnClasses[5]}>{`${Math.round(
-        (100 * obj.succeeded) / obj.total,
-      )}%`}</td>
-      <td className={tableColumnClasses[6]}>{`${formatTimeLastRunTime(
-        obj.last_runtime,
-      )}`}</td>
-    </>
-  );
+export const getPipelineRunsForRepositoriesDataViewRows: GetDataViewRows<
+  SummaryProps,
+  undefined
+> = (data, columns) => {
+  return data.map(({ obj }) => {
+    const [namespace, name] = obj.group_value.split('/');
+
+    const rowCells: Record<string, RowCell> = {
+      [tableColumnInfo[0].id]: {
+        cell: (
+          <ResourceLink
+            groupVersionKind={getGroupVersionKindForModel(RepositoryModel)}
+            name={name}
+            namespace={namespace}
+          />
+        ),
+        props: {
+          isStickyColumn: true,
+          hasRightBorder: true,
+          stickyMinWidth: '0',
+        },
+      },
+      [tableColumnInfo[1].id]: {
+        cell: (
+          <ResourceLink
+            groupVersionKind={getGroupVersionKindForModel(NamespaceModel)}
+            name={namespace}
+          />
+        ),
+      },
+      [tableColumnInfo[2].id]: {
+        cell: (
+          <Link to={`/k8s/ns/${namespace}/${repositoryReference}/${name}/Runs`}>
+            {obj.total}
+          </Link>
+        ),
+      },
+      [tableColumnInfo[3].id]: {
+        cell: formatTime(obj.total_duration),
+      },
+      [tableColumnInfo[4].id]: {
+        cell: formatTime(obj.avg_duration),
+      },
+      [tableColumnInfo[5].id]: {
+        cell: `${Math.round((100 * obj.succeeded) / obj.total)}%`,
+      },
+      [tableColumnInfo[6].id]: {
+        cell: formatTimeLastRunTime(obj.last_runtime),
+      },
+    };
+
+    return columns.map(({ id }) => ({
+      id,
+      props: rowCells[id]?.props,
+      cell: rowCells[id]?.cell,
+    }));
+  });
 };
-
-export default PipelineRunsForRepositoriesRow;

--- a/src/components/pipelines-overview/list-pages/PipelineRunsListPage.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsListPage.tsx
@@ -91,10 +91,20 @@ const PipelineRunsListPage: FC<PipelineRunsListPageProps> = ({
       90000,
     )
       .then((response) => {
+        const newSummaryData = (response?.summary || []) ?? [];
         setloaded(true);
         setPipelineRunsListError(undefined);
-        setSummaryData((response?.summary || []) ?? []);
-        setSummaryDataFiltered((response?.summary || []) ?? []);
+        setSummaryData(newSummaryData);
+        setSummaryDataFiltered(
+          searchText
+            ? newSummaryData.filter((summary) =>
+                summary.group_value
+                  .split('/')[1]
+                  .toLowerCase()
+                  .includes(searchText.toLowerCase()),
+              )
+            : newSummaryData,
+        );
       })
       .catch((e) => {
         if (e.name === 'AbortError') {
@@ -170,12 +180,8 @@ const PipelineRunsListPage: FC<PipelineRunsListPageProps> = ({
           />
         ) : (
           <>
-          {loaded && (
-            <Grid hasGutter className="pipeline-overview__listpage__grid">
-              <GridItem
-                span={9}
-                className="pipeline-overview__listpage__griditem"
-              >
+            <Grid hasGutter>
+              <GridItem span={3} rowSpan={1}>
                 {/* Lastrun Status is not provided by API  */}
                 {/* <StatusDropdown /> */}
                 <SearchInputField
@@ -184,7 +190,7 @@ const PipelineRunsListPage: FC<PipelineRunsListPageProps> = ({
                   handleNameChange={handleNameChange}
                 />
               </GridItem>
-              <GridItem span={3}>
+              <GridItem span={9} rowSpan={1}>
                 <ToggleGroup className="pf-v6-u-float-inline-end">
                   <ToggleGroupItem
                     text={t('Per Pipeline')}
@@ -200,10 +206,8 @@ const PipelineRunsListPage: FC<PipelineRunsListPageProps> = ({
                   />
                 </ToggleGroup>
               </GridItem>
-            </Grid>
-            )}
-            <Grid hasGutter>
-              <GridItem span={12}>
+
+              <GridItem rowSpan={1} span={12}>
                 {pageFlag === 1 ? (
                   <PipelineRunsForPipelinesList
                     summaryData={summaryData}

--- a/src/components/pipelines-overview/list-pages/PipelineRunsListPageK8s.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsListPageK8s.tsx
@@ -229,12 +229,6 @@ const PipelineRunsListPageK8s: FC<PipelineRunsListPageProps> = ({
     loadFormat: (v) => (v == 'perrepository' ? 2 : 1),
   });
 
-  // const handlePageChange = (pageNumber: number) => {
-  //   setloaded(false);
-  //   setSummaryData([]);
-  //   setSummaryDataFiltered([]);
-  //   setPageFlag(pageNumber);
-  // };
   const handleNameChange = (value: string) => {
     setSearchText(value);
   };
@@ -271,43 +265,18 @@ const PipelineRunsListPageK8s: FC<PipelineRunsListPageProps> = ({
           />
         ) : (
           <>
-            {!loadingPipelineRunsMetricsCount &&
-              !loadingPipelineRunsMetricsSum && (
-                <Grid hasGutter className="pipeline-overview__listpage__grid">
-                  <GridItem
-                    span={9}
-                    className="pipeline-overview__listpage__griditem"
-                  >
-                    {/* Lastrun Status is not provided by API  */}
-                    {/* <StatusDropdown /> */}
-                    <SearchInputField
-                      searchText={searchText}
-                      pageFlag={pageFlag}
-                      handleNameChange={handleNameChange}
-                    />
-                  </GridItem>
-                  {/*
-          Since Pipeline metrics for PAC is not available, commenting this
-          <GridItem span={3}>
-            <ToggleGroup className="pipeline-overview__listpage__button">
-              <ToggleGroupItem
-                text={t('Per Pipeline')}
-                buttonId="pipelineButton"
-                isSelected={pageFlag === 1}
-                onChange={() => handlePageChange(1)}
-              />
-              <ToggleGroupItem
-                text={t('Per Repository')}
-                buttonId="repositoryButton"
-                isSelected={pageFlag === 2}
-                onChange={() => handlePageChange(2)}
-              />
-            </ToggleGroup>
-          </GridItem> */}
-                </Grid>
-              )}
             <Grid hasGutter>
-              <GridItem span={12}>
+              <GridItem span={6} xl={3} rowSpan={1}>
+                {/* Lastrun Status is not provided by API  */}
+                {/* <StatusDropdown /> */}
+                <SearchInputField
+                  searchText={searchText}
+                  pageFlag={pageFlag}
+                  handleNameChange={handleNameChange}
+                />
+              </GridItem>
+
+              <GridItem span={12} rowSpan={1}>
                 {pageFlag === 1 ? (
                   <PipelineRunsForPipelinesListK8s
                     summaryData={summaryDataK8s}

--- a/src/components/pipelines-overview/utils.ts
+++ b/src/components/pipelines-overview/utils.ts
@@ -43,16 +43,6 @@ export type mainDataType = {
   summary?: SummaryProps;
 };
 
-export const listPageTableColumnClasses = [
-  '', //name
-  '', //namespace
-  'pf-v6-m-hidden pf-v6-m-visible-on-md', //total plr
-  'pf-v6-m-hidden pf-v6-m-visible-on-md', //total duration
-  'pf-v6-m-hidden pf-v6-m-visible-on-xl', //avg duration
-  'pf-v6-m-hidden pf-v6-m-visible-on-xl', //success rate
-  'pf-v6-m-hidden pf-v6-m-visible-on-xl', //last run time
-];
-
 export const TimeRangeOptions = () => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
   return {


### PR DESCRIPTION
## Summary

- **Migrate from VirtualizedTable to ConsoleDataView**: Replaced `VirtualizedTable` with `ConsoleDataView` across all PipelineRuns list pages (per-pipeline and per-repository views, both PAC and K8s variants). Converted row components from `RowProps` components to `GetDataViewRows` functions.
- **Sticky first column**: Made the first column (Pipeline/Repository name) sticky with a right border in both column headers and row cells.
- **Column nowrap**: Added `modifier: 'nowrap'` to all columns to prevent text wrapping in headers.
- **Info tooltips on columns**: Added `info` tooltips on "Average duration" and "Success rate" column headers explaining the metrics.
- **Namespace-aware columns**: Project column is now conditionally shown only in all-namespaces view instead of always being present.
- **Remove manual empty state**: Removed custom `EmptyState`/`EmptyMsg` handling — `ConsoleDataView` handles empty and loading states internally.
- **Consistent chart tick label font sizes**: Added explicit `fontSize: 12` to StatusCard chart tick labels that were previously missing it, ensuring consistency with other charts.
- **Extract chart layout constants**: Replaced magic numbers in chart height calculations (`bottomPad`, aspect ratio clamping) with named constants (`BOTTOM_PAD_DEFAULT`, `BOTTOM_PAD_ROTATED`, `CHART_ASPECT_RATIO`, etc.) across all 4 bar chart files.
- **Duration card cleanup**: Removed redundant `pf-v6-u-font-size-*` utility classes from the Duration card that were overriding PF6 defaults.
- **Search input cleanup**: Removed inline sizing class from `SearchInput`.
- **Filter fix (PipelineRunsListPage)**: Fixed search filter not being re-applied when time range changes and new data loads while search text is active.
- **Dead code removal**: Removed unused `listPageTableColumnClasses` from utils.

## Screen-recordings and screenshots For Tekton Results Pipeline Overview Page in XL and XS sizes

### Error Banners
<img width="1933" height="925" alt="Results_Error_banner_PO_XL" src="https://github.com/user-attachments/assets/fb731d7f-c463-4a3b-87b1-fd94702ea7c0" />

https://github.com/user-attachments/assets/86484796-c709-412d-9179-71ff4bab674d

### Loaders

https://github.com/user-attachments/assets/608206e1-2b33-4e69-8393-34b3ed070862

https://github.com/user-attachments/assets/6bb6507c-4333-4977-b4f5-634956dfd0ac

### Normal ConsoleDataView Operation

https://github.com/user-attachments/assets/5a1b6bb8-3661-4534-b309-fe524f51a118

## Screen-recordings and screenshots For Tekton Results Pipeline Metrics Page in XL and XS sizes

https://github.com/user-attachments/assets/6bc0ee1d-171e-4ed0-bb62-00aed4565fca

https://github.com/user-attachments/assets/76080c8c-ac77-41da-a9eb-c6f2e45bf5d9

## Screen-recordings and screenshots For Prometheus Pipeline Overview Page in XL and XS sizes

https://github.com/user-attachments/assets/e43dc071-2041-4789-9571-ad78fad32a59

https://github.com/user-attachments/assets/632b6260-0d17-4016-870d-077a158e96a3

## Screen-recordings and screenshots For Prometheus Pipeline Metrics Page in XL and XS sizes

https://github.com/user-attachments/assets/6cbd7ac5-6092-4a58-a1fb-c3bbedc6f86d

https://github.com/user-attachments/assets/286fc918-84ad-49ff-b0e8-8c42f21bf394


