### PR TITLE
SRVKP-11485: add loading indicators for PipelineRun and TaskRun logs

### DIFF
--- a/src/components/logs/LogsWrapperComponent.tsx
+++ b/src/components/logs/LogsWrapperComponent.tsx
@@ -197,11 +197,13 @@ const LogsWrapperComponent: FC<
           </Button>
         )}
       </div>
-      <div className="pf-v6-u-flex-1">
-        {!effectiveError ? (
+
+      {!effectiveError ? (
+        <div className="pf-v6-u-flex-1">
           <MultiStreamLogs
             {...props}
             taskName={taskName}
+            loaded={effectiveLoaded}
             resource={resourceRef.current}
             setCurrentLogsGetter={setLogGetter}
             activeStep={activeStep}
@@ -209,13 +211,13 @@ const LogsWrapperComponent: FC<
             pipelineRunName={pipelineRunName}
             pipelineRunFinished={pipelineRunFinished}
           />
-        ) : (
-          <TektonTaskRunLog
-            taskRun={taskRun}
-            setCurrentLogsGetter={setLogGetter}
-          />
-        )}
-      </div>
+        </div>
+      ) : (
+        <TektonTaskRunLog
+          taskRun={taskRun}
+          setCurrentLogsGetter={setLogGetter}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/logs/MultiStreamLogs.tsx
+++ b/src/components/logs/MultiStreamLogs.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 import Logs from './Logs';
 import { getRenderContainers } from './logs-utils';
 import { PodKind } from '../../types';
+import { Loading } from '../Loading';
 
 type MultiStreamLogsProps = {
   resource: PodKind;
@@ -11,6 +12,7 @@ type MultiStreamLogsProps = {
   isResourceManagedByKueue?: boolean;
   pipelineRunName?: string;
   pipelineRunFinished?: boolean;
+  loaded?: boolean;
 };
 
 export const MultiStreamLogs: FC<MultiStreamLogsProps> = ({
@@ -21,27 +23,30 @@ export const MultiStreamLogs: FC<MultiStreamLogsProps> = ({
   isResourceManagedByKueue,
   pipelineRunName,
   pipelineRunFinished,
+  loaded,
 }) => {
   const { containers, stillFetching } = getRenderContainers(resource);
 
+  if (!loaded) {
+    return <Loading />;
+  }
+
   return (
-    <>
-      <div
-        data-test-id="logs-task-container"
-        className="pf-v6-u-h-100 pf-v6-u-w-100"
-      >
-        <Logs
-          stillFetching={stillFetching}
-          taskName={taskName}
-          resource={resource}
-          containers={containers}
-          setCurrentLogsGetter={setCurrentLogsGetter}
-          activeStep={activeStep}
-          isResourceManagedByKueue={isResourceManagedByKueue}
-          pipelineRunName={pipelineRunName}
-          pipelineRunFinished={pipelineRunFinished}
-        />
-      </div>
-    </>
+    <div
+      data-test-id="logs-task-container"
+      className="pf-v6-u-h-100 pf-v6-u-w-100"
+    >
+      <Logs
+        stillFetching={stillFetching}
+        taskName={taskName}
+        resource={resource}
+        containers={containers}
+        setCurrentLogsGetter={setCurrentLogsGetter}
+        activeStep={activeStep}
+        isResourceManagedByKueue={isResourceManagedByKueue}
+        pipelineRunName={pipelineRunName}
+        pipelineRunFinished={pipelineRunFinished}
+      />
+    </div>
   );
 };

--- a/src/components/logs/TektonTaskRunLog.tsx
+++ b/src/components/logs/TektonTaskRunLog.tsx
@@ -55,7 +55,7 @@ export const TektonTaskRunLog: FC<TektonTaskRunLogProps> = ({
     <>
       <div
         data-test-id="tr-logs-task-container"
-        className="odc-tekton-taskrun-log pf-v6-u-h-100 pf-v6-u-w-100"
+        className="pf-v6-u-h-100 pf-v6-u-w-100"
       >
         <LogViewer
           useAnsiClasses={true}

--- a/src/components/pipelineRuns-details/PipelineRunLogs.tsx
+++ b/src/components/pipelineRuns-details/PipelineRunLogs.tsx
@@ -31,6 +31,7 @@ import { pipelineRunStatus } from '../utils/pipeline-filter-reducer';
 import { ColoredStatusIcon } from '../pipeline-topology/StatusIcons';
 import { resourcePathFromModel } from '../utils/utils';
 import './PipelineRunLogs.scss';
+import { Loading } from '../Loading';
 
 interface PipelineRunLogsProps {
   obj: PipelineRunKind;
@@ -193,50 +194,52 @@ const PipelineRunLogs: FC<PipelineRunLogsProps> = ({
           className="odc-pipeline-run-logs__tasklist"
           data-test-id="logs-tasklist"
         >
-          {taskCount > 0 ? (
+          {!waitingForPods && (
             <Nav onSelect={onNavSelect}>
               <NavList className="odc-pipeline-run-logs__nav">
-                {taskRunNames.map((taskRunName) => {
-                  const taskRun = tRuns.find(
-                    (tRun) => tRun.metadata.name === taskRunName,
-                  );
-                  return (
-                    <NavItem
-                      key={taskRunName}
-                      itemId={taskRunName}
-                      isActive={activeItem === taskRunName}
-                      className="odc-pipeline-run-logs__navitem"
-                    >
-                      <Link
-                        to={`${logsPath}?taskName=${
-                          taskRun?.metadata?.labels?.[
-                            TektonResourceLabel.pipelineTask
-                          ] || '-'
-                        }`}
+                {taskRunNames?.length > 0 ? (
+                  taskRunNames.map((taskRunName) => {
+                    const taskRun = tRuns.find(
+                      (tRun) => tRun.metadata.name === taskRunName,
+                    );
+                    return (
+                      <NavItem
+                        key={taskRunName}
+                        itemId={taskRunName}
+                        isActive={activeItem === taskRunName}
+                        className="odc-pipeline-run-logs__navitem"
                       >
-                        <ColoredStatusIcon status={taskRunStatus(taskRun)} />
-                        <span
-                          className="odc-pipeline-run-logs__namespan"
-                          ref={
-                            activeItem === taskRunName
-                              ? selectedItemRef
-                              : undefined
-                          }
+                        <Link
+                          to={`${logsPath}?taskName=${
+                            taskRun?.metadata?.labels?.[
+                              TektonResourceLabel.pipelineTask
+                            ] || '-'
+                          }`}
                         >
-                          {taskRun?.metadata?.labels?.[
-                            TektonResourceLabel.pipelineTask
-                          ] || '-'}
-                        </span>
-                      </Link>
-                    </NavItem>
-                  );
-                })}
+                          <ColoredStatusIcon status={taskRunStatus(taskRun)} />
+                          <span
+                            className="odc-pipeline-run-logs__namespan"
+                            ref={
+                              activeItem === taskRunName
+                                ? selectedItemRef
+                                : undefined
+                            }
+                          >
+                            {taskRun?.metadata?.labels?.[
+                              TektonResourceLabel.pipelineTask
+                            ] || '-'}
+                          </span>
+                        </Link>
+                      </NavItem>
+                    );
+                  })
+                ) : (
+                  <div className="odc-pipeline-run-logs__nav pf-v6-u-text-align-center">
+                    {t('No task runs found')}
+                  </div>
+                )}
               </NavList>
             </Nav>
-          ) : (
-            <div className="odc-pipeline-run-logs__nav pf-v6-u-text-align-center">
-              {t('No task runs found')}
-            </div>
           )}
         </div>
         {activeItem && resources ? (
@@ -251,7 +254,7 @@ const PipelineRunLogs: FC<PipelineRunLogsProps> = ({
             pipelineRunName={obj.metadata?.name}
             pipelineRunFinished={pipelineRunFinished}
           />
-        ) : (
+        ) : pipelineRunFinished && taskCount == 0 ? (
           <div
             className="pf-v6-u-w-100 pf-v6-u-pr-xl"
             data-test-id="task-logs-error"
@@ -273,7 +276,7 @@ const PipelineRunLogs: FC<PipelineRunLogsProps> = ({
               }
             />
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   );
@@ -303,8 +306,7 @@ export const PipelineRunLogsWithActiveTask: FC<
         pipelineRunManagedBy: obj?.spec?.managedBy,
       },
     );
-  /* this needs decoupling */
-  const taskRunsLoaded = k8sLoaded || trLoaded;
+  const taskRunsLoaded = (k8sLoaded && taskRuns.length > 0) || trLoaded;
   const { isResourceManagedByKueue } = useMultiClusterProxyService({
     managedBy: obj?.spec?.managedBy,
   });
@@ -327,7 +329,7 @@ export const PipelineRunLogsWithActiveTask: FC<
           title={t('PipelineRun is waiting to be admitted to a worker cluster')}
         />
       )}
-      {taskRunsLoaded && (
+      {taskRunsLoaded ? (
         <PipelineRunLogs
           obj={obj}
           activeTask={activeTask}
@@ -335,6 +337,8 @@ export const PipelineRunLogsWithActiveTask: FC<
           taskRuns={taskRuns}
           isResourceManagedByKueue={isResourceManagedByKueue}
         />
+      ) : (
+        <Loading />
       )}
     </>
   );

--- a/src/components/pipelines-tasks/tasks-details-pages/TaskRunLog.scss
+++ b/src/components/pipelines-tasks/tasks-details-pages/TaskRunLog.scss
@@ -1,10 +1,6 @@
 @use '../../logs/ansi-log-colors' as *;
 
 .odc-task-run-log {
-  display: flex;
-  flex: 1;
-  padding: var(--pf-t--global--spacer--xl);
-
   .pf-v6-c-log-viewer__text {
     white-space: pre;
   }

--- a/src/components/pipelines-tasks/tasks-details-pages/TaskRunLogs.tsx
+++ b/src/components/pipelines-tasks/tasks-details-pages/TaskRunLogs.tsx
@@ -33,7 +33,7 @@ const TaskRunLogs: FC<PropsWithChildren<Props>> = ({
     name: taskRun.status.podName,
   };
   return (
-    <div className="odc-task-run-log">
+    <div className="pf-v6-u-flex-1 pf-v6-u-p-xl pf-v6-u-pr-0">
       <LogsWrapperComponent
         taskRun={taskRun}
         resource={podResources}


### PR DESCRIPTION
## Summary

Fixes missing or inconsistent loading states on PipelineRun and TaskRun log views. While task runs, pods, or Tekton Results log data are still being fetched, the UI now shows the shared `<Loading />` spinner instead of blank panels, premature error messages, or a task list that appears before data is ready.

**Changes:**
- Show a loader in `PipelineRunLogsWithActiveTask` until task runs are loaded from the cluster and/or Tekton Results (`taskRunsLoaded`).
- Tighten `taskRunsLoaded` so k8s is considered loaded only when task runs exist (`k8sLoaded && taskRuns.length > 0`), avoiding a flash of empty UI before Results data arrives.
- Show a loader in `MultiStreamLogs` while the pod watch (or multi-cluster pod poll) is in progress via a new `loaded` prop from `LogsWrapperComponent`.
- Hide the task nav while waiting for a pod (`waitingForPods`) and only show the static error log viewer when the PipelineRun is finished with zero task runs.
- Align TaskRun log layout by moving flex/padding from SCSS to PatternFly utility classes.

**Additional checks:**
- [x] No flash of “No task runs found” before Results data loads on deleted/completed PipelineRuns.

## Screen recordings

- [x] `Existing_TR_in_results_loading.mov`

https://github.com/user-attachments/assets/9f73bd01-b1c6-49bc-a215-218f777da17f

- [x] `Deleted_TR_in_results_loading.mov`

https://github.com/user-attachments/assets/407134a9-e6e3-4979-80bd-486b399e1a18

- [x] `Deleted_PLR_in_results_loading.mov`

https://github.com/user-attachments/assets/101bacd8-7bd9-4597-8af1-b30bd544fb35

- [x] `Existing_PLR_in_cluster_loading.mov`

https://github.com/user-attachments/assets/5e61bb34-23dc-466e-8e17-7efcce8f2b2d

- [x] `Active_PLR_in_cluster_loading.mov`

https://github.com/user-attachments/assets/6315a129-ca21-4d39-9b48-df1071f8b86f


