### PR TITLE
SRVKP-12183: added missing label suggestions for CRs

### DIFF
--- a/src/components/common/DataViewFilterToolbar.scss
+++ b/src/components/common/DataViewFilterToolbar.scss
@@ -1,0 +1,17 @@
+.pipelines-console-plugin-position-relative {
+  position: relative;
+}
+
+.cp-label-suggestion-box {
+  background-color: var(--pf-t--global--background--color--floating--default);
+  box-shadow: var(--pf-t--global--box-shadow--md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pf-t--global--spacer--gap--group--vertical);
+  padding: var(--pf-t--global--spacer--sm);
+  max-height: 200px;
+  overflow-y: auto;
+  position: absolute;
+  width: 100%;
+  z-index: var(--pf-t--global--z-index--sm);
+}

--- a/src/components/common/DataViewFilterToolbar.tsx
+++ b/src/components/common/DataViewFilterToolbar.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import {
   Badge,
   Button,
+  Label,
   Menu,
   MenuContent,
   MenuItem,
@@ -11,6 +12,7 @@ import {
   MenuToggle,
   Popper,
   SearchInput,
+  SelectList,
   Toolbar,
   ToolbarContent,
   ToolbarFilter,
@@ -19,6 +21,7 @@ import {
   ToolbarToggleGroup,
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
+import './DataViewFilterToolbar.scss';
 export interface FilterOption {
   value: string;
   label: string;
@@ -37,7 +40,8 @@ export interface CheckboxFilterConfig {
 export interface FilterValues {
   name: string;
   labels: string[];
-  [key: string]: string | string[];
+  labelSuggestions?: string[];
+  [key: string]: string | string[] | undefined;
 }
 
 interface DataViewFilterToolbarProps {
@@ -153,6 +157,94 @@ const CheckboxFilterInput: FC<{
         appendTo={containerRef.current || undefined}
         isVisible={isOpen}
       />
+    </div>
+  );
+};
+
+const LabelFilterInput: FC<{
+  value: string;
+  onChange: (value: string) => void;
+  onSelect: (label: string) => void;
+  suggestions: string[];
+  selectedLabels: string[];
+  placeholder?: string;
+}> = ({
+  value,
+  onChange,
+  onSelect,
+  suggestions,
+  selectedLabels,
+  placeholder,
+}) => {
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const filtered = useMemo(() => {
+    if (!value.trim()) return [];
+    const processedText = value.trim().replace(/\s*=\s*/, '=');
+    const lower = processedText.toLowerCase();
+    return suggestions.filter(
+      (s) => !selectedLabels.includes(s) && s.toLowerCase().includes(lower),
+    );
+  }, [suggestions, selectedLabels, value]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setShowSuggestions(false);
+      }
+    };
+    window.addEventListener('click', handleClickOutside);
+    return () => window.removeEventListener('click', handleClickOutside);
+  }, []);
+
+  const handleSelect = (label: string) => {
+    onSelect(label);
+    onChange('');
+    setShowSuggestions(false);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="pipelines-console-plugin-position-relative"
+    >
+      <SearchInput
+        placeholder={placeholder}
+        value={value}
+        onChange={(_event, v) => {
+          onChange(v);
+          setShowSuggestions(!!v.trim());
+        }}
+        onFocus={() => {
+          if (value.trim()) setShowSuggestions(true);
+        }}
+        onClear={() => {
+          onChange('');
+          setShowSuggestions(false);
+        }}
+        onKeyUp={(e) => {
+          if (e.key === 'Enter' && value.trim()) {
+            handleSelect(value.trim());
+          }
+        }}
+      />
+      {showSuggestions && filtered.length > 0 && (
+        <SelectList className="cp-label-suggestion-box">
+          {filtered.map((label) => (
+            <div key={label}>
+              <Label
+                variant="outline"
+                color="purple"
+                onClick={() => handleSelect(label)}
+                style={{ cursor: 'pointer' }}
+              >
+                {label}
+              </Label>
+            </div>
+          ))}
+        </SelectList>
+      )}
     </div>
   );
 };
@@ -350,24 +442,20 @@ export const DataViewFilterToolbar: FC<DataViewFilterToolbarProps> = ({
                 categoryName={t('Label')}
                 showToolbarItem={activeCategory === t('Label')}
               >
-                <SearchInput
-                  placeholder={t('Filter by label')}
+                <LabelFilterInput
                   value={labelInput}
-                  onChange={(_event, value) => setLabelInput(value)}
-                  onClear={() => setLabelInput('')}
-                  onKeyUp={(e) => {
-                    if (
-                      e.key === 'Enter' &&
-                      labelInput.trim() &&
-                      !(filterValues.labels || []).includes(labelInput.trim())
-                    ) {
+                  onChange={setLabelInput}
+                  onSelect={(label) => {
+                    if (!(filterValues.labels || []).includes(label)) {
                       onFilterChange('labels', [
                         ...(filterValues.labels || []),
-                        labelInput.trim(),
+                        label,
                       ]);
-                      setLabelInput('');
                     }
                   }}
+                  suggestions={filterValues.labelSuggestions || []}
+                  selectedLabels={filterValues.labels || []}
+                  placeholder={t('Filter by label')}
                 />
               </ToolbarFilter>
             )}

--- a/src/components/hooks/useDataViewFilter.ts
+++ b/src/components/hooks/useDataViewFilter.ts
@@ -232,7 +232,7 @@ export const useDataViewFilter = <T extends K8sResourceCommon>({
     return values;
   }, [checkboxFilters]);
 
-  const [filterValues, setFilterValues] = useState<FilterValues>(initialValues);
+  const [filterState, setFilterState] = useState<FilterValues>(initialValues);
   const [, setSearchParams] = useSearchParams();
 
   const resetPage = useCallback(() => {
@@ -245,27 +245,47 @@ export const useDataViewFilter = <T extends K8sResourceCommon>({
 
   const onFilterChange = useCallback(
     (key: string, value: string | string[]) => {
-      setFilterValues((prev) => ({ ...prev, [key]: value }));
+      setFilterState((prev) => ({ ...prev, [key]: value }));
       resetPage();
     },
     [resetPage],
   );
 
   const onClearAll = useCallback(() => {
-    setFilterValues(resetFilterState);
+    setFilterState(resetFilterState);
     resetPage();
   }, [resetPage]);
+
+  const labelSuggestions = useMemo(() => {
+    if (!data) return [];
+    const labelsSet = new Set<string>();
+    const getLabelsFn = getLabels ?? defaultGetLabels;
+    data.forEach((obj) => {
+      const labels = getLabelsFn(obj);
+      if (labels) {
+        Object.entries(labels).forEach(([key, value]) => {
+          labelsSet.add(`${key}=${value}`);
+        });
+      }
+    });
+    return Array.from(labelsSet).sort();
+  }, [data, getLabels]);
+
+  const filterValues = useMemo<FilterValues>(
+    () => ({ ...filterState, labelSuggestions }),
+    [filterState, labelSuggestions],
+  );
 
   const passesNameAndLabelFilters = useCallback(
     (obj: T): boolean => {
       const name = getName(obj);
       if (
-        filterValues.name &&
-        !name?.toLowerCase().includes(filterValues.name.toLowerCase())
+        filterState.name &&
+        !name?.toLowerCase().includes(filterState.name.toLowerCase())
       ) {
         return false;
       }
-      const labelFilters = filterValues.labels || [];
+      const labelFilters = filterState.labels || [];
       if (labelFilters.length > 0 && getLabels) {
         if (!matchesLabels(getLabels(obj), labelFilters)) {
           return false;
@@ -273,7 +293,7 @@ export const useDataViewFilter = <T extends K8sResourceCommon>({
       }
       return true;
     },
-    [filterValues.name, filterValues.labels, getName, getLabels],
+    [filterState.name, filterState.labels, getName, getLabels],
   );
 
   const passesCheckboxFilter = useCallback(
@@ -281,7 +301,7 @@ export const useDataViewFilter = <T extends K8sResourceCommon>({
       if (!resourceType) return true;
       for (const filter of checkboxFilters) {
         if (filter.id === excludeFilterId) continue;
-        const selected = (filterValues[filter.id] as string[]) || [];
+        const selected = (filterState[filter.id] as string[]) || [];
         if (
           selected.length > 0 &&
           !matchesCheckboxFilter(obj, filter.id, selected)
@@ -291,7 +311,7 @@ export const useDataViewFilter = <T extends K8sResourceCommon>({
       }
       return true;
     },
-    [resourceType, checkboxFilters, filterValues, matchesCheckboxFilter],
+    [resourceType, checkboxFilters, filterState, matchesCheckboxFilter],
   );
 
   const filteredData = useMemo(() => {


### PR DESCRIPTION
## Summary

Add label filter suggestions to the DataView filter toolbar, matching the behavior of the OpenShift Console’s `ListPageFilter` / `AutocompleteInput` label filter.

- **`useDataViewFilter`**: Collects unique `key=value` labels from the resource data passed into the hook and exposes them via `filterValues.labelSuggestions`, so list pages do not need any changes.
- **`DataViewFilterToolbar`**: Replaces the plain label `SearchInput` with a `LabelFilterInput` that shows suggestions as users type.
- **Suggestion list behavior**:
  - Suggestions appear only after the user enters text (not on focus alone)
  - Case-insensitive substring matching against the full `key=value` string (matches both key and value)
  - Normalizes whitespace around `=` (e.g. `key = value` → `key=value`)
  - Excludes labels already selected as filter chips
  - Supports click-to-select and Enter to add a custom label
  - Uses PatternFly `SelectList` + purple `Label` chips, styled similarly to the console repo
  - Suggestion box is scrollable with `max-height: 200px`

Here are titles you can add under **Screen recordings**:

## Screen recordings

- **User events**

https://github.com/user-attachments/assets/5912e223-fca6-4c15-ba40-8562aebc9325

- **Cluster Trigger Bindings and Pipelines with label filtering** 

https://github.com/user-attachments/assets/640ebaf5-c2a0-47c9-86ea-0722fec9f36a

- **TaskRuns with pagination** 

https://github.com/user-attachments/assets/f8a85647-ef5f-4676-88c6-7fa67e4b051c

- **Pipelines, PipelineRuns, and Tasks** 

https://github.com/user-attachments/assets/25f0dbaa-8ed5-4519-bd64-27a14ffb3226

## Assisted by:
Claude 4.6 Opus High
