### PR TITLE
SRVKP-9437: fix - resolve pending approval tasks displaying as Unknown

### DIFF
--- a/src/components/utils/pipeline-approval-utils.ts
+++ b/src/components/utils/pipeline-approval-utils.ts
@@ -97,6 +97,9 @@ export const getApprovalStatus = (
   if (approvalState === ApproverStatusResponse.Timedout) {
     return ApprovalStatus.TimedOut;
   }
+  if (approvalState === ApproverStatusResponse.Pending) {
+    return ApprovalStatus.RequestSent;
+  }
 
   return ApprovalStatus.Unknown;
 };


### PR DESCRIPTION
## Summary
In the OpenShift Pipelines Approvals tab, newly created manual approval tasks for a PipelineRun are shown with a status of “Unknown” even though they are pending. Because the Approvals tab filters by "Pending" by default, these tasks do not match the filter criteria and are completely hidden from the user, making the page look empty.

## Root Cause
The bug resides in the UI's “getApprovalStatus” function (console-plugin/src/components/utils/pipeline-approval-utils.ts).
The function currently enforces a strict logic gate: it only checks if an approval is "pending" if the associated PipelineRun is currently in a Running state. If the PipelineRun is not running ( i.e. status of the PipelineRun is not yet fetched by the UI ) then the function skips the pending status check entirely.
Instead of evaluating the task's actual state, it hits the bottom of the function and returns an unconditional default fallthrough of ApprovalStatus.Unknown.

## Changes
Right before the final fallthrough to Unknown, the function should check if the task's core state is ApproverStatusResponse.Pending and return ApprovalStatus.RequestSent (which renders as "Pending" in the UI).

## Screen Recordings 
### Before fix

https://github.com/user-attachments/assets/820ca350-cc24-4175-952a-a64f7551d3c5


https://github.com/user-attachments/assets/11de159e-20ea-4207-ad9d-068c0c73063c


https://github.com/user-attachments/assets/f9203e22-c4ea-4b8b-b8c2-d40a5602cc52

### After fix combined

https://github.com/user-attachments/assets/38b61676-3686-4380-bd5b-270fc0d068af


