### PR TITLE
SRVKP-12147: fix mag toast redirection for non-admin user with approval task from multiple namespace

### DIFF
--- a/locales/en/plugin__pipelines-console-plugin.json
+++ b/locales/en/plugin__pipelines-console-plugin.json
@@ -454,6 +454,7 @@
   "Right click": "Right click",
   "Route": "Route",
   "Routes": "Routes",
+  "run{{plural}} in namespace {{namespaceName}}.": "run{{plural}} in namespace {{namespaceName}}.",
   "run{{plural}} in other namespaces.": "run{{plural}} in other namespaces.",
   "run{{plural}}.": "run{{plural}}.",
   "Running": "Running",

--- a/src/components/approval-tasks/approval-notification/ApprovalToastContent.tsx
+++ b/src/components/approval-tasks/approval-notification/ApprovalToastContent.tsx
@@ -5,53 +5,44 @@ import { ExternalLink } from '../../utils/link';
 import './ApprovalToastContent.scss';
 
 interface ApprovalToastContentProps {
-  type: string;
+  type: 'current' | 'other' | 'admin';
   uniquePipelineRuns: number;
-  devconsolePath?: string;
-  adminconsolePath?: string;
+  path: string;
+  namespaceName?: string;
 }
 
 const ApprovalToastContent: FC<ApprovalToastContentProps> = ({
   type,
   uniquePipelineRuns,
-  devconsolePath,
-  adminconsolePath,
+  path,
+  namespaceName,
 }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
-  if (type === 'current') {
-    return (
-      <>
-        {t('Your approval has been requested on {{plrs}} pipeline', {
-          plrs: uniquePipelineRuns,
-        })}
-        {t('run{{plural}}.', {
-          plural: uniquePipelineRuns > 1 ? 's' : '',
-        })}
-        <p className="pipelines-approval-toast__link">
-          <ExternalLink href={devconsolePath} text={t('Go to Approvals tab')} />
-        </p>
-      </>
-    );
-  }
-  if (type === 'other') {
-    return (
-      <>
-        {t('Your approval has been requested on {{plrs}} pipeline', {
-          plrs: uniquePipelineRuns,
-        })}
-        {t('run{{plural}} in other namespaces.', {
-          plural: uniquePipelineRuns > 1 ? 's' : '',
-        })}
-        <p className="pipelines-approval-toast__link">
-          <ExternalLink
-            href={adminconsolePath}
-            text={t('Go to Admin Approvals tab')}
-          />
-        </p>
-      </>
-    );
-  }
-  return null;
+  const linkText =
+    type === 'admin'
+      ? t('Go to Admin Approvals tab')
+      : t('Go to Approvals tab');
+  const plural = uniquePipelineRuns > 1 ? 's' : '';
+  const suffixMap = {
+    other: t('run{{plural}} in namespace {{namespaceName}}.', {
+      plural,
+      namespaceName,
+    }),
+    admin: t('run{{plural}} in other namespaces.', { plural }),
+    current: t('run{{plural}}.', { plural }),
+  };
+
+  return (
+    <>
+      {t('Your approval has been requested on {{plrs}} pipeline', {
+        plrs: uniquePipelineRuns,
+      })}
+      {suffixMap[type]}
+      <p className="pipelines-approval-toast__link">
+        <ExternalLink href={path} text={linkText} />
+      </p>
+    </>
+  );
 };
 
 export default ApprovalToastContent;

