### PR TITLE
SRVKP-11472,SRVKP-11475: Fix ANSI color bleed across log lines in pipeline log viewer

### DIFF
--- a/src/components/logs/Logs.tsx
+++ b/src/components/logs/Logs.tsx
@@ -16,6 +16,7 @@ import {
   getMultiClusterLogsUrl,
   getMultiClusterLogsStreamPath,
 } from '../utils/multi-cluster-api';
+import { resetAnsiStatePerLine } from './logs-utils';
 
 type LogsProps = {
   resource: PodKind;
@@ -57,7 +58,7 @@ const processLogData = (
       }
     }
   });
-  return result;
+  return resetAnsiStatePerLine(result);
 };
 
 const Logs: FC<LogsProps> = ({

--- a/src/components/logs/TektonTaskRunLog.tsx
+++ b/src/components/logs/TektonTaskRunLog.tsx
@@ -10,6 +10,7 @@ import { Banner } from '@patternfly/react-core';
 import './TektonTaskRunLog.scss';
 import '../pipelineRuns-details/PipelineRunLogs.scss';
 import { useTranslation } from 'react-i18next';
+import { resetAnsiStatePerLine } from './logs-utils';
 
 type TektonTaskRunLogProps = {
   taskRun?: TaskRunKind;
@@ -46,7 +47,7 @@ export const TektonTaskRunLog: FC<TektonTaskRunLogProps> = ({
     if (!trResults) return '';
     const formattedTaskName = `${taskName.toUpperCase()}`;
 
-    return `${formattedTaskName}\n${trResults}\n\n`;
+    return resetAnsiStatePerLine(`${formattedTaskName}\n${trResults}\n\n`);
   }, [trResults, taskName]);
   const lastRowIndex = trResults ? formattedResults.split('\n').length : 0;
 

--- a/src/components/logs/logs-utils.ts
+++ b/src/components/logs/logs-utils.ts
@@ -324,3 +324,8 @@ export const getDownloadAllLogsCallbackMultiCluster = (
 
   return () => fetchMcLogs();
 };
+
+export const resetAnsiStatePerLine = (logData: string): string => {
+  if (!logData) return logData;
+  return logData.replace(/\n/g, '\n\x1b[0m');
+};


### PR DESCRIPTION
## Summary

PF6 `LogViewer` uses a single shared stateful `AnsiUp` instance with virtualized row rendering. If any row leaves ANSI color state open — due to a malformed, missing, or literal (non-interpreted) reset — that state carries into subsequent rendered rows, causing color bleed across unrelated log lines, timestamps, and table columns.

This fix inserts an ANSI reset (`\x1b[0m`) at every line boundary before log content is passed to `LogViewer`, ensuring each row starts with a clean ANSI state.

**Known trade-off:** Intentional multi-line color spans (e.g. a single `\033[31m` spanning multiple lines) will only color the first line. This is acceptable because multi-line spans were already unreliable due to virtualized rendering and shared AnsiUp state.

## Changes Made

| File | Change |
|------|--------|
| `src/components/logs/logs-utils.ts` | Added `resetAnsiStatePerLine()` utility |
| `src/components/logs/Logs.tsx` | Applied `resetAnsiStatePerLine()` in `processLogData()` |
| `src/components/logs/TektonTaskRunLog.tsx` | Applied `resetAnsiStatePerLine()` in `formattedResults` |

## Screen Recordings

### [SRVKP-11472](https://redhat.atlassian.net/browse/SRVKP-11472): ANSI color bleed when malformed escape sequence appears

Before Fix:

https://github.com/user-attachments/assets/3f0637aa-ca8b-4027-8bce-055818b83e7c

After Fix:

https://github.com/user-attachments/assets/16320815-5808-4231-8d26-371d03cce06f


### [SRVKP-11475](https://redhat.atlassian.net/browse/SRVKP-11475): ANSI color bleed inside Unicode table

Before Fix:

https://github.com/user-attachments/assets/5b59744f-704e-4c84-a9dc-341ce37be5d9

After Fix:

https://github.com/user-attachments/assets/34e1cc6b-9b0f-4018-a5ec-a1f254acc463


### Terminal Reference (expected behavior)

The following shows the behavior of CLI with Intentional multi-line color spans (e.g. a single `\033[31m` spanning multiple lines), confirming that the fix aligns the LogViewer output with standard terminal behavior.

<img width="1920" height="1080" alt="Screenshot From 2026-05-06 17-12-21" src="https://github.com/user-attachments/assets/69b2c5ca-4b96-42c1-a02f-31f17feccc5f" />


<details>
<summary>YAML for task used for generating the above log</summary>

```yaml
apiVersion: tekton.dev/v1
kind: Task
metadata:
  name: ansi-multiline-already-broken
spec:
  steps:
    - name: generate
      image: registry.access.redhat.com/ubi9/ubi
      script: |
        #!/usr/bin/env bash
        echo "===== SCROLL TEST: Multi-line span across viewport boundary ====="
        echo ""
        echo -e "\033[31m--- RED BLOCK START (line 1 of 200) ---"
        for i in $(seq 2 199); do
          echo "  Red block line $i (should be red if span works)"
        done
        echo -e "--- RED BLOCK END (line 200 of 200) ---\033[0m"
        echo ""
        echo "This line should be default color after the red block."
        echo ""
        echo -e "\033[1;32m--- GREEN BOLD BLOCK START (line 1 of 200) ---"
        for i in $(seq 2 199); do
          echo "  Green bold block line $i (should be green+bold if span works)"
        done
        echo -e "--- GREEN BOLD BLOCK END (line 200 of 200) ---\033[0m"
        echo ""
        echo "This line should be default color after the green block."
        echo ""
        echo "===== DONE ====="
``` 
        
</details>


Assisted-by: Claude 4.6 high