### PR TITLE
SRVKP-11477: cve fix for lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "classnames": "^2.3.2",
     "gherkin-lint": "^4.1.3",
     "i18next-conv": "^15.1.1",
-    "lodash-es": "^4.17.23",
+    "lodash-es": "^4.18.1",
     "micromatch": "4.0.8",
     "path-browserify": "^1.0.1",
     "stream-browserify": "^3.0.0",
@@ -187,8 +187,8 @@
     "webpack": "5.94.0",
     "@types/d3-dispatch": "3.0.6",
     "@types/d3-selection": "3.0.10",
-    "lodash": "4.17.23",
-    "lodash-es": "4.17.23",
+    "lodash": "4.18.1",
+    "lodash-es": "4.18.1",
     "immutable@^3.0.0": "3.8.3",
     "immutable@^5.0.0": "5.1.5"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,8 +1549,8 @@ __metadata:
   linkType: hard
 
 "@cucumber/cucumber@npm:^12.0.0":
-  version: 12.8.2
-  resolution: "@cucumber/cucumber@npm:12.8.2"
+  version: 12.8.3
+  resolution: "@cucumber/cucumber@npm:12.8.3"
   dependencies:
     "@cucumber/ci-environment": "npm:13.0.0"
     "@cucumber/cucumber-expressions": "npm:19.0.0"
@@ -1593,7 +1593,7 @@ __metadata:
     yup: "npm:1.7.1"
   bin:
     cucumber-js: bin/cucumber.js
-  checksum: 10c0/916787ab90cdafe785c6f23a23c4419e71508f744aa15c7e55d25134963ffd62d7b7f9254c925911540dae770b93bf280caa4c5456b32a9f0078325181f5dbaa
+  checksum: 10c0/8a1d5e8816dfbaa75aa17be6edb915d88ead809aa28fc86bef82ede22463cebb9b40015a7fc81ede40d19cdc55492a94004a17167e8052739145ba2a745ac3cf
   languageName: node
   linkType: hard
 
@@ -5646,9 +5646,9 @@ __metadata:
   linkType: hard
 
 "ast-module-types@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "ast-module-types@npm:6.0.1"
-  checksum: 10c0/b835a3518accd480c8102fe18cc782bf8f38c7844764e8c27c6494203688c788d6fc90f27dd3b7b3941ff3f2cc1a9269cd7471df55bd467f86af56093808d5a8
+  version: 6.0.2
+  resolution: "ast-module-types@npm:6.0.2"
+  checksum: 10c0/fd0054131b86c4fd13d8a1a3376a37342ced397e53a3434bf91eabbfcc4387df32952efd9c3ede4265069decb859451bc1516da7e971bce1ebcbbdec1356e5d3
   languageName: node
   linkType: hard
 
@@ -5979,11 +5979,11 @@ __metadata:
   linkType: hard
 
 "baseline-browser-mapping@npm:^2.10.12":
-  version: 2.10.27
-  resolution: "baseline-browser-mapping@npm:2.10.27"
+  version: 2.10.29
+  resolution: "baseline-browser-mapping@npm:2.10.29"
   bin:
     baseline-browser-mapping: dist/cli.cjs
-  checksum: 10c0/8ebadaeeddc99367a1522661476d6c895b452a96023c6cef0576aecf8f5f6d37c91e6bde8fa8904cc11a32c5c6bc9df2030481504e50a5aed17e6c7f8bac3b5a
+  checksum: 10c0/d629a6d87f1aa0585b85ec8bf686bf58d706836fe7827d7bd11f646db2292f2089d8dff33fdd9a1ffe4c07424ae5b08743f57d9405d45cd8ceeb145e8dfb58e5
   languageName: node
   linkType: hard
 
@@ -8345,9 +8345,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.328":
-  version: 1.5.352
-  resolution: "electron-to-chromium@npm:1.5.352"
-  checksum: 10c0/d1672a327420ea0c5dffbd604c448e5bacf9238953f7ce464f3d31c98309bb5ebe82443fb2425de0a78db3ef89261356ee59967dbac866e16262b8bbc0a03209
+  version: 1.5.353
+  resolution: "electron-to-chromium@npm:1.5.353"
+  checksum: 10c0/a5481023e4056d8773b5ccd646906123d82f2821466b26b521b96c9645d0714c5be6a5af792ec8477b904a5fcfe3794bfc45d2acbf8b306f4693842fb85a7cd4
   languageName: node
   linkType: hard
 
@@ -8415,12 +8415,12 @@ __metadata:
   linkType: hard
 
 "enhanced-resolve@npm:^5.0.0, enhanced-resolve@npm:^5.17.1, enhanced-resolve@npm:^5.20.0, enhanced-resolve@npm:^5.21.0":
-  version: 5.21.1
-  resolution: "enhanced-resolve@npm:5.21.1"
+  version: 5.21.2
+  resolution: "enhanced-resolve@npm:5.21.2"
   dependencies:
     graceful-fs: "npm:^4.2.4"
     tapable: "npm:^2.3.3"
