### PR TITLE
SRVKP-11698: added flag for ApprovalTask tab display in PipelineRunDetails page

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -744,6 +744,7 @@
     },
     "flags": {
       "required": [
+        "OPENSHIFT_PIPELINE_APPROVAL_TASK",
         "HIDE_STATIC_PIPELINE_PLUGIN_PIPELINERUN_DETAIL_APPROVALS_TAB"
       ]
     }
@@ -764,6 +765,7 @@
     },
     "flags": {
       "required": [
+        "OPENSHIFT_PIPELINE_APPROVAL_TASK",
         "HIDE_STATIC_PIPELINE_PLUGIN_PIPELINERUN_DETAIL_APPROVALS_TAB"
       ]
     }


### PR DESCRIPTION
### **Summary**
Approvals Tab was getting displayed in PipelineRunDetails page even though MAG was not setup in the cluster, and the tab was giving error.

Conditionally displaying the ApprovalsTab in PipelineRunDetails page, to hide the tab when MAG is not setup in the cluster using `OPENSHIFT_PIPELINE_APPROVAL_TASK` flag

### **Changes**

Added `OPENSHIFT_PIPELINE_APPROVAL_TASK` as required flag for HorizontalNav of PipelineRun in `console-extensions.json`

### **Screen Recording - Before**

https://github.com/user-attachments/assets/7c375234-9002-4498-8cd3-c5f6b0358a5d


### **Screen Recording - After - Without MAG setup**

https://github.com/user-attachments/assets/37efb8bd-effb-4d00-92c8-6e6883be9329


### **Screen Recording - After - With MAG setup**

https://github.com/user-attachments/assets/accd74ec-586d-4bd0-bfcd-5ef2157fc6be

