### PR TITLE
SRVKP-8292: Unify Stop and Cancel PipelineRun visibility logic

### DIFF
--- a/src/components/utils/__tests__/pipeline-augment.spec.ts
+++ b/src/components/utils/__tests__/pipeline-augment.spec.ts
@@ -22,8 +22,7 @@ import {
   getRunStatusColor,
   getTaskStatus,
   pipelineRefExists,
-  shouldHidePipelineRunCancel,
-  shouldHidePipelineRunStop,
+  shouldHidePipelineRunStopOrCancel,
   TaskStatus,
   totalPipelineRunCustomTasks,
   totalPipelineRunTasks,
@@ -205,40 +204,26 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       expect(taskCount).toEqual(expectedTaskCount);
     });
 
-    it('should not hide the pipelinerun stop action ', () => {
+    it('should not hide the pipelinerun stop or cancel action ', () => {
       const pipelineRun =
         pipelineTestData[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP]
           .pipelineRuns[DataState.IN_PROGRESS];
-      expect(shouldHidePipelineRunStop(pipelineRun, [])).toEqual(false);
+      expect(shouldHidePipelineRunStopOrCancel(pipelineRun)).toEqual(false);
     });
 
-    it('should hide the pipelinerun stop action ', () => {
+    it('should hide the pipelinerun stop or cancel action for succeeded run', () => {
       const pipelineRun =
         pipelineTestData[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP]
           .pipelineRuns[DataState.SUCCESS];
-      expect(shouldHidePipelineRunStop(pipelineRun, [])).toEqual(true);
+      expect(shouldHidePipelineRunStopOrCancel(pipelineRun)).toEqual(true);
     });
 
-    it('should hide the pipelinerun cancel action ', () => {
-      const pipelineRun =
-        pipelineTestData[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP]
-          .pipelineRuns[DataState.SUCCESS];
-      expect(shouldHidePipelineRunCancel(pipelineRun, [])).toEqual(true);
-    });
-
-    it('should not hide the pipelinerun cancel action ', () => {
-      const pipelineRun =
-        pipelineTestData[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP]
-          .pipelineRuns[DataState.IN_PROGRESS];
-      expect(shouldHidePipelineRunCancel(pipelineRun, [])).toEqual(false);
-    });
-
-    it('should hide the pipelinerun cancel action ', () => {
+    it('should hide the pipelinerun stop or cancel action for stopped run', () => {
       const pipelineRun =
         pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE].pipelineRuns[
           DataState.PIPELINE_RUN_STOPPED
         ];
-      expect(shouldHidePipelineRunCancel(pipelineRun, [])).toEqual(true);
+      expect(shouldHidePipelineRunStopOrCancel(pipelineRun)).toEqual(true);
     });
   });
 

--- a/src/components/utils/pipeline-augment.ts
+++ b/src/components/utils/pipeline-augment.ts
@@ -8,7 +8,7 @@ import { chart_color_black_500 as cancelledColor } from '@patternfly/react-token
 import { chart_color_blue_100 as pendingColor } from '@patternfly/react-tokens/dist/js/chart_color_blue_100';
 import { chart_color_blue_300 as runningColor } from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
 import { chart_color_green_400 as successColor } from '@patternfly/react-tokens/dist/js/chart_color_green_400';
-import { t_chart_global_danger_color_100 as failureColor } from "@patternfly/react-tokens/dist/js/t_chart_global_danger_color_100";
+import { t_chart_global_danger_color_100 as failureColor } from '@patternfly/react-tokens/dist/js/t_chart_global_danger_color_100';
 import { TektonResourceLabel } from '../../consts';
 import {
   ClusterTriggerBindingModel,
@@ -357,51 +357,20 @@ export const getModelReferenceFromTaskKind = (
   return getReferenceForModel(model);
 };
 
-export const countRunningTasks = (
+export const shouldHidePipelineRunStopOrCancel = (
   pipelineRun: PipelineRunKind,
-  taskRuns: TaskRunKind[],
-): number => {
-  const taskStatuses =
-    taskRuns && getTaskStatus(pipelineRun, undefined, taskRuns);
-  return taskStatuses?.Running;
+): boolean => {
+  if (!pipelineRun) {
+    return true;
+  }
+
+  const status = pipelineRunFilterReducer(pipelineRun);
+
+  return [
+    ComputedStatus.Succeeded,
+    ComputedStatus.Failed,
+    ComputedStatus.Cancelled,
+
+    ComputedStatus.Cancelling,
+  ].includes(status);
 };
-
-export const shouldHidePipelineRunStop = (
-  pipelineRun: PipelineRunKind,
-  taskRuns: TaskRunKind[],
-): boolean =>
-  !(
-    pipelineRun &&
-    (countRunningTasks(pipelineRun, taskRuns) > 0 ||
-      pipelineRunFilterReducer(pipelineRun) === ComputedStatus.Running)
-  );
-
-export const shouldHidePipelineRunStopForTaskRunStatus = (
-  pipelineRun: PipelineRunKind,
-  taskRunStatusObj: TaskStatus,
-): boolean =>
-  !(
-    pipelineRun &&
-    (taskRunStatusObj?.Running > 0 ||
-      pipelineRunFilterReducer(pipelineRun) === ComputedStatus.Running)
-  );
-
-export const shouldHidePipelineRunCancel = (
-  pipelineRun: PipelineRunKind,
-  taskRuns: TaskRunKind[],
-): boolean =>
-  !(
-    pipelineRun &&
-    countRunningTasks(pipelineRun, taskRuns) > 0 &&
-    pipelineRunFilterReducer(pipelineRun) !== ComputedStatus.Cancelled
-  );
-
-export const shouldHidePipelineRunCancelForTaskRunStatus = (
-  pipelineRun: PipelineRunKind,
-  taskRunStatusObj: TaskStatus,
-): boolean =>
-  !(
-    pipelineRun &&
-    taskRunStatusObj?.Running > 0 &&
-    pipelineRunFilterReducer(pipelineRun) !== ComputedStatus.Cancelled
-  );

--- a/src/utils/pipelineRun-actions-provider.tsx
+++ b/src/utils/pipelineRun-actions-provider.tsx
@@ -15,10 +15,7 @@ import {
   getPipelineRunData,
   resourcePathFromModel,
 } from '../components/utils/utils';
-import {
-  shouldHidePipelineRunCancel,
-  shouldHidePipelineRunStop,
-} from '../components/utils/pipeline-augment';
+import { shouldHidePipelineRunStopOrCancel } from '../components/utils/pipeline-augment';
 import {
   isResourceLoadedFromTR,
   tektonResultsFlag,
@@ -35,8 +32,7 @@ export const usePipelineRunActionsProvider = (resource: PipelineRunKind) => {
 
   const { name, namespace } = resource.metadata;
 
-  const hidePLRStop = shouldHidePipelineRunStop(resource, []);
-  const hidePLRCancel = shouldHidePipelineRunCancel(resource, []);
+  const hidePLRStopOrCancel = shouldHidePipelineRunStopOrCancel(resource);
   const isDeleteDisabled = isResourceLoadedFromTR(resource);
 
   const hasPipelineRef = !!(
@@ -129,12 +125,12 @@ export const usePipelineRunActionsProvider = (resource: PipelineRunKind) => {
       {
         id: 'stop-pipelinerun',
         label: t('Stop'),
-        disabled: hidePLRStop || !canUpdatePipelineRun,
+        disabled: hidePLRStopOrCancel || !canUpdatePipelineRun,
         tooltip:
-          !hidePLRStop && canUpdatePipelineRun
+          !hidePLRStopOrCancel && canUpdatePipelineRun
             ? t('Let the running tasks complete, then execute finally tasks')
             : undefined,
-        disabledTooltip: hidePLRStop
+        disabledTooltip: hidePLRStopOrCancel
           ? t('PipelineRun cannot be stopped in its current state')
           : t('Insufficient permissions to update PipelineRun'),
         cta: () => {
@@ -158,14 +154,14 @@ export const usePipelineRunActionsProvider = (resource: PipelineRunKind) => {
       {
         id: 'cancel-pipelinerun',
         label: t('Cancel'),
-        disabled: hidePLRCancel || !canUpdatePipelineRun,
+        disabled: hidePLRStopOrCancel || !canUpdatePipelineRun,
         tooltip:
-          !hidePLRCancel && canUpdatePipelineRun
+          !hidePLRStopOrCancel && canUpdatePipelineRun
             ? t(
                 'Interrupt any executing non finally tasks, then execute finally tasks',
               )
             : undefined,
-        disabledTooltip: hidePLRCancel
+        disabledTooltip: hidePLRStopOrCancel
           ? t('PipelineRun cannot be cancelled in its current state')
           : t('Insufficient permissions to update PipelineRun'),
         cta: () => {
@@ -206,8 +202,7 @@ export const usePipelineRunActionsProvider = (resource: PipelineRunKind) => {
     currentUser,
     location,
     hasPipelineRef,
-    hidePLRStop,
-    hidePLRCancel,
+    hidePLRStopOrCancel,
     isDeleteDisabled,
     navigate,
     launchErrorModal,


### PR DESCRIPTION
## Summary

- Replaced the separate `shouldHidePipelineRunStop` and `shouldHidePipelineRunCancel` functions (along with their `ForTaskRunStatus` variants and the `countRunningTasks` helper) with a single unified `shouldHidePipelineRunStopOrCancel` function.
- The new function hides both Stop and Cancel actions when the PipelineRun is in a terminal or transitioning-terminal state: `Succeeded`, `Failed`, `Cancelled`, or `Cancelling`.
- Removes the dependency on `taskRuns` list for determining action visibility — the check is now based solely on the PipelineRun's computed status, simplifying the logic significantly.
- Updated `usePipelineRunActionsProvider` to use the single shared flag (`hidePLRStopOrCancel`) for both the Stop and Cancel action items.
- Updated tests to reflect the consolidated API, removing redundant duplicate test cases.

## Screen recording before

https://github.com/user-attachments/assets/87e03e0a-f3ee-4c1b-9692-00de65038390


## Screen recording after

https://github.com/user-attachments/assets/a554baeb-b628-4459-a870-ca4c59f2f447

