### PR TITLE
SRVKP-11708: removed the .ocs-quick-search-modal and corresponding scss file

### DIFF
--- a/src/components/pipeline-builder/PipelineBuilderForm.tsx
+++ b/src/components/pipeline-builder/PipelineBuilderForm.tsx
@@ -236,7 +236,7 @@ const PipelineBuilderForm: FC<PipelineBuilderFormProps> = (props) => {
       >
         <DrawerContentBody onClick={closeRef}>
           <div
-            className="opp-pipeline-builder ocs-quick-search-modal__no-backdrop"
+            className="opp-pipeline-builder pipelines-ocs-quick-search-modal__no-backdrop"
             ref={contentRef}
           >
             <PipelineBuilderHeader />

--- a/src/components/quick-search/QuickSearchModal.scss
+++ b/src/components/quick-search/QuickSearchModal.scss
@@ -1,4 +1,4 @@
-.ocs-quick-search-modal {
+.pipelines-ocs-quick-search-modal {
   box-shadow: none !important;
   overflow: unset;
   background: none !important;

--- a/src/components/quick-search/QuickSearchModal.tsx
+++ b/src/components/quick-search/QuickSearchModal.tsx
@@ -1,8 +1,5 @@
 import type { ReactNode, SetStateAction, Dispatch, FC } from 'react';
-import {
-	Modal,
-	ModalVariant
-} from '@patternfly/react-core';
+import { Modal, ModalVariant } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { DetailsRendererFunction } from './QuickSearchDetails';
 import QuickSearchModalBody from './QuickSearchModalBody';
@@ -47,7 +44,7 @@ const QuickSearchModal: FC<QuickSearchModalProps> = ({
 
   return viewContainer ? (
     <Modal
-      className="ocs-quick-search-modal"
+      className="pipelines-ocs-quick-search-modal"
       variant={ModalVariant.medium}
       aria-label={t('Quick search')}
       isOpen={isOpen}

--- a/src/components/quick-search/QuickSearchModalBody.scss
+++ b/src/components/quick-search/QuickSearchModalBody.scss
@@ -1,4 +1,4 @@
-.ocs-quick-search-modal-body {
+.pipelines-ocs-quick-search-modal-body {
   display: flex;
   flex-direction: column;
   background: var(--pf-t--global--background--color--primary--default);

--- a/src/components/quick-search/QuickSearchModalBody.tsx
+++ b/src/components/quick-search/QuickSearchModalBody.tsx
@@ -62,12 +62,8 @@ const QuickSearchModalBody: FC<QuickSearchModalBodyProps> = ({
   const [catalogItems, setCatalogItems] = useState<CatalogItem[]>(null);
   const [catalogTypes, setCatalogTypes] = useState<CatalogType[]>([]);
   const [isRndActive, setIsRndActive] = useState(false);
-  const [maxHeight, setMaxHeight] = useState(
-    DEFAULT_HEIGHT_WITH_NO_ITEMS,
-  );
-  const [minHeight, setMinHeight] = useState(
-    DEFAULT_HEIGHT_WITH_NO_ITEMS,
-  );
+  const [maxHeight, setMaxHeight] = useState(DEFAULT_HEIGHT_WITH_NO_ITEMS);
+  const [minHeight, setMinHeight] = useState(DEFAULT_HEIGHT_WITH_NO_ITEMS);
   const [minWidth, setMinWidth] = useState(MIN_WIDTH);
   const [searchTerm, setSearchTerm] = useState<string>(
     getQueryArgument('catalogSearch') || '',
@@ -81,8 +77,7 @@ const QuickSearchModalBody: FC<QuickSearchModalBodyProps> = ({
     width: number;
   }>();
   const [tektonTasks] = useTasksProvider({});
-  const [draggableBoundary, setDraggableBoundary] =
-    useState<string>(null);
+  const [draggableBoundary, setDraggableBoundary] = useState<string>(null);
   const [isSearching, setIsSearching] = useState(false);
   const [isSearchError, setIsSearchError] = useState(false);
   const ref = useRef<HTMLDivElement>();
@@ -183,7 +178,8 @@ const QuickSearchModalBody: FC<QuickSearchModalBodyProps> = ({
           artifactHubResults,
           tektonTasks,
         );
-        const { filteredItems, viewAllLinks, catalogItemTypes } = catalogResults;
+        const { filteredItems, viewAllLinks, catalogItemTypes } =
+          catalogResults;
 
         const mergedItems = [
           ...filteredItems,
@@ -361,7 +357,7 @@ const QuickSearchModalBody: FC<QuickSearchModalBodyProps> = ({
     >
       <div
         ref={ref}
-        className="ocs-quick-search-modal-body"
+        className="pipelines-ocs-quick-search-modal-body"
         style={{
           height: getModalHeight(),
         }}


### PR DESCRIPTION
### Summary
This PR resolves a UI styling conflict where the pipelines-plugin was unintentionally overriding core OpenShift Console styles. The collision occurred because both the plugin and the core console utilized the .ocs-quick-search-modal class name.
By removing the redundant local SCSS definition and the associated class assignments within the plugin, we allow the modal to either inherit correct global styles or utilize standard PatternFly components without side-effect-inducing overrides.

### Key Changes
QuickSearchModal.tsx: Removed the import of QuickSearchModal.scss and stripped the .ocs-quick-search-modal class from the Modal component.
PipelineBuilderForm.tsx: Removed the .ocs-quick-search-modal__no-backdrop class from the main container div to prevent style bleeding and ensure consistent layout behavior.
QuickSearchModal.scss: Deleted the stylesheet entirely as it contained the conflicting global class definitions.

### How to Verify

- Fresh Load: Log in to OCP and go to the Topology view. Open the "Add to Project" modal. Verify it looks correct.
- Trigger Collision Path: Navigate to the Pipeline Builder page (ensuring the plugin and its components are initialized).
- Verify Fix: Return to Topology and open the "Add to Project" modal again. The styling should remain intact and no longer be affected by the pipelines-plugin logic.
- Regression Check: Ensure the Quick Search functionality within the Pipeline Builder itself still renders correctly without the deleted local styles.

### Screen Recordings before

https://github.com/user-attachments/assets/1a609f92-63aa-45f4-93f3-ae8846c64724

### Screen Recordings after

#### Dark

https://github.com/user-attachments/assets/458b2ff0-e0a1-4b87-b9ca-8531e07be7f8

https://github.com/user-attachments/assets/ba6f9e6d-fbd0-45d5-be22-aa69d9cb954c

#### Light

https://github.com/user-attachments/assets/fd331c00-94a3-4309-ae9e-9dda4fc7e6c0