-  checksum: 10c0/272b365bb7573fe05384e28e9738a41828a71558bf651683aa194aad79a64a4c19e08857d9fb2f476e3481758c92b2cacf77ba9fa950250fe2e39954a0ac5bc4
+  checksum: 10c0/104714f6481d9310ad561bbc63d1e2ded53d69da934eab8d5aa9c751778e95aeb01531f19cd040d697b38d886d62bbd31f1cdc81e8b3fc66c30a520dc7a293ce
   languageName: node
   linkType: hard
 
@@ -9439,8 +9439,8 @@ __metadata:
   linkType: hard
 
 "filing-cabinet@npm:^5.3.0":
-  version: 5.4.2
-  resolution: "filing-cabinet@npm:5.4.2"
+  version: 5.5.1
+  resolution: "filing-cabinet@npm:5.5.1"
   dependencies:
     app-module-path: "npm:^2.2.0"
     commander: "npm:^12.1.0"
@@ -9455,7 +9455,7 @@ __metadata:
     typescript: "npm:^5.9.3"
   bin:
     filing-cabinet: bin/cli.js
-  checksum: 10c0/43e3cd74f147aa2a087ea6cc086c6f03236969fed24233d1e395e62480844dafac87f6fdc57f3dd16fb07c54e979c6927240653cbf880e121727a48e01b350ca
+  checksum: 10c0/8338ec90c550c8d64f4642f2aadf1f86e43312142fc681561971b393edb3a632371da171638bd0abcc9a60b464cbc6b914af9fc057c413e71fba4f6cafa4e6ef
   languageName: node
   linkType: hard
 
@@ -12852,10 +12852,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:4.17.23":
-  version: 4.17.23
-  resolution: "lodash-es@npm:4.17.23"
-  checksum: 10c0/3150fb6660c14c7a6b5f23bd11597d884b140c0e862a17fdb415aaa5ef7741523182904a6b7929f04e5f60a11edb5a79499eb448734381c99ffb3c4734beeddd
+"lodash-es@npm:4.18.1":
+  version: 4.18.1
+  resolution: "lodash-es@npm:4.18.1"
+  checksum: 10c0/35d4dcf87ef07f8d090f409447575800108057e360b445f590d0d25d09e3d1e33a163d2fc100d4d072b0f901d5e2fc533cd7c4bfd8eeb38a06abec693823c8b8
   languageName: node
   linkType: hard
 
@@ -12985,10 +12985,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.23":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
+"lodash@npm:4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
   languageName: node
   linkType: hard
 
@@ -14448,7 +14448,7 @@ __metadata:
     jest-environment-jsdom: "npm:^29.7.0"
     jest-junit: "npm:^16.0.0"
     js-base64: "npm:^2.5.1"
-    lodash-es: "npm:^4.17.23"
+    lodash-es: "npm:^4.18.1"
     micromatch: "npm:4.0.8"
     mocha-junit-reporter: "npm:^2.2.0"
     mochawesome: "npm:^7.1.3"
@@ -16305,12 +16305,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.7.4, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.3, semver@npm:^7.7.4":
+"semver@npm:7.7.4":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:
     semver: bin/semver.js
   checksum: 10c0/5215ad0234e2845d4ea5bb9d836d42b03499546ddafb12075566899fc617f68794bb6f146076b6881d755de17d6c6cc73372555879ec7dce2c2feee947866ad2
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.3, semver@npm:^7.7.4":
+  version: 7.8.0
+  resolution: "semver@npm:7.8.0"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/8f096ca9b80ffd47b308d03f9ce8c873e27e2983f36023c559cdc92c51e8433fc23ebbfe57ec9623fc155636a6961ee989501099841ae4bb1babc8d2b3f048cd
   languageName: node
   linkType: hard
 
@@ -17251,8 +17260,8 @@ __metadata:
   linkType: hard
 
 "terser-webpack-plugin@npm:^5.3.10":
-  version: 5.5.0
-  resolution: "terser-webpack-plugin@npm:5.5.0"
+  version: 5.6.0
+  resolution: "terser-webpack-plugin@npm:5.6.0"
   dependencies:
     "@jridgewell/trace-mapping": "npm:^0.3.25"
     jest-worker: "npm:^27.4.5"
@@ -17261,13 +17270,31 @@ __metadata:
   peerDependencies:
     webpack: ^5.1.0
   peerDependenciesMeta:
+    "@minify-html/node":
+      optional: true
     "@swc/core":
+      optional: true
+    "@swc/css":
+      optional: true
+    "@swc/html":
+      optional: true
+    clean-css:
+      optional: true
+    cssnano:
+      optional: true
+    csso:
       optional: true
     esbuild:
       optional: true
