### PR TITLE
SRVKP-11563: css fix for logviewer with error banner

### DIFF
--- a/src/components/logs/Logs.tsx
+++ b/src/components/logs/Logs.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
-import { Alert, Banner } from '@patternfly/react-core';
+import { Alert, Banner, Flex, FlexItem } from '@patternfly/react-core';
 import { LogViewer } from '@patternfly/react-log-viewer';
 import { Base64 } from 'js-base64';
 import { useTranslation } from 'react-i18next';
@@ -412,40 +412,51 @@ const Logs: FC<LogsProps> = ({
   }, [logData, activeStep, findTargetRowForActiveStep]);
 
   return (
-    <div className="pf-v6-u-h-100 pf-v6-u-w-100">
+    <Flex
+      className={'pf-v6-u-h-100 pf-v6-u-w-100'}
+      direction={{ default: 'column' }}
+    >
       {error && (
-        <Alert
-          variant="danger"
-          isInline
-          title={t('An error occurred while retrieving the requested logs.')}
-        />
+        <FlexItem>
+          <Alert
+            variant="danger"
+            isInline
+            className="pf-v6-u-my-md"
+            title={t('An error occurred while retrieving the requested logs.')}
+          />
+        </FlexItem>
       )}
-      <LogViewer
-        useAnsiClasses={true}
-        header={
-          <Banner className="pf-v6-l-flex pf-v6-l-gap-md">
-            <span data-test-id="logs-taskName" className="pf-v6-u-font-size-md">
-              {taskName}
-            </span>
-            {stillFetching ? (
-              <span data-test-id="loading-indicator">
-                <Loading isInline={true} />
+      <FlexItem flex={{ default: 'flex_4' }} className={'pf-v6-u-min-height'}>
+        <LogViewer
+          useAnsiClasses={true}
+          header={
+            <Banner className="pf-v6-l-flex pf-v6-l-gap-md">
+              <span
+                data-test-id="logs-taskName"
+                className="pf-v6-u-font-size-md"
+              >
+                {taskName}
               </span>
-            ) : null}
-          </Banner>
-        }
-        hasLineNumbers={false}
-        isTextWrapped={false}
-        data={
-          error
-            ? t('An error occurred while retrieving the requested logs.')
-            : formattedLogString
-        }
-        theme="dark"
-        scrollToRow={scrollToRow}
-        height="100%"
-      />
-    </div>
+              {stillFetching ? (
+                <span data-test-id="loading-indicator">
+                  <Loading isInline={true} />
+                </span>
+              ) : null}
+            </Banner>
+          }
+          hasLineNumbers={false}
+          isTextWrapped={false}
+          data={
+            error
+              ? t('An error occurred while retrieving the requested logs.')
+              : formattedLogString
+          }
+          theme="dark"
+          scrollToRow={scrollToRow}
+          height="100%"
+        />
+      </FlexItem>
+    </Flex>
   );
 };
 

--- a/src/components/pipelineRuns-details/PipelineRunLogs.tsx
+++ b/src/components/pipelineRuns-details/PipelineRunLogs.tsx
@@ -317,6 +317,7 @@ export const PipelineRunLogsWithActiveTask: FC<
         <Alert
           isInline
           variant="warning"
+          className="pf-v6-u-mt-md"
           title={t(
             'The multi-cluster connection is unavailable. Logs and status may be delayed until connection is restored.',
           )}
@@ -326,6 +327,7 @@ export const PipelineRunLogsWithActiveTask: FC<
         <Alert
           isInline
           variant="info"
+          className="pf-v6-u-mt-md"
           title={t('PipelineRun is waiting to be admitted to a worker cluster')}
         />
       )}


### PR DESCRIPTION
### **Problem**
When the log viewer displayed an error banner (e.g. "An error occurred while retrieving the requested logs"), the layout would break — the error alert and the LogViewer competed for space within a basic div, causing the log viewer to overflow or render incorrectly.

### **Summary**
Switched to a PatternFly `Flex` container with `direction={{ default: 'column' }} `so the error banner and the log viewer stack vertically. The LogViewer is given  to grow and consume remaining height, ensuring it renders at full size regardless of whether the error banner is visible.

### **Changes**

- Replaced the plain `<div>` wrapper in the Logs component with PatternFly `<Flex> / <FlexItem> `to create a proper column-based flex layout
- Wrapped the error `<Alert>` in its own `<FlexItem> `so it takes only its natural height and doesn't interfere with the log viewer sizing
- Wrapped `<LogViewer>` in a `<FlexItem flex="flex_4">` so it fills the remaining vertical space correctly when an error banner is present
- Added `pf-v6-u-my-md` margin utility to the error alert for visual spacing in `Logs.tsx`
- Added `pf-v6-u-mt-md` margin utility for multicluster warning and info alerts in `PipelineRunLogs.tsx`


ScreenShot - Before

<img width="1919" height="924" alt="image" src="https://github.com/user-attachments/assets/ec1baf94-3426-49c6-8008-524d9368fda7" />

ScreenShot - Before (Multicluster Alerts)
<img width="1280" height="917" alt="image" src="https://github.com/user-attachments/assets/3f17b685-2dfc-442b-ac0c-55a12797f614" />


**Screen Recording - After Fix**

https://github.com/user-attachments/assets/e0ad66ea-cddf-4b87-be79-3aaf3ed651bf



**Screen Recording - After Fix - Tekton Results**

https://github.com/user-attachments/assets/bbdbdf1d-43e0-48ba-b9a3-c014d3aa7d58

**Screen Recording - After Fix - Multi Cluster Warning Alert**

https://github.com/user-attachments/assets/6b14fb90-304d-4d4d-ba71-f3785380eea4

**Screen Recording - After Fix - Multi Cluster Info Alert**


https://github.com/user-attachments/assets/36bccd92-2aa2-4e55-96d2-76719bab200a


Assisted-by: Claude 4.6 high

