### PR TITLE
SRVKP-9448: Resolve overlapping text in Approvals list Current Status column

### DIFF
--- a/src/components/approval-tasks/ApprovalRow.scss
+++ b/src/components/approval-tasks/ApprovalRow.scss
@@ -1,5 +1,4 @@
 .pipelines-approval-status-icon {
-  position: fixed;
   margin-left: -10px;
 
   @-moz-document url-prefix() {


### PR DESCRIPTION
## Description:
This PR fixes a UI rendering bug in the OpenShift Pipelines Approvals tab where the "Current status" elements were superimposing on top of one another, making the text unreadable.

## Root Cause & Technical Fix:
The issue was caused by a position: fixed CSS property applied to the status component. Because fixed positioning removes elements from the standard document flow, multiple status items within the column were collapsing onto the exact same coordinate space on the screen.

By removing position: fixed, the status components now respect the natural flow of the table cell, restoring proper alignment and readability.

## Screen Shot
### Before
<img width="1004" height="472" alt="[SRVKP-9448](https://redhat.atlassian.net/browse/SRVKP-9448)-Before" src="https://github.com/user-attachments/assets/45850c9f-793a-4fd5-981c-87d74312839b" />

### After
<img width="1279" height="608" alt="[SRVKP-9448](https://redhat.atlassian.net/browse/SRVKP-9448)-After" src="https://github.com/user-attachments/assets/c4dd537b-2b29-421d-a907-2b7c07f7a644" />

## Release Notes
The "Current Status" column now renders correctly instead of an overlap, making it easier to read and verify pipeline tasks.
