### PR TITLE
SRVKP-10414: removed Tech and Dev Preview badges for GA CRDs

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -179,7 +179,7 @@
       "abbr": "PLR"
     }
   },
-    {
+  {
     "type": "console.model-metadata",
     "properties": {
       "model": {
@@ -208,19 +208,19 @@
     }
   },
   {
-      "type": "console.model-metadata",
-      "properties": {
-        "model": {
-          "group": "tekton.dev",
-          "version": "v1beta1",
-          "kind": "TaskRun"
-        },
-        "color": "#38812f",
-        "label": "%plugin__pipelines-console-plugin~TaskRun%",
-        "labelPlural": "%plugin__pipelines-console-plugin~TaskRuns%",
-        "abbr": "TR"
-      }
-    },
+    "type": "console.model-metadata",
+    "properties": {
+      "model": {
+        "group": "tekton.dev",
+        "version": "v1beta1",
+        "kind": "TaskRun"
+      },
+      "color": "#38812f",
+      "label": "%plugin__pipelines-console-plugin~TaskRun%",
+      "labelPlural": "%plugin__pipelines-console-plugin~TaskRuns%",
+      "abbr": "TR"
+    }
+  },
   {
     "type": "console.model-metadata",
     "properties": {
@@ -246,8 +246,7 @@
       "color": "#38812f",
       "label": "%plugin__pipelines-console-plugin~TriggerBinding%",
       "labelPlural": "%plugin__pipelines-console-plugin~TriggerBindings%",
-      "abbr": "TB",
-      "badge": "tech"
+      "abbr": "TB"
     }
   },
   {
@@ -261,8 +260,7 @@
       "color": "#38812f",
       "label": "%plugin__pipelines-console-plugin~ClusterTriggerBinding%",
       "labelPlural": "%plugin__pipelines-console-plugin~ClusterTriggerBindings%",
-      "abbr": "CTB",
-      "badge": "tech"
+      "abbr": "CTB"
     }
   },
   {
@@ -276,8 +274,7 @@
       "color": "#38812f",
       "label": "%plugin__pipelines-console-plugin~TriggerTemplate%",
       "labelPlural": "%plugin__pipelines-console-plugin~TriggerTemplates%",
-      "abbr": "TT",
-      "badge": "tech"
+      "abbr": "TT"
     }
   },
   {
@@ -291,8 +288,7 @@
       "color": "#38812f",
       "label": "%plugin__pipelines-console-plugin~EventListener%",
       "labelPlural": "%plugin__pipelines-console-plugin~EventListeners%",
-      "abbr": "EL",
-      "badge": "tech"
+      "abbr": "EL"
     }
   },
   {
@@ -306,8 +302,7 @@
       "color": "#38812f",
       "label": "%plugin__pipelines-console-plugin~Repository%",
       "labelPlural": "%plugin__pipelines-console-plugin~Repositories%",
-      "abbr": "R",
-      "badge": "dev"
+      "abbr": "R"
     }
   },
   {
@@ -337,7 +332,7 @@
       "labelPlural": "%plugin__pipelines-console-plugin~TektonHubs%",
       "abbr": "TH"
     }
-  }, 
+  },
   {
     "type": "console.context-provider",
     "properties": {
@@ -1619,7 +1614,9 @@
         "version": "v1",
         "kind": "Task"
       },
-      "provider": { "$codeRef": "defaultActionsProvider.useDefaultActionsProvider" }
+      "provider": {
+        "$codeRef": "defaultActionsProvider.useDefaultActionsProvider"
+      }
     }
   },
   {
@@ -1630,7 +1627,9 @@
         "version": "v1",
         "kind": "Pipeline"
       },
-      "provider": { "$codeRef": "pipelineActionsProvider.usePipelineActionsProvider" }
+      "provider": {
+        "$codeRef": "pipelineActionsProvider.usePipelineActionsProvider"
+      }
     }
   },
   {
@@ -1641,7 +1640,9 @@
         "version": "v1",
         "kind": "PipelineRun"
       },
-      "provider": { "$codeRef": "pipelineRunActionsProvider.usePipelineRunActionsProvider" }
+      "provider": {
+        "$codeRef": "pipelineRunActionsProvider.usePipelineRunActionsProvider"
+      }
     }
   },
   {
@@ -1652,7 +1653,9 @@
         "version": "v1",
         "kind": "TaskRun"
       },
-      "provider": { "$codeRef": "taskRunActionsProvider.useTaskRunActionsProvider" }
+      "provider": {
+        "$codeRef": "taskRunActionsProvider.useTaskRunActionsProvider"
+      }
     }
   },
   {
@@ -1663,7 +1666,9 @@
         "version": "v1beta1",
         "kind": "ClusterTriggerBinding"
       },
-      "provider": { "$codeRef": "defaultActionsProvider.useDefaultActionsProvider" }
+      "provider": {
+        "$codeRef": "defaultActionsProvider.useDefaultActionsProvider"
+      }
     }
   },
   {
@@ -1674,7 +1679,9 @@
         "version": "v1beta1",
         "kind": "EventListener"
       },
-      "provider": { "$codeRef": "defaultActionsProvider.useDefaultActionsProvider" }
+      "provider": {
+        "$codeRef": "defaultActionsProvider.useDefaultActionsProvider"
+      }
     }
   },
   {
@@ -1685,7 +1692,9 @@
         "version": "v1beta1",
         "kind": "TriggerTemplate"
       },
-      "provider": { "$codeRef": "defaultActionsProvider.useDefaultActionsProvider" }
+      "provider": {
+        "$codeRef": "defaultActionsProvider.useDefaultActionsProvider"
+      }
     }
   },
   {
@@ -1696,7 +1705,9 @@
         "version": "v1beta1",
         "kind": "TriggerBinding"
       },
-      "provider": { "$codeRef": "defaultActionsProvider.useDefaultActionsProvider" }
+      "provider": {
+        "$codeRef": "defaultActionsProvider.useDefaultActionsProvider"
+      }
     }
   },
   {
@@ -1707,7 +1718,9 @@
         "version": "v1alpha1",
         "kind": "Repository"
       },
-      "provider": { "$codeRef": "defaultActionsProvider.useDefaultActionsProvider" }
+      "provider": {
+        "$codeRef": "defaultActionsProvider.useDefaultActionsProvider"
+      }
     }
   }
 ]


### PR DESCRIPTION
### **Summary**

Removed `Tech Preview` and `Dev Preview` badges for below CRDs which are already GA

1. Repository (PAC) - Removed Dev Preview label
2. TriggerBinding - Removed Tech Preview label
3. ClusterTriggerBinding - Removed Tech Preview label
4. TriggerTemplate - Removed Tech Preview label
5. EventListener - Removed Tech Preview label

### **Changes**
Removed the respective badges from `console-extensions.json` file

### **Screen Recording - Before**

https://github.com/user-attachments/assets/f15c477a-2512-416d-bca3-25ed399d1c2a


### **Screen Recording - After**

https://github.com/user-attachments/assets/d3e847ab-29be-4558-baac-5a523a7765d6