--- a/src/components/approval-tasks/approval-notification/pipeline-approval-context.tsx
+++ b/src/components/approval-tasks/approval-notification/pipeline-approval-context.tsx
@@ -3,7 +3,9 @@ import { AlertVariant } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import {
   WatchK8sResource,
+  useAccessReview,
   useActiveNamespace,
+  useActivePerspective,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
   getGroupVersionKindForModel,
@@ -16,7 +18,12 @@ import {
   ApproverStatusResponse,
 } from '../../../types';
 import { ApprovalTaskModel } from '../../../models';
-import { ApprovalLabels, ApprovalFields } from '../../../consts';
+import {
+  ApprovalLabels,
+  ApprovalFields,
+  DEV_PERSPECTIVE_BASE_PATH,
+  ADMIN_PERSPECTIVE_BASE_PATH,
+} from '../../../consts';
 import { useToast } from '../../toast/useToast';
 import { useActiveUserWithUpdate } from '../../hooks/hooks';
 import { isUserAuthorizedForApproval } from '../../utils/approval-group-utils';
@@ -47,8 +54,18 @@ export const usePipelineApprovalToast = () => {
   const [currentToasts, setCurrentToasts] = useState<{
     [key: string]: { toastId: string };
   }>({});
-  const devconsolePath = `/dev-pipelines/ns/${namespace}/approvals?rowFilter-status=pending`;
-  const adminconsolePath = `pipelines/all-namespaces/approvals?rowFilter-status=pending`;
+  const [perspective] = useActivePerspective();
+  const basePath =
+    perspective.toLowerCase() === 'dev'
+      ? DEV_PERSPECTIVE_BASE_PATH
+      : ADMIN_PERSPECTIVE_BASE_PATH;
+  const currentNsPath = `${basePath}/ns/${namespace}/approvals?rowFilter-status=pending`;
+
+  const [canAccessAllNamespace] = useAccessReview({
+    group: '',
+    resource: 'namespaces',
+    verb: 'list',
+  });
 
   const approvalsResource: WatchK8sResource = {
     groupVersionKind: getGroupVersionKindForModel(ApprovalTaskModel),
@@ -57,20 +74,31 @@ export const usePipelineApprovalToast = () => {
   const [approvalTasks] =
     useK8sWatchResource<ApprovalTaskKind[]>(approvalsResource);
   useEffect(() => {
-    if (currentToasts?.current?.toastId) {
-      removeToast(currentToasts.current.toastId);
-      setCurrentToasts((toasts) => ({ ...toasts, current: { toastId: '' } }));
-    }
-    if (currentToasts?.other?.toastId) {
-      removeToast(currentToasts.other.toastId);
-      setCurrentToasts((toasts) => ({ ...toasts, other: { toastId: '' } }));
-    }
-  }, [approvalTasks, currentUser.username, t, addToast, removeToast]);
+    Object.entries(currentToasts).forEach(([key, { toastId }]) => {
+      if (toastId) {
+        removeToast(toastId);
+        setCurrentToasts((toasts) => ({ ...toasts, [key]: { toastId: '' } }));
+      }
+    });
+    //cleanup to removeToast
+    return () => {
+      Object.entries(currentToasts).forEach(([key, { toastId }]) => {
+        if (toastId) {
+          removeToast(toastId);
+        }
+      });
+    };
+  }, [
+    approvalTasks,
+    currentUser.username,
+    t,
+    addToast,
+    removeToast,
+    namespace,
+  ]);
 
   useEffect(() => {
     const processApprovalTasks = async () => {
-      let toastID = '';
-
       // Filter approval tasks for current user with async group checking
       const userApprovalTasksInWait = [];
       for (const approvalTask of approvalTasks) {
@@ -132,50 +160,89 @@ export const usePipelineApprovalToast = () => {
         ).size;
 
         if (uniquePipelineRuns > 0) {
-          toastID = addToast({
+          const toastID = addToast({
             variant: AlertVariant.custom,
             title: t('Task approval required'),
             content: (
               <ApprovalToastContent
                 type="current"
                 uniquePipelineRuns={uniquePipelineRuns}
-                devconsolePath={devconsolePath}
+                path={currentNsPath}
               />
             ),
             timeout: 25000,
             dismissible: true,
           }) as any;
+          setCurrentToasts((toasts) => ({
+            ...toasts,
+            current: { toastId: toastID },
+          }));
         }
-        setCurrentToasts((toasts) => ({
-          ...toasts,
-          current: { toastId: toastID },
-        }));
       }
 
       if (otherNsApprovalTasks.length > 0) {
-        const uniquePipelineRuns = new Set(
-          getPipelineRunsofApprovals(otherNsApprovalTasks),
-        ).size;
+        const tasksByNamespace = otherNsApprovalTasks.reduce<
+          Record<string, ApprovalTaskKind[]>
+        >((acc, task) => {
+          const ns = task?.metadata?.namespace;
+          if (ns) {
+            acc[ns] = acc[ns] || [];
+            acc[ns].push(task);
+          }
+          return acc;
+        }, {});
 
-        if (uniquePipelineRuns > 0) {
-          toastID = addToast({
+        if (canAccessAllNamespace) {
+          const allNsPath = `${basePath}/all-namespaces/approvals?rowFilter-status=pending`;
+          const totalPipelineRuns = new Set(
+            getPipelineRunsofApprovals(otherNsApprovalTasks),
+          ).size;
+          const toastId = addToast({
             variant: AlertVariant.custom,
             title: t('Task approval required'),
             content: (
               <ApprovalToastContent
-                type="other"
-                uniquePipelineRuns={uniquePipelineRuns}
-                adminconsolePath={adminconsolePath}
+                type="admin"
+                uniquePipelineRuns={totalPipelineRuns}
+                path={allNsPath}
               />
             ),
             timeout: 25000,
             dismissible: true,
+          }) as any;
+          setCurrentToasts((toasts) => ({
+            ...toasts,
+            [`all-ns`]: { toastId: toastId },
+          }));
+        } else {
+          Object.entries(tasksByNamespace).forEach(([ns, tasks]) => {
+            const uniquePipelineRuns = new Set(
+              getPipelineRunsofApprovals(tasks),
+            ).size;
+
+            if (uniquePipelineRuns > 0) {
+              const nsPath = `${basePath}/ns/${ns}/approvals?rowFilter-status=pending`;
+              const toastID = addToast({
+                variant: AlertVariant.custom,
+                title: t('Task approval required'),
+                content: (
+                  <ApprovalToastContent
+                    type="other"
+                    uniquePipelineRuns={uniquePipelineRuns}
+                    path={nsPath}
+                    namespaceName={ns}
+                  />
+                ),
+                timeout: 25000,
+                dismissible: true,
+              }) as any;
+              setCurrentToasts((toasts) => ({
+                ...toasts,
+                [`other-${ns}`]: { toastId: toastID },
+              }));
+            }
           });
         }
-        setCurrentToasts((toasts) => ({
-          ...toasts,
-          other: { toastId: toastID },
-        }));
       }
     };
 
@@ -186,8 +253,9 @@ export const usePipelineApprovalToast = () => {
     namespace,
     t,
     addToast,
-    devconsolePath,
-    adminconsolePath,
+    basePath,
+    currentNsPath,
     updateUserInfo,
+    canAccessAllNamespace,
   ]);
 };

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -201,3 +201,5 @@ export const PIPELINE_RUN_KUEUE_ORIGIN_LABEL =
   'kueue.x-k8s.io/multikueue-origin';
 export const KUEUE_LABEL_PREFIX = 'kueue.x-k8s.io';
 export const DASH = '-';
+export const ADMIN_PERSPECTIVE_BASE_PATH = '/pipelines';
+export const DEV_PERSPECTIVE_BASE_PATH = '/dev-pipelines';


### PR DESCRIPTION
### **Summary**
Fixed approval toast notification redirection for non-admin users. Previously, "other namespace" approval toasts always linked to the admin console's all-namespaces path, which non-admin users cannot access. Now the plugin checks useAccessReview for namespace-list permission and adjusts behavior accordingly

- Admin users see a single aggregated toast linking to the all-namespaces approvals view.
- Non-admin users see one toast per namespace, each linking directly to that namespace's approvals tab.

### **Changes**

- Perspective-aware paths: Toast links now respect the active perspective (dev vs admin) using useActivePerspective, instead of hardcoding /dev-pipelines or /pipelines prefixes.
- Refactor: `ApprovalToastContent` to accept a single path prop (plus optional namespaceName) instead of separate devconsolePath / adminconsolePath, reducing duplication and simplifying the component. A new type: 'admin' variant was added for the all-namespaces case.
- Cleanup: Generalized toast removal logic to iterate over all tracked toasts instead of checking current and other individually; moved setCurrentToasts inside the uniquePipelineRuns > 0 guard to avoid storing empty toast IDs.

### **Test plan**


- [ ]  Log in as a non-admin user with access to multiple namespaces, trigger approval tasks, and verify individual per-namespace toasts appear with correct links.
- [ ] Log in as a cluster-admin user, trigger approval tasks in multiple namespaces, and verify a single toast appears linking to the all-namespaces approvals view along with a single toast if the user is active in some namespace.
- [ ]  Switch between dev and admin perspectives and confirm toast links use the correct base path (/dev-pipelines vs /pipelines).
- [ ]  Verify clicking the toast link navigates to the approvals tab with the pending filter applied.
- [ ]  Confirm toasts are properly dismissed and replaced when the approval task list changes.

### **Screen Recordings**
**Before Fix**

https://github.com/user-attachments/assets/c22d01c6-3a7f-4989-8d44-b0d68e0c8a5c


After Fix - NonAdmin Approver User with ApprovalTasks from Multiple NameSpace

https://github.com/user-attachments/assets/7aaf5b9a-0e94-4da3-a8e4-1523ca1a1b8c

After Fix - Admin Approver User

https://github.com/user-attachments/assets/9d43302d-c427-4d97-bcf9-b5f436497fbc


Assisted-by: Claude 4.6 high