+    html-minifier-terser:
+      optional: true
+    lightningcss:
+      optional: true
+    postcss:
+      optional: true
     uglify-js:
       optional: true
-  checksum: 10c0/ea2277cc6c80981fd8ce170016b1cd92d33cdf89d50e81ad387218dd46db55b8d69c8f736a35d7deb238962dbe003dd084f0a2494cbbd55f46a9c9d3e90e583a
+  checksum: 10c0/191882a727d571291df49b11bdcfa7459aa78e96c542a993d66f70df052404e3b30157708a80c2895bbe2de4860217c2addcf15d5b2321df8f0aa0de2191f64f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### **Summary**
upgraded version of `lodash-es` and updated resolution versions of `lodash-es` and `lodash` to fix CVE version of transitive dependency

### **Fix**
```
"dependencies": {
   "lodash-es": "^4.18.1",
},
"resolutions":{
   "lodash": "4.18.1",
   "lodash-es": "4.18.1"
}
```

### **Screen Recordings/ Screenshots**

**yarn build**
<img width="1385" height="466" alt="image" src="https://github.com/user-attachments/assets/0a41666e-5ddc-4f88-813e-b9ae9f15f0ef" />


**yarn test**
<img width="1414" height="464" alt="image" src="https://github.com/user-attachments/assets/ce641ec2-c2d2-40c8-b657-8662b0b091e6" />

**UI Sanity**

https://github.com/user-attachments/assets/e555fbce-96f8-44ea-be62-b49a611cfdec


https://github.com/user-attachments/assets/6c5b6c64-3754-47a0-8b1f-82ae31b9bdbd


**dependencies for lodash**
```
yarn why lodash    
├─ @cypress/webpack-preprocessor@npm:5.17.1
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @cypress/webpack-preprocessor@npm:5.17.1 [def00]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @openshift-console/dynamic-plugin-sdk-webpack@npm:1.1.1
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @openshift-console/dynamic-plugin-sdk-webpack@npm:1.1.1 [def00]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @openshift-console/dynamic-plugin-sdk@npm:1.4.0
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @openshift/dynamic-plugin-sdk-utils@npm:4.1.0
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @openshift/dynamic-plugin-sdk-utils@npm:4.1.0 [def00]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @openshift/dynamic-plugin-sdk-webpack@npm:4.1.0
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @openshift/dynamic-plugin-sdk-webpack@npm:4.1.0 [fe5fa]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @openshift/dynamic-plugin-sdk@npm:4.0.0
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @openshift/dynamic-plugin-sdk@npm:4.0.0 [def00]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @patternfly/react-charts@npm:7.2.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @patternfly/react-charts@npm:7.2.2 [def00]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @patternfly/react-table@npm:5.2.1
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @patternfly/react-table@npm:5.4.16
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @patternfly/react-table@npm:5.4.16 [286ce]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @patternfly/react-table@npm:5.2.1 [def00]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @patternfly/react-topology@npm:5.2.1
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ @patternfly/react-topology@npm:5.2.1 [def00]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ babel-types@npm:6.26.0
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ cypress-multi-reporters@npm:1.6.4
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ cypress-multi-reporters@npm:1.6.4 [def00]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ cypress@npm:13.17.0
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ dagre@npm:0.8.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ formik@npm:2.0.3
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ formik@npm:2.0.3 [def00]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ gherkin-lint@npm:4.2.4
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ graphlib@npm:2.1.8
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-area@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-area@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-axis@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-axis@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-bar@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-bar@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-box-plot@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-box-plot@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-brush-container@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-brush-container@npm:36.9.2 [34e9a]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-chart@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-chart@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-core@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-core@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-create-container@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-create-container@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-cursor-container@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-cursor-container@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-group@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-group@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-legend@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-legend@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-line@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-line@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-pie@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-pie@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-polar-axis@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-polar-axis@npm:36.9.2 [589df]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-scatter@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-scatter@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-selection-container@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-selection-container@npm:36.9.2 [34e9a]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-shared-events@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-shared-events@npm:36.9.2 [589df]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-stack@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-stack@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-tooltip@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-tooltip@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-voronoi-container@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-voronoi-container@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-zoom-container@npm:36.9.2
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
├─ victory-zoom-container@npm:36.9.2 [209ad]
│  └─ lodash@npm:4.18.1 (via npm:4.18.1)
│
└─ yup@npm:0.32.11
   └─ lodash@npm:4.18.1 (via npm:4.18.1)
```

**dependencies for lodash-es**

```
yarn why lodash-es
├─ formik@npm:2.0.3
│  └─ lodash-es@npm:4.18.1 (via npm:4.18.1)
│
├─ formik@npm:2.0.3 [def00]
│  └─ lodash-es@npm:4.18.1 (via npm:4.18.1)
│
├─ pipelines-console-plugin@workspace:.
│  └─ lodash-es@npm:4.18.1 (via npm:4.18.1)
│
└─ yup@npm:0.32.11
```