### PR TITLE
SRVKP-12111: use cluster resolver namespace for task links on Pipeline details 

### DIFF
--- a/src/components/pipelines-details/utils.ts
+++ b/src/components/pipelines-details/utils.ts
@@ -28,11 +28,14 @@ export const getPipelineTaskLinks = (
           const nameParam = task.taskRef.params?.find(
             (param) => param.name === 'name',
           )?.value;
+          const namespaceParam = task.taskRef.params?.find(
+            (param) => param.name === 'namespace',
+          )?.value;
           return {
             resourceKind: getSafeTaskResourceKind(task.taskRef.kind),
             name: nameParam,
             qualifier: task.name,
-            namespace: PIPELINE_NAMESPACE,
+            namespace: namespaceParam ?? PIPELINE_NAMESPACE,
             resourceApiVersion: version,
           };
         }


### PR DESCRIPTION
## Summary

Fixes incorrect navigation for **cluster resolver** tasks on the Pipeline details page. Task links in the **Tasks** and **Finally tasks** lists were always built against `openshift-pipelines`, even when the `taskRef` specified a different namespace.

The change reads the `namespace` parameter from `taskRef.params` (same pattern as `name`) and falls back to `PIPELINE_NAMESPACE` when it is omitted, so links point at the namespace where the Task actually lives.

## Problem

On the Pipeline details page, `getPipelineTaskLinks()` builds links for cluster-resolver tasks (`taskRef.resolver === 'cluster'`). Before this fix, those links always used `PIPELINE_NAMESPACE` (`openshift-pipelines`) as the target namespace, ignoring the resolver’s `namespace` param.

That broke links for pipelines that reference cluster tasks in another namespace (for example, user namespaces or custom task catalogs).

## Solution

In `getPipelineTaskLinks()` (`src/components/pipelines-details/utils.ts`), extract `namespace` from `taskRef.params` and use:

```ts
namespace: namespaceParam ?? PIPELINE_NAMESPACE
```

Behavior is unchanged when `namespace` is missing or set to `openshift-pipelines`; links are corrected when a different namespace is specified.

## Test plan

- [x] Open a Pipeline that uses cluster resolver tasks with `namespace` set to a namespace other than `openshift-pipelines`
- [x] On the **Details** tab, confirm **Tasks** / **Finally tasks** links open the correct Task in the resolver’s namespace
- [x] Open a Pipeline with cluster resolver tasks that omit `namespace` (or use `openshift-pipelines`) and confirm links still work as before
- [x] Verify embedded tasks, direct `taskRef` tasks, and custom/approval tasks are unaffected

## Screen recording Before

https://github.com/user-attachments/assets/ebdcd5ed-4758-4ef8-ab3f-f61359f7e220

## Screen recording After

#### Cluster resolver tasks in a different namespace

https://github.com/user-attachments/assets/aa9647b8-94bd-49ac-8268-8648e56b4aa5

#### Embedded tasks

https://github.com/user-attachments/assets/60fdee6b-6929-4fe6-b6ee-460ac0c4ba81



