### PR TITLE
SRVKP-11565: Fix stale PipelineRun details view by forcing remount on resource change

### DIFF
--- a/src/components/pipelineRuns-details/PipelineRunDetails.tsx
+++ b/src/components/pipelineRuns-details/PipelineRunDetails.tsx
@@ -21,7 +21,11 @@ const PipelineRunDetails: FC<PipelineRunDetailsProps> = ({
   }
 
   return (
-    <PageSection hasBodyWrapper={false} isFilled>
+    <PageSection
+      key={pipelineRun?.metadata?.uid + pipelineRun?.metadata?.name}
+      hasBodyWrapper={false}
+      isFilled
+    >
       <Title headingLevel="h2">{t('PipelineRun details')}</Title>
       <PipelineRunVisualization pipelineRun={pipelineRun} />
       <Grid hasGutter>


### PR DESCRIPTION
**Description:**
The PipelineRun details page was not updating correctly when the underlying PipelineRun changed (e.g., rerunning a PLR). This was due to component reuse within `DetailsPage`/`navFactory`, causing `PipelineRunDetails` to retain stale state for PLR's with same name.

**Fix:**
Added a `key` (based on PipelineRun `uid`/`name`) to the `PipelineRunDetails` component to force a remount whenever the PipelineRun changes.

**Impact:**

* Ensures fresh rendering of PipelineRun details
* Fixes stale UI issues for archived and multicluster PipelineRuns
* No functional changes beyond correct re-rendering

**Screen recording before**

https://github.com/user-attachments/assets/4906fb5e-8d85-4452-948f-d5252aa2f004

**Screen recording after**

https://github.com/user-attachments/assets/fe0b7939-8948-40e5-a771-f05ab17646fa

https://github.com/user-attachments/assets/6451c208-4e9a-4409-8b2a-5f18152ff4b9