### PR TITLE
SRVKP-12177: fix to reset Pagination for ConsoleDataView when Filtering by name

### DIFF
--- a/src/components/pipelines-overview/__tests__/PipelinesOverview.spec.tsx
+++ b/src/components/pipelines-overview/__tests__/PipelinesOverview.spec.tsx
@@ -38,6 +38,7 @@ jest.mock('react-redux', () => ({
 }));
 jest.mock('react-router', () => ({
   useLocation: jest.fn(),
+  useSearchParams: jest.fn(() => [new URLSearchParams(), jest.fn()]),
 }));
 
 jest.spyOn(utils, 'useQueryParams').mockReturnValue(null);

--- a/src/components/pipelines-overview/list-pages/PipelineRunsListPage.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsListPage.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 import { useState, useRef, useEffect } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
+import { useSearchParams } from 'react-router';
 import {
   Alert,
   Card,
@@ -36,6 +37,7 @@ const PipelineRunsListPage: FC<PipelineRunsListPageProps> = ({
 }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
   const isDevConsoleProxyAvailable = useFlag(FLAGS.DEVCONSOLE_PROXY);
+  const [, setSearchParams] = useSearchParams();
 
   const [pageFlag, setPageFlag] = useState(1);
   const [loaded, setloaded] = useState(false);
@@ -163,6 +165,12 @@ const PipelineRunsListPage: FC<PipelineRunsListPageProps> = ({
         .includes(value.toLowerCase()),
     );
     setSummaryDataFiltered(filteredData);
+    setSearchParams((prev) => {
+      /*Reset Pagination for ConsoleDataView when Filtering by name*/
+      const next = new URLSearchParams(prev);
+      next.set('page', '1');
+      return next;
+    });
   };
   return (
     <Card

--- a/src/components/pipelines-overview/list-pages/PipelineRunsListPageK8s.tsx
+++ b/src/components/pipelines-overview/list-pages/PipelineRunsListPageK8s.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react';
 import { useState, useMemo, useEffect } from 'react';
 import classNames from 'classnames';
+import { useSearchParams } from 'react-router';
 import { Alert, Card, CardBody, Grid, GridItem } from '@patternfly/react-core';
 import {
   PrometheusResponse,
@@ -128,6 +129,7 @@ const PipelineRunsListPageK8s: FC<PipelineRunsListPageProps> = ({
   const [searchText, setSearchText] = useState('');
   const [tickValues, type] = getXaxisValues(timespan);
   const { t } = useTranslation('plugin__pipelines-console-plugin');
+  const [, setSearchParams] = useSearchParams();
 
   const [projects, projectsLoaded] = useK8sWatchResource<Project[]>({
     isList: true,
@@ -231,6 +233,12 @@ const PipelineRunsListPageK8s: FC<PipelineRunsListPageProps> = ({
 
   const handleNameChange = (value: string) => {
     setSearchText(value);
+    setSearchParams((prev) => {
+      /*Reset Pagination for ConsoleDataView when Filtering by name*/
+      const next = new URLSearchParams(prev);
+      next.set('page', '1');
+      return next;
+    });
   };
 
   useEffect(() => {


### PR DESCRIPTION
### **Summary**

- Fixes pagination not resetting to page 1 when filtering PipelineRuns by name in the Overview list pages
- When a user types in the name filter, the page search param is now explicitly set to 1, ensuring ConsoleDataView shows results from the first page instead of potentially showing an empty page

### **Changes**
The fix uses useSearchParams from react-router to reset page to 1 inside the name-filter handler in both components.

1. PipelineRunsListPage.tsx 
2. PipelineRunsListPageK8s.tsx

### **Test Plan**

- [ ]  Navigate to the Pipelines Overview page
- [ ]  Go to the PipelineRuns list tab
- [ ]  Page forward (e.g. go to page 2 or 3)
- [ ]  Type a filter string in the name search box
- [ ]  Verify the list resets to page 1 and shows matching results
- [ ]  Verify clearing the filter still works correctly and pagination is functional

### **Screen Recordings**

**Before**

https://github.com/user-attachments/assets/dd61020b-21e0-4aad-a9ca-00b258ac8be6

**After Fix - Tekton Results**

https://github.com/user-attachments/assets/9ea13c49-8881-46e1-89d1-91a75f432b80

**After Fix - Prometheus**

https://github.com/user-attachments/assets/f5c096ea-01b2-4359-b936-e8797a8df4b6


Assisted-by: Claude 4.6 high
