### PR TITLE
SRVKP-11566: Removed LoadingInline wrapper and updated the LoadingBox component

### DIFF
--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -15,10 +15,7 @@ export const Loading: FC<LoadingProps> = ({
   ariaLabel,
 }) => (
   <Bullseye data-test="loading-indicator" className={className}>
-    <Spinner size={size} isInline={isInline} aria-label={ariaLabel} />
+    <Spinner size={size ?? 'lg'} isInline={isInline} aria-label={ariaLabel} />
   </Bullseye>
 );
 Loading.displayName = 'Loading';
-
-export const LoadingInline: FC = () => <Loading isInline={true} />;
-LoadingInline.displayName = 'LoadingInline';

--- a/src/components/common/ResourceDropdown.tsx
+++ b/src/components/common/ResourceDropdown.tsx
@@ -21,7 +21,7 @@ import {
   SearchInput,
   Divider,
 } from '@patternfly/react-core';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 
 type DropdownItemProps = {
   name: string;
@@ -29,11 +29,7 @@ type DropdownItemProps = {
   resource: K8sResourceKind;
 };
 
-const DropdownItem: FC<DropdownItemProps> = ({
-  name,
-  namespace,
-  resource,
-}) => {
+const DropdownItem: FC<DropdownItemProps> = ({ name, namespace, resource }) => {
   return (
     <span className="co-resource-item">
       <span className="">
@@ -151,7 +147,7 @@ const ResourceDropdown: FC<ResourceDropdownProps> = (props) => {
     loaded ? (
       <span className="btn-dropdown__item--placeholder">{placeholder}</span>
     ) : (
-      <LoadingInline />
+      <Loading isInline={true} />
     ),
   );
   const [isOpen, setIsOpen] = useState(false);
@@ -263,13 +259,13 @@ const ResourceDropdown: FC<ResourceDropdownProps> = (props) => {
   // Handle data updates and initial load
   useEffect(() => {
     if (!loaded && !loadError) {
-      setTitle(<LoadingInline />);
+      setTitle(<Loading isInline={true} />);
       return;
     }
 
     if (loadError) {
       setTitle(
-        <span className="cos-error-title">
+        <span className="pf-v6-u-text-color-status-danger">
           {t(
             'plugin__pipelines-console-plugin~Error loading - {{placeholder}}',
             { placeholder },

--- a/src/components/common/StorageClassDropdown.tsx
+++ b/src/components/common/StorageClassDropdown.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode, MouseEvent, Ref } from 'react';
 import { Component } from 'react';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 import _ from 'lodash';
 import {
   FormGroup,
@@ -105,7 +105,7 @@ export class StorageClassDropdownInnerWithTranslation extends Component<
     items: {},
     name: this.props.name,
     selectedKey: this.props.selectedKey,
-    title: <LoadingInline />,
+    title: <Loading isInline={true} />,
     defaultClass: this.props.defaultClass,
     isOpen: false,
     filterValue: '',
@@ -149,7 +149,7 @@ export class StorageClassDropdownInnerWithTranslation extends Component<
     if (loadError) {
       this.setState({
         title: (
-          <div className="cos-error-title">
+          <div className="pf-v6-u-text-color-status-danger">
             {t('plugin__pipelines-console-plugin~Error loading {{desc}}', {
               desc: nextProps.desc,
             })}
@@ -281,7 +281,7 @@ export class StorageClassDropdownInnerWithTranslation extends Component<
 
     // Only show the dropdown if 'no storage class' is not the only option which depends on defaultClass
     const itemsAvailableToShow = defaultClass || _.size(this.state.items) > 1;
-    
+
     const toggle = (toggleRef: Ref<MenuToggleElement>) => (
       <MenuToggle
         ref={toggleRef}

--- a/src/components/common/button-bar.jsx
+++ b/src/components/common/button-bar.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import * as PropTypes from 'prop-types';
 import { Alert, AlertGroup } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { LoadingInline } from '../status/status-box';
+import { Loading } from '../Loading';
 
 const injectDisabled = (children, disabled) => {
   return Children.map(children, (c) => {
@@ -67,7 +67,7 @@ export const ButtonBar = ({
         {successMessage && <SuccessMessage message={successMessage} />}
         {errorMessage && <ErrorMessage message={errorMessage} />}
         {injectDisabled(children, inProgress)}
-        {inProgress && <LoadingInline />}
+        {inProgress && <Loading isInline={true} />}
         {infoMessage && <InfoMessage message={infoMessage} />}
       </AlertGroup>
     </div>

--- a/src/components/logs/LogSnippetFromPod.tsx
+++ b/src/components/logs/LogSnippetFromPod.tsx
@@ -2,7 +2,7 @@ import type { ReactNode, FC } from 'react';
 import { useState, useEffect } from 'react';
 import { Alert } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 import { consoleFetchText } from '@openshift-console/dynamic-plugin-sdk';
 import { PodModel } from '../../models';
 import { resourceURL } from '../utils/k8s-utils';
@@ -87,7 +87,7 @@ const LogSnippetFromPod: FC<LogSnippetFromPodProps> = ({
   }
 
   if (!logSnippet) {
-    return <LoadingInline />;
+    return <Loading isInline={true} />;
   }
 
   return <>{children(logSnippet)}</>;

--- a/src/components/logs/Logs.tsx
+++ b/src/components/logs/Logs.tsx
@@ -11,7 +11,7 @@ import { ContainerSpec, ContainerStatus, PodKind } from '../../types';
 import { PodModel } from '../../models';
 import { resourceURL } from '../utils/k8s-utils';
 import { containerToLogSourceStatus } from '../utils/pipeline-utils';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 import {
   getMultiClusterLogsUrl,
   getMultiClusterLogsStreamPath,
@@ -428,7 +428,7 @@ const Logs: FC<LogsProps> = ({
             </span>
             {stillFetching ? (
               <span data-test-id="loading-indicator">
-                <LoadingInline />
+                <Loading isInline={true} />
               </span>
             ) : null}
           </Banner>

--- a/src/components/logs/LogsWrapperComponent.tsx
+++ b/src/components/logs/LogsWrapperComponent.tsx
@@ -18,7 +18,7 @@ import { PodKind, TaskRunKind } from '../../types';
 import { MultiStreamLogs } from './MultiStreamLogs';
 import { TektonTaskRunLog } from './TektonTaskRunLog';
 import { useFullscreen } from './fullscreen';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 import { TektonResourceLabel } from '../../consts';
 import { getMultiClusterPods } from '../utils/multi-cluster-api';
 import { usePoll } from '../pipelines-metrics/poll-hook';
@@ -175,7 +175,7 @@ const LogsWrapperComponent: FC<
               <span className="pf-v6-l-flex pf-m-row pf-m-gap-sm pf-m-align-items-center">
                 <DownloadIcon />
                 <span>{downloadAllLabel || t('Download all')}</span>
-                {downloadAllStatus && <LoadingInline />}
+                {downloadAllStatus && <Loading isInline={true} />}
               </span>
             </Button>
             <div>|</div>

--- a/src/components/logs/TektonTaskRunLog.tsx
+++ b/src/components/logs/TektonTaskRunLog.tsx
@@ -4,7 +4,7 @@ import { LogViewer } from '@patternfly/react-log-viewer';
 import { HttpError } from '@openshift-console/dynamic-plugin-sdk/lib/utils/error/http-error';
 import { TaskRunKind } from '../../types';
 import { TektonResourceLabel } from '../../consts';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 import { useTRTaskRunLog } from '../hooks/useTektonResult';
 import { Banner } from '@patternfly/react-core';
 import './TektonTaskRunLog.scss';
@@ -68,7 +68,7 @@ export const TektonTaskRunLog: FC<TektonTaskRunLogProps> = ({
               </span>
               {!trLoaded && !errorMessage ? (
                 <span data-test-id="loading-indicator">
-                  <LoadingInline />
+                  <Loading isInline={true} />
                 </span>
               ) : null}
             </Banner>

--- a/src/components/pipelineRuns-details/PipelineRunVisualization.tsx
+++ b/src/components/pipelineRuns-details/PipelineRunVisualization.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { usePipelineFromPipelineRun } from '../hooks/usePipelineFromPipelineRun';
 import { useTaskRuns } from '../hooks/useTaskRuns';
 import { ComputedStatus, PipelineKind, PipelineRunKind } from '../../types';
-import { LoadingInline } from '../Loading';
+import { LoadingBox } from '../status/status-box';
 import PipelineVisualization from '../pipelines-details/PipelineVisualization';
 import { pipelineRunFilterReducer } from '../utils/pipeline-filter-reducer';
 import './PipelineRunVisualization.scss';
@@ -37,10 +37,10 @@ const PipelineRunVisualization: FC<PipelineRunVisualizationProps> = ({
   /* this needs decoupling */
   const taskRunsLoaded = k8sLoaded || trLoaded;
   const pipeline: PipelineKind = usePipelineFromPipelineRun(pipelineRun);
-  if (!pipeline) {
+  if (!pipeline || !taskRunsLoaded) {
     return (
       <div className="pipeline-plr-loader">
-        <LoadingInline />
+        <LoadingBox />
       </div>
     );
   }

--- a/src/components/pipelines-list/status/LinkedPipelineRunTaskStatus.tsx
+++ b/src/components/pipelines-list/status/LinkedPipelineRunTaskStatus.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 import { PipelineRunKind, TaskRunKind } from '../../../types';
 import { PipelineBars, PipelineBarsForTaskRunsStatus } from './PipelineBars';
-import { LoadingInline } from '../../Loading';
+import { Loading } from '../../Loading';
 import { PipelineRunModel } from '../../../models';
 import { getReferenceForModel } from '../../pipelines-overview/utils';
 import { TaskStatus } from '../../utils/pipeline-augment';
@@ -51,7 +51,7 @@ const LinkedPipelineRunTaskStatus: FC<LinkedPipelineRunTaskStatusProps> = ({
     ) : taskRunsLoaded && taskRuns?.length === 0 && !taskRunStatusObj ? (
       <>{'-'}</>
     ) : (
-      <LoadingInline />
+      <Loading isInline={true} />
     );
 
   if (pipelineRun.metadata?.name && pipelineRun.metadata?.namespace) {

--- a/src/components/pipelines-list/status/PipelineRunStatus.tsx
+++ b/src/components/pipelines-list/status/PipelineRunStatus.tsx
@@ -5,7 +5,7 @@ import { PipelineRunModel } from '../../../models';
 import { PipelineRunKind, TaskRunKind } from '../../../types';
 import PipelineResourceStatus from './PipelineResourceStatus';
 import StatusPopoverContent from './StatusPopoverContent';
-import { LoadingInline } from '../../Loading';
+import { Loading } from '../../Loading';
 import { getPLRLogSnippet } from '../../logs/pipelineRunLogSnippet';
 import { getReferenceForModel } from '../../pipelines-overview/utils';
 import { useMultiClusterProxyService } from '../../hooks/useMultiClusterProxyService';
@@ -25,7 +25,9 @@ const PipelineRunStatus: FC<PipelineRunStatusProps> = ({
   taskRunsLoaded,
 }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
-  const { isResourceManagedByKueue } = useMultiClusterProxyService({ managedBy: pipelineRun?.spec?.managedBy });
+  const { isResourceManagedByKueue } = useMultiClusterProxyService({
+    managedBy: pipelineRun?.spec?.managedBy,
+  });
   const logPath = `/k8s/ns/${
     pipelineRun?.metadata.namespace
   }/${getReferenceForModel(PipelineRunModel)}/${
@@ -43,7 +45,7 @@ const PipelineRunStatus: FC<PipelineRunStatusProps> = ({
         />
       </PipelineResourceStatus>
     ) : (
-      <LoadingInline />
+      <Loading isInline={true} />
     )
   ) : (
     <>{'-'}</>

--- a/src/components/pipelines-metrics/PipelinesAverageDuration.tsx
+++ b/src/components/pipelines-metrics/PipelinesAverageDuration.tsx
@@ -15,7 +15,7 @@ import {
 } from '@patternfly/react-charts/victory';
 import { Card, CardBody, CardTitle, Alert } from '@patternfly/react-core';
 import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 import {
   formatDate,
   getDropDownDate,
@@ -74,7 +74,7 @@ const PipelinesAverageDuration: FC<PipelinesAverageDurationProps> = ({
   interval,
   parentName,
   namespace,
-  kind
+  kind,
 }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
   const isDevConsoleProxyAvailable = useFlag(FLAGS.DEVCONSOLE_PROXY);
@@ -93,10 +93,10 @@ const PipelinesAverageDuration: FC<PipelinesAverageDurationProps> = ({
   };
   const [chartWidth, setChartWidth] = useState(0);
   const chartContainerRef = useCallback((node: HTMLDivElement | null) => {
-      if (node) {
-        setChartWidth(node.clientWidth);
-      }
-    }, []);
+    if (node) {
+      setChartWidth(node.clientWidth);
+    }
+  }, []);
 
   if (namespace == ALL_NAMESPACES_KEY) {
     namespace = '-';
@@ -245,25 +245,31 @@ const PipelinesAverageDuration: FC<PipelinesAverageDurationProps> = ({
   }
   if (showLabel) bottomPad += 15;
   // Calculating height using this formula with the help of width and bottom padding
-  const chartHeight = 10 + Math.max(50, Math.min(100, Math.round(chartWidth / 5))) + bottomPad;
+  const chartHeight =
+    10 + Math.max(50, Math.min(100, Math.round(chartWidth / 5))) + bottomPad;
 
   return (
     <>
-     <Card
-        className={classNames('pipeline-overview__min-width-full pipeline-overview__overflow-hidden pf-v6-u-display-flex pf-v6-u-flex-direction-column', {
-          'pipeline-overview__number-of-plr-card': !pipelineAverageDurationError,
-          'card-border': bordered,
-          'pf-v6-u-h-100': !pipelineAverageDurationError,
-        })}
+      <Card
+        className={classNames(
+          'pipeline-overview__min-width-full pipeline-overview__overflow-hidden pf-v6-u-display-flex pf-v6-u-flex-direction-column',
+          {
+            'pipeline-overview__number-of-plr-card':
+              !pipelineAverageDurationError,
+            'card-border': bordered,
+            'pf-v6-u-h-100': !pipelineAverageDurationError,
+          },
+        )}
       >
         <CardTitle className="pipeline-overview__number-of-plr-card__title">
           <span>{t('Average duration')}</span>
         </CardTitle>
-         <CardBody
-            className={classNames({
-              'pf-v6-u-flex-1 pipeline-overview__min-height-0 pf-v6-u-display-flex pf-v6-u-flex-direction-column pf-v6-u-justify-content-flex-end pf-v6-u-align-items-flex-start pf-v6-u-p-0': !pipelineAverageDurationError,
-            })}
-          >
+        <CardBody
+          className={classNames({
+            'pf-v6-u-flex-1 pipeline-overview__min-height-0 pf-v6-u-display-flex pf-v6-u-flex-direction-column pf-v6-u-justify-content-flex-end pf-v6-u-align-items-flex-start pf-v6-u-p-0':
+              !pipelineAverageDurationError,
+          })}
+        >
           {pipelineAverageDurationError ? (
             <Alert
               variant="danger"
@@ -274,7 +280,9 @@ const PipelinesAverageDuration: FC<PipelinesAverageDurationProps> = ({
           ) : (
             <div
               ref={chartContainerRef}
-              className={`pf-v6-u-w-100 ${chartWidth > 0 ? 'pf-v6-u-h-100' : ''}`}
+              className={`pf-v6-u-w-100 ${
+                chartWidth > 0 ? 'pf-v6-u-h-100' : ''
+              }`}
             >
               {loaded ? (
                 <Chart
@@ -314,7 +322,7 @@ const PipelinesAverageDuration: FC<PipelinesAverageDurationProps> = ({
                 </Chart>
               ) : (
                 <div className="pf-v6-u-display-flex pf-v6-u-align-items-center pf-v6-u-justify-content-center pf-v6-u-h-100 pf-v6-u-p-md pf-v6-u-p-0-on-md">
-                  <LoadingInline />
+                  <Loading isInline={true} />
                 </div>
               )}
             </div>

--- a/src/components/pipelines-metrics/PipelinesAverageDurationK8s.tsx
+++ b/src/components/pipelines-metrics/PipelinesAverageDurationK8s.tsx
@@ -22,7 +22,7 @@ import {
   parsePrometheusDuration,
 } from '../pipelines-overview/dateTime';
 import { ALL_NAMESPACES_KEY } from '../../consts';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 import {
   usePipelineMetricsForAllNamespacePoll,
   usePipelineMetricsForNamespaceForPipelinePoll,
@@ -97,10 +97,10 @@ const PipelinesAverageDurationK8s: FC<PipelinesAverageDurationProps> = ({
   };
   const [chartWidth, setChartWidth] = useState(0);
   const chartContainerRef = useCallback((node: HTMLDivElement | null) => {
-      if (node) {
-        setChartWidth(node.clientWidth);
-      }
-    }, []);
+    if (node) {
+      setChartWidth(node.clientWidth);
+    }
+  }, []);
 
   const [tickValues, type] = getXaxisValues(timespan);
   const [averageDurationError, setAverageDurationError] = useState<
@@ -305,7 +305,8 @@ const PipelinesAverageDurationK8s: FC<PipelinesAverageDurationProps> = ({
   }
   if (showLabel) bottomPad += 15;
   // Calculating height using this formula with the help of width and bottom padding
-  const chartHeight = 10 + Math.max(50, Math.min(100, Math.round(chartWidth / 5))) + bottomPad;
+  const chartHeight =
+    10 + Math.max(50, Math.min(100, Math.round(chartWidth / 5))) + bottomPad;
 
   return (
     <>
@@ -335,7 +336,9 @@ const PipelinesAverageDurationK8s: FC<PipelinesAverageDurationProps> = ({
           ) : (
             <div
               ref={chartContainerRef}
-              className={`pf-v6-u-w-100 ${chartWidth > 0 ? 'pf-v6-u-h-100' : ''}`}
+              className={`pf-v6-u-w-100 ${
+                chartWidth > 0 ? 'pf-v6-u-h-100' : ''
+              }`}
             >
               {!averageDurationLoading ? (
                 <Chart
@@ -375,7 +378,7 @@ const PipelinesAverageDurationK8s: FC<PipelinesAverageDurationProps> = ({
                 </Chart>
               ) : (
                 <div className="pf-v6-u-display-flex pf-v6-u-align-items-center pf-v6-u-justify-content-center pf-v6-u-h-100 pf-v6-u-p-md pf-v6-u-p-0-on-md">
-                  <LoadingInline />
+                  <Loading isInline={true} />
                 </div>
               )}
             </div>

--- a/src/components/pipelines-overview/PipelineRunsDurationCard.tsx
+++ b/src/components/pipelines-overview/PipelineRunsDurationCard.tsx
@@ -22,7 +22,7 @@ import { getResultsSummary } from '../utils/summary-api';
 import { DataType, FLAGS } from '../../types';
 import { ALL_NAMESPACES_KEY } from '../../consts';
 import { formatTime, getDropDownDate } from './dateTime';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 
 import './PipelinesOverview.scss';
 
@@ -113,9 +113,12 @@ const PipelinesRunsDurationCard: FC<PipelinesRunsDurationProps> = ({
   return (
     <>
       <Card
-        className={classNames('pf-v6-u-h-100 pipeline-overview__min-width-full pf-v6-u-font-size-lg', {
-          'card-border': bordered,
-        })}
+        className={classNames(
+          'pf-v6-u-h-100 pipeline-overview__min-width-full pf-v6-u-font-size-lg',
+          {
+            'card-border': bordered,
+          },
+        )}
       >
         <CardTitle>
           <span>{t('Duration')}</span>
@@ -149,7 +152,7 @@ const PipelinesRunsDurationCard: FC<PipelinesRunsDurationProps> = ({
                       '-'
                     )
                   ) : (
-                    <LoadingInline />
+                    <Loading isInline={true} />
                   )}
                 </GridItem>
               </Grid>
@@ -171,7 +174,7 @@ const PipelinesRunsDurationCard: FC<PipelinesRunsDurationProps> = ({
                       '-'
                     )
                   ) : (
-                    <LoadingInline />
+                    <Loading isInline={true} />
                   )}
                 </GridItem>
               </Grid>
@@ -193,7 +196,7 @@ const PipelinesRunsDurationCard: FC<PipelinesRunsDurationProps> = ({
                       '-'
                     )
                   ) : (
-                    <LoadingInline />
+                    <Loading isInline={true} />
                   )}
                 </GridItem>
               </Grid>

--- a/src/components/pipelines-overview/PipelineRunsDurationCardK8s.tsx
+++ b/src/components/pipelines-overview/PipelineRunsDurationCardK8s.tsx
@@ -32,7 +32,7 @@ import {
 } from '../pipelines-metrics/hooks';
 import { MetricsQueryPrefix, PipelineQuery } from '../pipelines-metrics/utils';
 import { getXaxisValues } from './dateTime';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 
 import './PipelinesOverview.scss';
 
@@ -53,8 +53,9 @@ const PipelineRunsDurationCardK8s: FC<PipelinesRunsDurationProps> = ({
   bordered,
 }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
-  const [pipelineRunsDurationError, setPipelineRunsDurationError] =
-    useState<string | null>(null);
+  const [pipelineRunsDurationError, setPipelineRunsDurationError] = useState<
+    string | null
+  >(null);
 
   const [
     totalPipelineRunsCountData,
@@ -185,9 +186,12 @@ const PipelineRunsDurationCardK8s: FC<PipelinesRunsDurationProps> = ({
   return (
     <>
       <Card
-        className={classNames('pf-v6-u-h-100 pipeline-overview__min-width-full pf-v6-u-font-size-lg', {
-          'card-border': bordered,
-        })}
+        className={classNames(
+          'pf-v6-u-h-100 pipeline-overview__min-width-full pf-v6-u-font-size-lg',
+          {
+            'card-border': bordered,
+          },
+        )}
       >
         <CardTitle className="pf-v6-u-font-size-xl">
           <span>{t('Duration')}</span>
@@ -203,10 +207,7 @@ const PipelineRunsDurationCardK8s: FC<PipelinesRunsDurationProps> = ({
             />
           ) : (
             <>
-              <Grid
-                hasGutter
-                className="pf-v6-u-mb-sm pf-v6-u-font-size-lg"
-              >
+              <Grid hasGutter className="pf-v6-u-mb-sm pf-v6-u-font-size-lg">
                 <GridItem span={9} className="pf-v6-u-mb-sm">
                   <span className="pf-v6-u-font-size-lg">
                     <MonitoringIcon className="pf-v6-u-mr-sm" />
@@ -218,21 +219,16 @@ const PipelineRunsDurationCardK8s: FC<PipelinesRunsDurationProps> = ({
                   className="pf-v6-u-text-align-end pf-v6-u-font-size-lg pipeline-overview__chart-color-blue"
                 >
                   {loadingPipelineRunsCount ? (
-                    <LoadingInline />
+                    <Loading isInline={true} />
                   ) : (
                     averageDuration
                   )}
                 </GridItem>
               </Grid>
-              <Grid
-                hasGutter
-                className="pf-v6-u-mb-sm pf-v6-u-font-size-lg"
-              >
+              <Grid hasGutter className="pf-v6-u-mb-sm pf-v6-u-font-size-lg">
                 <GridItem span={9} className="pf-v6-u-mb-sm">
                   <span className="pf-v6-u-font-size-lg">
-                    <InfoCircleIcon
-                      className="pf-v6-u-mr-sm pipeline-overview__chart-color-blue"
-                    />
+                    <InfoCircleIcon className="pf-v6-u-mr-sm pipeline-overview__chart-color-blue" />
                     {t('Maximum')}
                   </span>
                 </GridItem>
@@ -240,7 +236,7 @@ const PipelineRunsDurationCardK8s: FC<PipelinesRunsDurationProps> = ({
                   span={3}
                   className="pf-v6-u-text-align-end pf-v6-u-font-size-lg pipeline-overview__chart-color-blue"
                 >
-                  {loadingPipelineRunsCount ? <LoadingInline /> : '-'}
+                  {loadingPipelineRunsCount ? <Loading isInline={true} /> : '-'}
                 </GridItem>
               </Grid>
               <Grid hasGutter className="pf-v6-u-font-size-lg">
@@ -255,7 +251,7 @@ const PipelineRunsDurationCardK8s: FC<PipelinesRunsDurationProps> = ({
                   className="pf-v6-u-text-align-end pf-v6-u-font-size-lg pipeline-overview__chart-color-blue"
                 >
                   {loadingPipelineRunsDuration ? (
-                    <LoadingInline />
+                    <Loading isInline={true} />
                   ) : (
                     totalPipelineRunsDuration ?? '-'
                   )}

--- a/src/components/pipelines-overview/PipelineRunsNumbersChart.tsx
+++ b/src/components/pipelines-overview/PipelineRunsNumbersChart.tsx
@@ -27,7 +27,7 @@ import { getResultsSummary } from '../utils/summary-api';
 import { DataType, FLAGS, SummaryResponse } from '../../types';
 import { ALL_NAMESPACES_KEY } from '../../consts';
 import { getFilter, useInterval } from './utils';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 
 interface PipelinesRunsNumbersChartProps {
   namespace?: string;
@@ -241,23 +241,28 @@ const PipelinesRunsNumbersChart: FC<PipelinesRunsNumbersChartProps> = ({
   }
   if (showLabel) bottomPad += 15;
   // Calculating height using this formula with the help of width and bottom padding
-  const chartHeight = 10 + Math.max(50, Math.min(100, Math.round(chartWidth / 5))) + bottomPad;
+  const chartHeight =
+    10 + Math.max(50, Math.min(100, Math.round(chartWidth / 5))) + bottomPad;
 
   return (
     <>
       <Card
-        className={classNames('pipeline-overview__min-width-full pipeline-overview__overflow-hidden pf-v6-u-display-flex pf-v6-u-flex-direction-column', {
-          'pipeline-overview__number-of-plr-card': !pipelineRunsChartError,
-          'card-border': bordered,
-          'pf-v6-u-h-100': !pipelineRunsChartError,
-        })}
+        className={classNames(
+          'pipeline-overview__min-width-full pipeline-overview__overflow-hidden pf-v6-u-display-flex pf-v6-u-flex-direction-column',
+          {
+            'pipeline-overview__number-of-plr-card': !pipelineRunsChartError,
+            'card-border': bordered,
+            'pf-v6-u-h-100': !pipelineRunsChartError,
+          },
+        )}
       >
         <CardTitle className="pf-v6-u-pb-0">
           <span>{t('Number of PipelineRuns')}</span>
         </CardTitle>
         <CardBody
           className={classNames({
-            'pf-v6-u-flex-1 pipeline-overview__min-height-0 pf-v6-u-display-flex pf-v6-u-flex-direction-column pf-v6-u-justify-content-flex-end pf-v6-u-align-items-flex-start pf-v6-u-p-0': !pipelineRunsChartError,
+            'pf-v6-u-flex-1 pipeline-overview__min-height-0 pf-v6-u-display-flex pf-v6-u-flex-direction-column pf-v6-u-justify-content-flex-end pf-v6-u-align-items-flex-start pf-v6-u-p-0':
+              !pipelineRunsChartError,
           })}
         >
           {pipelineRunsChartError ? (
@@ -270,7 +275,9 @@ const PipelinesRunsNumbersChart: FC<PipelinesRunsNumbersChartProps> = ({
           ) : (
             <div
               ref={chartContainerRef}
-              className={`pf-v6-u-w-100 ${chartWidth > 0 ? 'pf-v6-u-h-100' : ''}`}
+              className={`pf-v6-u-w-100 ${
+                chartWidth > 0 ? 'pf-v6-u-h-100' : ''
+              }`}
             >
               {loaded ? (
                 <Chart
@@ -306,7 +313,7 @@ const PipelinesRunsNumbersChart: FC<PipelinesRunsNumbersChartProps> = ({
                 </Chart>
               ) : (
                 <div className="pf-v6-u-display-flex pf-v6-u-align-items-center pf-v6-u-justify-content-center pf-v6-u-h-100 pf-v6-u-p-md pf-v6-u-p-0-on-md">
-                  <LoadingInline />
+                  <Loading isInline={true} />
                 </div>
               )}
             </div>

--- a/src/components/pipelines-overview/PipelineRunsNumbersChartK8s.tsx
+++ b/src/components/pipelines-overview/PipelineRunsNumbersChartK8s.tsx
@@ -32,7 +32,7 @@ import {
   PipelineQuery,
   adjustToStartOfWeek,
 } from '../pipelines-metrics/utils';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 
 interface PipelinesRunsNumbersChartProps {
   namespace?: string;
@@ -252,7 +252,8 @@ const PipelineRunsNumbersChartK8s: FC<PipelinesRunsNumbersChartProps> = ({
   }
   if (showLabel) bottomPad += 15;
   // Calculating height using this formula with the help of width and bottom padding
-  const chartHeight = 10 + Math.max(50, Math.min(100, Math.round(chartWidth / 5))) + bottomPad;
+  const chartHeight =
+    10 + Math.max(50, Math.min(100, Math.round(chartWidth / 5))) + bottomPad;
 
   useEffect(() => {
     const hasNonAbortError =
@@ -268,7 +269,8 @@ const PipelineRunsNumbersChartK8s: FC<PipelinesRunsNumbersChartProps> = ({
     <>
       <Card
         className={classNames({
-          'pf-v6-u-h-100 pipeline-overview__min-width-full pipeline-overview__overflow-hidden pf-v6-u-display-flex pf-v6-u-flex-direction-column': !pipelineRunsChartError,
+          'pf-v6-u-h-100 pipeline-overview__min-width-full pipeline-overview__overflow-hidden pf-v6-u-display-flex pf-v6-u-flex-direction-column':
+            !pipelineRunsChartError,
           'card-border': bordered,
         })}
       >
@@ -277,7 +279,8 @@ const PipelineRunsNumbersChartK8s: FC<PipelinesRunsNumbersChartProps> = ({
         </CardTitle>
         <CardBody
           className={classNames({
-            'pf-v6-u-flex-1 pipeline-overview__min-height-0 pf-v6-u-display-flex pf-v6-u-flex-direction-column pf-v6-u-justify-content-flex-end pf-v6-u-align-items-flex-start pf-v6-u-p-0': !pipelineRunsChartError,
+            'pf-v6-u-flex-1 pipeline-overview__min-height-0 pf-v6-u-display-flex pf-v6-u-flex-direction-column pf-v6-u-justify-content-flex-end pf-v6-u-align-items-flex-start pf-v6-u-p-0':
+              !pipelineRunsChartError,
           })}
         >
           {pipelineRunsChartError ? (
@@ -290,11 +293,13 @@ const PipelineRunsNumbersChartK8s: FC<PipelinesRunsNumbersChartProps> = ({
           ) : (
             <div
               ref={chartContainerRef}
-              className={`pf-v6-u-w-100 ${chartWidth > 0 ? 'pf-v6-u-h-100' : ''}`}
+              className={`pf-v6-u-w-100 ${
+                chartWidth > 0 ? 'pf-v6-u-h-100' : ''
+              }`}
             >
               {loadingRunSuccessRatioData ? (
                 <div className="pf-v6-u-display-flex pf-v6-u-align-items-center pf-v6-u-justify-content-center pf-v6-u-h-100 pf-v6-u-p-md pf-v6-u-p-0-on-md">
-                  <LoadingInline />
+                  <Loading isInline={true} />
                 </div>
               ) : (
                 <Chart

--- a/src/components/pipelines-overview/PipelineRunsStatusCard.tsx
+++ b/src/components/pipelines-overview/PipelineRunsStatusCard.tsx
@@ -39,7 +39,7 @@ import {
 } from './dateTime';
 import { getFilter, useInterval } from './utils';
 import { getResultsSummary } from '../utils/summary-api';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 import { ALL_NAMESPACES_KEY } from '../../consts';
 import { DataType, FLAGS, SummaryResponse } from '../../types';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
@@ -483,7 +483,7 @@ const PipelinesRunsStatusCard: FC<PipelinesRunsStatusCardProps> = ({
                     />
                   ) : (
                     <div className="pf-v6-u-display-flex pf-v6-u-align-items-center pf-v6-u-justify-content-center pf-v6-u-w-100">
-                      <LoadingInline />
+                      <Loading isInline={true} />
                     </div>
                   )}
                 </div>
@@ -494,8 +494,9 @@ const PipelinesRunsStatusCard: FC<PipelinesRunsStatusCardProps> = ({
                     'pf-v6-u-display-flex pf-v6-u-h-100 pf-v6-u-w-100 pipeline-overview__chart-area',
                     {
                       'pf-v6-u-align-items-flex-end': loaded,
-                      'pf-v6-u-align-items-center pf-v6-u-justify-content-center': !loaded,
-                    }
+                      'pf-v6-u-align-items-center pf-v6-u-justify-content-center':
+                        !loaded,
+                    },
                   )}
                 >
                   {loaded ? (
@@ -538,7 +539,7 @@ const PipelinesRunsStatusCard: FC<PipelinesRunsStatusCardProps> = ({
                       </ChartGroup>
                     </Chart>
                   ) : (
-                    <LoadingInline />
+                    <Loading isInline={true} />
                   )}
                 </div>
               </GridItem>

--- a/src/components/pipelines-overview/PipelineRunsStatusCardK8s.tsx
+++ b/src/components/pipelines-overview/PipelineRunsStatusCardK8s.tsx
@@ -49,7 +49,7 @@ import {
   adjustToStartOfWeek,
 } from '../pipelines-metrics/utils';
 import { getTotalPipelineRuns, isMatchingFirstTickValue } from './utils';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 
 interface PipelinesRunsStatusCardProps {
   timespan?: number;
@@ -568,7 +568,7 @@ const PipelineRunsStatusCardK8s: FC<PipelinesRunsStatusCardProps> = ({
                 <div className="pf-v6-u-display-flex pf-v6-u-align-items-center pipeline-overview__chart-area">
                   {loadingRunSuccessRatioData ? (
                     <div className="pf-v6-u-display-flex pf-v6-u-align-items-center pf-v6-u-justify-content-center pf-v6-u-w-100">
-                      <LoadingInline />
+                      <Loading isInline={true} />
                     </div>
                   ) : (
                     <div>
@@ -638,7 +638,7 @@ const PipelineRunsStatusCardK8s: FC<PipelinesRunsStatusCardProps> = ({
                   )}
                 >
                   {loadingTotalPipelineRunsData ? (
-                    <LoadingInline />
+                    <Loading isInline={true} />
                   ) : (
                     <Chart
                       containerComponent={

--- a/src/components/pipelines-overview/PipelineRunsTotalCard.tsx
+++ b/src/components/pipelines-overview/PipelineRunsTotalCard.tsx
@@ -19,7 +19,7 @@ import { PipelineModel, RepositoryModel } from '../../models';
 import { getResultsSummary } from '../utils/summary-api';
 import { ALL_NAMESPACES_KEY } from '../../consts';
 import { getDropDownDate } from './dateTime';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 import { DataType, FLAGS } from '../../types';
 
 import './PipelinesOverview.scss';
@@ -183,7 +183,7 @@ const PipelinesRunsTotalCard: FC<PipelinesRunsDurationProps> = ({
                   span={3}
                   className="pf-v6-u-text-align-end pipeline-overview__chart-color-blue"
                 >
-                  {loaded ? plrRun : <LoadingInline />}
+                  {loaded ? plrRun : <Loading isInline={true} />}
                 </GridItem>
               </Grid>
               <Grid hasGutter className="pf-v6-u-mb-sm">
@@ -199,7 +199,7 @@ const PipelinesRunsTotalCard: FC<PipelinesRunsDurationProps> = ({
                   span={3}
                   className="pf-v6-u-text-align-end pipeline-overview__chart-color-blue"
                 >
-                  {loaded ? repoRun : <LoadingInline />}
+                  {loaded ? repoRun : <Loading isInline={true} />}
                 </GridItem>
               </Grid>
               <Grid hasGutter className="pf-v6-u-mb-sm">
@@ -213,7 +213,7 @@ const PipelinesRunsTotalCard: FC<PipelinesRunsDurationProps> = ({
                   span={3}
                   className="pf-v6-u-text-align-end pipeline-overview__chart-color-blue"
                 >
-                  {loaded ? totalRun : <LoadingInline />}
+                  {loaded ? totalRun : <Loading isInline={true} />}
                 </GridItem>
               </Grid>
             </>

--- a/src/components/pipelines-overview/PipelineRunsTotalCardK8s.tsx
+++ b/src/components/pipelines-overview/PipelineRunsTotalCardK8s.tsx
@@ -23,7 +23,7 @@ import {
   usePipelineMetricsForNamespacePoll,
 } from '../pipelines-metrics/hooks';
 import { getXaxisValues } from './dateTime';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 
 import './PipelinesOverview.scss';
 
@@ -88,9 +88,12 @@ const PipelineRunsTotalCardK8s: FC<PipelinesRunsDurationProps> = ({
   return (
     <>
       <Card
-        className={classNames('pf-v6-u-h-100 pipeline-overview__min-width-full pf-v6-u-font-size-lg', {
-          'card-border': bordered,
-        })}
+        className={classNames(
+          'pf-v6-u-h-100 pipeline-overview__min-width-full pf-v6-u-font-size-lg',
+          {
+            'card-border': bordered,
+          },
+        )}
       >
         <CardTitle className="pf-v6-u-font-size-xl">
           <span>{t('Total runs')}</span>
@@ -125,7 +128,11 @@ const PipelineRunsTotalCardK8s: FC<PipelinesRunsDurationProps> = ({
                   span={3}
                   className="pf-v6-u-text-align-end pf-v6-u-font-size-lg pipeline-overview__chart-color-blue"
                 >
-                  {loadingTotalPipelineRunsData ? <LoadingInline /> : '-'}
+                  {loadingTotalPipelineRunsData ? (
+                    <Loading isInline={true} />
+                  ) : (
+                    '-'
+                  )}
                 </GridItem>
               </Grid>
               <Grid
@@ -147,7 +154,11 @@ const PipelineRunsTotalCardK8s: FC<PipelinesRunsDurationProps> = ({
                   span={3}
                   className="pf-v6-u-text-align-end pf-v6-u-font-size-lg pipeline-overview__chart-color-blue"
                 >
-                  {loadingTotalPipelineRunsData ? <LoadingInline /> : '-'}
+                  {loadingTotalPipelineRunsData ? (
+                    <Loading isInline={true} />
+                  ) : (
+                    '-'
+                  )}
                 </GridItem>
               </Grid>
               <Grid hasGutter className="pf-v6-u-font-size-lg">
@@ -162,7 +173,7 @@ const PipelineRunsTotalCardK8s: FC<PipelinesRunsDurationProps> = ({
                   className="pf-v6-u-text-align-end pf-v6-u-font-size-lg pipeline-overview__chart-color-blue"
                 >
                   {loadingTotalPipelineRunsData ? (
-                    <LoadingInline />
+                    <Loading isInline={true} />
                   ) : (
                     totalPipelineRuns
                   )}

--- a/src/components/pipelines-tasks/tasks-details-pages/events/events.jsx
+++ b/src/components/pipelines-tasks/tasks-details-pages/events/events.jsx
@@ -14,7 +14,7 @@ import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { ResourceLink, Timestamp } from '@openshift-console/dynamic-plugin-sdk';
 import { WSFactory } from '@openshift-console/dynamic-plugin-sdk/lib/utils/k8s/ws-factory';
 import { apiGroupForReference } from '../../../utils/pipeline-utils';
-import { Box, Loading } from '../../../status/status-box';
+import { Box } from '../../../status/status-box';
 import { EventModel, NodeModel } from '../../../../models';
 import { FLAGS } from '../../../../types';
 import { TogglePlay } from './toggle-play';
@@ -22,6 +22,7 @@ import { EventStreamList } from './event-stream';
 import { watchURL } from '../../../utils/common-utils';
 import { resourcePathFromModel } from '../../../utils/utils';
 import { namespaceProptype } from './propTypes';
+import { Loading } from '../../../Loading';
 
 const maxMessages = 500;
 const flushInterval = 500;
@@ -214,7 +215,7 @@ export const ErrorLoadingEvents = () => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
   return (
     <Box>
-      <div className="cos-status-box__title cos-error-title">
+      <div className="cos-status-box__title pf-v6-u-text-color-status-danger">
         {t('Error loading events')}
       </div>
       <div className="cos-status-box__detail cp-text-align-center">
@@ -378,7 +379,7 @@ const EventStream = ({
       : t('Showing most recent {{value}} event', { value: count });
 
   return (
-    <PageSection hasBodyWrapper={false} isFilled >
+    <PageSection hasBodyWrapper={false} isFilled>
       <div className="co-sysevent-stream">
         <div className="co-sysevent-stream__status">
           <div className="co-sysevent-stream__timeline__btn-text">

--- a/src/components/status/PipelineRunStatusPopoverContent.tsx
+++ b/src/components/status/PipelineRunStatusPopoverContent.tsx
@@ -7,7 +7,7 @@ import { useTaskRuns } from '../hooks/useTaskRuns';
 import { useMultiClusterProxyService } from '../hooks/useMultiClusterProxyService';
 import LogSnippetBlock from '../logs/LogSnippetBlock';
 import { getPLRLogSnippet } from '../logs/pipelineRunLogSnippet';
-import { LoadingInline } from '../Loading';
+import { Loading } from '../Loading';
 import { pipelineRunStatus } from '../utils/pipeline-filter-reducer';
 import { resourcePathFromModel } from '../utils/utils';
 import './StatusPopoverContent.scss';
@@ -42,7 +42,7 @@ const PipelineRunStatusPopoverContent: FC<StatusPopoverContentProps> = ({
   if (!taskRunsLoaded) {
     return (
       <div style={{ minHeight: '300px' }}>
-        <LoadingInline />
+        <Loading isInline={true} />
       </div>
     );
   }

--- a/src/components/status/status-box.tsx
+++ b/src/components/status/status-box.tsx
@@ -3,6 +3,7 @@ import type { FC, ReactNode } from 'react';
 import classNames from 'classnames';
 import { Button } from '@patternfly/react-core';
 import { useTranslation, Trans } from 'react-i18next';
+import { Loading } from '../Loading';
 import './status-box.scss';
 
 export const Box: FC<BoxProps> = ({ children, className }) => (
@@ -18,7 +19,7 @@ export const LoadError: FC<LoadErrorProps> = ({
   const { t } = useTranslation('plugin__pipelines-console-plugin');
   return (
     <Box className={className}>
-      <div className="cp-text-align-center cos-error-title">
+      <div className="cp-text-align-center pf-v6-u-text-color-status-danger">
         {_.isString(message)
           ? t('Error Loading {{label}}: {{message}}', {
               label,
@@ -47,32 +48,10 @@ export const LoadError: FC<LoadErrorProps> = ({
 };
 LoadError.displayName = 'LoadError';
 
-export const Loading: FC<LoadingProps> = ({ className }) => (
-  <div
-    className={classNames('co-m-loader co-an-fade-in-out', className)}
-    data-test="loading-indicator"
-  >
-    <div className="co-m-loader-dot__one" />
-    <div className="co-m-loader-dot__two" />
-    <div className="co-m-loader-dot__three" />
-  </div>
-);
-Loading.displayName = 'Loading';
-
-export const LoadingInline: FC = () => (
-  <Loading className="co-m-loader--inline" />
-);
-LoadingInline.displayName = 'LoadingInline';
-
-export const LoadingBox: FC<LoadingBoxProps> = ({
-  className,
-  message,
-}) => (
-  <Box className={classNames('cos-status-box--loading', className)}>
+export const LoadingBox: FC<LoadingBoxProps> = ({ className, message }) => (
+  <Box className={classNames('pf-v6-u-h-100 pf-v6-u-w-100', className)}>
     <Loading />
-    {message && (
-      <div className="cos-status-box__loading-message">{message}</div>
-    )}
+    {message && <div className="pf-v6-u-mt-md">{message}</div>}
   </Box>
 );
 LoadingBox.displayName = 'LoadingBox';
@@ -87,10 +66,6 @@ type LoadErrorProps = {
   className?: string;
   message?: string;
   canRetry?: boolean;
-};
-
-type LoadingProps = {
-  className?: string;
 };
 
 type LoadingBoxProps = {


### PR DESCRIPTION
## Summary

Consolidates loading UI on the shared PatternFly-based `Loading` component, removes the `LoadingInline` wrapper, refreshes `LoadingBox` with PF6 layout utilities, and aligns `PipelineRunVisualization` with the same full-page loading treatment while pipeline or task run data is still resolving.

## What changed

- **`Loading.tsx`**
  - Removed `LoadingInline` export.
  - Default spinner size is now `'lg'` when `size` is omitted (`size ?? 'lg'`).

- **`status-box.tsx`**
  - Dropped the legacy dot loader and the `Loading` / `LoadingInline` exports from this module.
  - `LoadingBox` now wraps the shared `Loading` from `../Loading` and uses PF6 utility classes for centering and layout; optional message uses `pf-v6-u-mt-md`.

- **Call sites**
  - Replaced `LoadingInline` with `<Loading isInline={true} />` across dropdowns, logs, metrics/overview cards, list status cells, popover content, etc.

- **`PipelineRunVisualization.tsx`**
  - While either the resolved **pipeline** is missing **or** **task runs** are not loaded yet, the visualization area shows **`LoadingBox`** instead of an inline spinner (previously only gated on `!pipeline`).

- **`events.jsx`**
  - Imports `Loading` from `../../../Loading` (no longer from `status-box`); 

## Why

- Single source of truth for spinners (PatternFly `Spinner` + `Bullseye`), easier maintenance and consistent accessibility / test hooks (`data-test="loading-indicator"` on `Loading`).
- `LoadingBox` matches PF6 spacing/layout patterns used elsewhere in the plugin.

## Screen recordings

https://github.com/user-attachments/assets/153262e5-ed7f-4b56-9eda-2c12f785f879

https://github.com/user-attachments/assets/b6a30c1a-cdad-4224-8e4d-7b4c05932b9b

https://github.com/user-attachments/assets/7a9c4f99-c8d1-43f2-8c04-9dad0bf0fea7

https://github.com/user-attachments/assets/2fb8938f-751c-4170-a4df-b682e2c1ee30

https://github.com/user-attachments/assets/9285c976-e6dc-4fe4-b4db-7d22bc903d02



