### PR TITLE
SRVKP-11472,SRVKP-11475: Fix ANSI color bleed across log lines in pipeline log viewer for main branch

### DIFF
--- a/src/components/logs/Logs.tsx
+++ b/src/components/logs/Logs.tsx
@@ -15,6 +15,7 @@ import {
   getMultiClusterLogsUrl,
   getMultiClusterLogsStreamPath,
 } from '../utils/multi-cluster-api';
+import { resetAnsiStatePerLine } from './logs-utils';
 
 type LogsProps = {
   resource: PodKind;
@@ -56,7 +57,7 @@ const processLogData = (
       }
     }
   });
-  return result;
+  return resetAnsiStatePerLine(result);
 };
 
 const Logs: React.FC<LogsProps> = ({

--- a/src/components/logs/TektonTaskRunLog.tsx
+++ b/src/components/logs/TektonTaskRunLog.tsx
@@ -7,6 +7,7 @@ import { LoadingInline } from '../Loading';
 import { useTRTaskRunLog } from '../hooks/useTektonResult';
 import { Banner } from '@patternfly/react-core';
 import './TektonTaskRunLog.scss';
+import { resetAnsiStatePerLine } from './logs-utils';
 
 type TektonTaskRunLogProps = {
   taskRun?: TaskRunKind;
@@ -39,7 +40,7 @@ export const TektonTaskRunLog: React.FC<TektonTaskRunLogProps> = ({
     if (!trResults) return '';
     const formattedTaskName = `${taskName.toUpperCase()}`;
 
-    return `${formattedTaskName}\n${trResults}\n\n`;
+    return resetAnsiStatePerLine(`${formattedTaskName}\n${trResults}\n\n`);
   }, [trResults, taskName]);
   const lastRowIndex = trResults ? formattedResults.split('\n').length : 0;
 

--- a/src/components/logs/logs-utils.ts
+++ b/src/components/logs/logs-utils.ts
@@ -326,3 +326,8 @@ export const getDownloadAllLogsCallbackMultiCluster = (
 
   return () => fetchMcLogs();
 };
+
+export const resetAnsiStatePerLine = (logData: string): string => {
+  if (!logData) return logData;
+  return logData.replace(/\n/g, '\n\x1b[0m');
+};


### PR DESCRIPTION
## Summary

PF6 `LogViewer` uses a single shared stateful `AnsiUp` instance with virtualized row rendering. If any row leaves ANSI color state open — due to a malformed, missing, or literal (non-interpreted) reset — that state carries into subsequent rendered rows, causing color bleed across unrelated log lines, timestamps, and table columns.

This fix inserts an ANSI reset (`\x1b[0m`) at every line boundary before log content is passed to `LogViewer`, ensuring each row starts with a clean ANSI state.

**Known trade-off:** Intentional multi-line color spans (e.g. a single `\033[31m` spanning multiple lines) will only color the first line. This is acceptable because multi-line spans were already unreliable due to virtualized rendering and shared AnsiUp state.

## Changes Made

| File | Change |
|------|--------|
| `src/components/logs/logs-utils.ts` | Added `resetAnsiStatePerLine()` utility |
| `src/components/logs/Logs.tsx` | Applied `resetAnsiStatePerLine()` in `processLogData()` |
| `src/components/logs/TektonTaskRunLog.tsx` | Applied `resetAnsiStatePerLine()` in `formattedResults` |

## Screen Recordings

### [SRVKP-11472](https://redhat.atlassian.net/browse/SRVKP-11472): ANSI color bleed when malformed escape sequence appears

Before Fix:

https://github.com/user-attachments/assets/4a8f9e04-bacf-4a8a-948d-1e9ecfdc782f

After Fix:

https://github.com/user-attachments/assets/5e65b248-f9b0-4a49-81d5-3b301f9f3dc3

### [SRVKP-11475](https://redhat.atlassian.net/browse/SRVKP-11475): ANSI color bleed inside Unicode table

Before Fix:

https://github.com/user-attachments/assets/404c96a4-e998-4fb0-990c-7d074b088611

After Fix:

https://github.com/user-attachments/assets/3113c895-cf3b-4a2a-a5b8-1b84b25c8218

### Terminal Reference (expected behavior)

The following shows the behavior of CLI with Intentional multi-line color spans (e.g. a single `\033[31m` spanning multiple lines), confirming that the fix aligns the LogViewer output with standard terminal behavior.

<img width="1920" height="1080" alt="Screenshot From 2026-05-06 17-12-21" src="https://github.com/user-attachments/assets/69b2c5ca-4b96-42c1-a02f-31f17feccc5f" />


<details>
<summary>YAML for task used for generating the above log</summary>

```yaml
apiVersion: tekton.dev/v1
kind: Task
metadata:
  name: ansi-multiline-already-broken
spec:
  steps:
    - name: generate
      image: registry.access.redhat.com/ubi9/ubi
      script: |
        #!/usr/bin/env bash
        echo "===== SCROLL TEST: Multi-line span across viewport boundary ====="
        echo ""
        echo -e "\033[31m--- RED BLOCK START (line 1 of 200) ---"
        for i in $(seq 2 199); do
          echo "  Red block line $i (should be red if span works)"
        done
        echo -e "--- RED BLOCK END (line 200 of 200) ---\033[0m"
        echo ""
        echo "This line should be default color after the red block."
        echo ""
        echo -e "\033[1;32m--- GREEN BOLD BLOCK START (line 1 of 200) ---"
        for i in $(seq 2 199); do
          echo "  Green bold block line $i (should be green+bold if span works)"
        done
        echo -e "--- GREEN BOLD BLOCK END (line 200 of 200) ---\033[0m"
        echo ""
        echo "This line should be default color after the green block."
        echo ""
        echo "===== DONE ====="
``` 
        
</details>