### PR TITLE
SRVKP-9451: Cherry-pick SRVKP-12147 fix from master to main

### DIFF
--- a/locales/en/plugin__pipelines-console-plugin.json
+++ b/locales/en/plugin__pipelines-console-plugin.json
@@ -452,6 +452,7 @@
   "Right click": "Right click",
   "Route": "Route",
   "Routes": "Routes",
+  "run{{plural}} in namespace {{namespaceName}}.": "run{{plural}} in namespace {{namespaceName}}.",
   "run{{plural}} in other namespaces.": "run{{plural}} in other namespaces.",
   "run{{plural}}.": "run{{plural}}.",
   "Running": "Running",

--- a/src/components/approval-tasks/approval-notification/ApprovalToastContent.tsx
+++ b/src/components/approval-tasks/approval-notification/ApprovalToastContent.tsx
@@ -5,53 +5,44 @@ import { ExternalLink } from '../../utils/link';
 import './ApprovalToastContent.scss';
 
 interface ApprovalToastContentProps {
-  type: string;
+  type: 'current' | 'other' | 'admin';
   uniquePipelineRuns: number;
-  devconsolePath?: string;
-  adminconsolePath?: string;
+  path: string;
+  namespaceName?: string;
 }
 
 const ApprovalToastContent: React.FC<ApprovalToastContentProps> = ({
   type,
   uniquePipelineRuns,
-  devconsolePath,
-  adminconsolePath,
+  path,
+  namespaceName,
 }) => {
   const { t } = useTranslation('plugin__pipelines-console-plugin');
-  if (type === 'current') {
-    return (
-      <>
-        {t('Your approval has been requested on {{plrs}} pipeline', {
-          plrs: uniquePipelineRuns,
-        })}
-        {t('run{{plural}}.', {
-          plural: uniquePipelineRuns > 1 ? 's' : '',
-        })}
-        <p className="pipelines-approval-toast__link">
-          <ExternalLink href={devconsolePath} text={t('Go to Approvals tab')} />
-        </p>
-      </>
-    );
-  }
-  if (type === 'other') {
-    return (
-      <>
-        {t('Your approval has been requested on {{plrs}} pipeline', {
-          plrs: uniquePipelineRuns,
-        })}
-        {t('run{{plural}} in other namespaces.', {
-          plural: uniquePipelineRuns > 1 ? 's' : '',
-        })}
-        <p className="pipelines-approval-toast__link">
-          <ExternalLink
-            href={adminconsolePath}
-            text={t('Go to Admin Approvals tab')}
-          />
-        </p>
-      </>
-    );
-  }
-  return null;
+  const linkText =
+    type === 'admin'
+      ? t('Go to Admin Approvals tab')
+      : t('Go to Approvals tab');
+  const plural = uniquePipelineRuns > 1 ? 's' : '';
+  const suffixMap = {
+    other: t('run{{plural}} in namespace {{namespaceName}}.', {
+      plural,
+      namespaceName,
+    }),
+    admin: t('run{{plural}} in other namespaces.', { plural }),
+    current: t('run{{plural}}.', { plural }),
+  };
+
+  return (
+    <>
+      {t('Your approval has been requested on {{plrs}} pipeline', {
+        plrs: uniquePipelineRuns,
+      })}
+      {suffixMap[type]}
+      <p className="pipelines-approval-toast__link">
+        <ExternalLink href={path} text={linkText} />
+      </p>
+    </>
+  );
 };
 
 export default ApprovalToastContent;

--- a/src/components/approval-tasks/approval-notification/pipeline-approval-context.tsx
+++ b/src/components/approval-tasks/approval-notification/pipeline-approval-context.tsx
@@ -3,7 +3,9 @@ import { AlertVariant } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import {
   WatchK8sResource,
+  useAccessReview,
   useActiveNamespace,
+  useActivePerspective,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
   getGroupVersionKindForModel,
@@ -16,7 +18,12 @@ import {
   ApproverStatusResponse,
 } from '../../../types';
 import { ApprovalTaskModel } from '../../../models';
-import { ApprovalLabels, ApprovalFields } from '../../../consts';
+import {
+  ApprovalLabels,
+  ApprovalFields,
+  DEV_PERSPECTIVE_BASE_PATH,
+  ADMIN_PERSPECTIVE_BASE_PATH,
+} from '../../../consts';
 import { useToast } from '../../toast/useToast';
 import { useActiveUserWithUpdate } from '../../hooks/hooks';
 import { isUserAuthorizedForApproval } from '../../utils/approval-group-utils';
@@ -47,8 +54,18 @@ export const usePipelineApprovalToast = () => {
   const [currentToasts, setCurrentToasts] = React.useState<{
     [key: string]: { toastId: string };
   }>({});
-  const devconsolePath = `/dev-pipelines/ns/${namespace}/approvals?rowFilter-status=pending`;
-  const adminconsolePath = `pipelines/all-namespaces/approvals?rowFilter-status=pending`;
+  const [perspective] = useActivePerspective();
+  const basePath =
+    perspective.toLowerCase() === 'dev'
+      ? DEV_PERSPECTIVE_BASE_PATH
+      : ADMIN_PERSPECTIVE_BASE_PATH;
+  const currentNsPath = `${basePath}/ns/${namespace}/approvals?rowFilter-status=pending`;
+
+  const [canAccessAllNamespace] = useAccessReview({
+    group: '',
+    resource: 'namespaces',
+    verb: 'list',
+  });
 
   const approvalsResource: WatchK8sResource = {
     groupVersionKind: getGroupVersionKindForModel(ApprovalTaskModel),
@@ -57,20 +74,31 @@ export const usePipelineApprovalToast = () => {
   const [approvalTasks] =
     useK8sWatchResource<ApprovalTaskKind[]>(approvalsResource);
   React.useEffect(() => {
-    if (currentToasts?.current?.toastId) {
-      removeToast(currentToasts.current.toastId);
-      setCurrentToasts((toasts) => ({ ...toasts, current: { toastId: '' } }));
-    }
-    if (currentToasts?.other?.toastId) {
-      removeToast(currentToasts.other.toastId);
-      setCurrentToasts((toasts) => ({ ...toasts, other: { toastId: '' } }));
-    }
-  }, [approvalTasks, currentUser.username, t, addToast, removeToast]);
+    Object.entries(currentToasts).forEach(([key, { toastId }]) => {
+      if (toastId) {
+        removeToast(toastId);
+        setCurrentToasts((toasts) => ({ ...toasts, [key]: { toastId: '' } }));
+      }
+    });
+    //cleanup to removeToast
+    return () => {
+      Object.entries(currentToasts).forEach(([key, { toastId }]) => {
+        if (toastId) {
+          removeToast(toastId);
+        }
+      });
+    };
+  }, [
+    approvalTasks,
+    currentUser.username,
+    t,
+    addToast,
+    removeToast,
+    namespace,
+  ]);
 
   React.useEffect(() => {
     const processApprovalTasks = async () => {
-      let toastID = '';
-
       // Filter approval tasks for current user with async group checking
       const userApprovalTasksInWait = [];
       for (const approvalTask of approvalTasks) {
@@ -132,50 +160,89 @@ export const usePipelineApprovalToast = () => {
         ).size;
 
         if (uniquePipelineRuns > 0) {
-          toastID = addToast({
+          const toastID = addToast({
             variant: AlertVariant.custom,
             title: t('Task approval required'),
             content: (
               <ApprovalToastContent
                 type="current"
                 uniquePipelineRuns={uniquePipelineRuns}
-                devconsolePath={devconsolePath}
+                path={currentNsPath}
               />
             ),
             timeout: 25000,
             dismissible: true,
           }) as any;
+          setCurrentToasts((toasts) => ({
+            ...toasts,
+            current: { toastId: toastID },
+          }));
         }
-        setCurrentToasts((toasts) => ({
-          ...toasts,
-          current: { toastId: toastID },
-        }));
       }
 
       if (otherNsApprovalTasks.length > 0) {
-        const uniquePipelineRuns = new Set(
-          getPipelineRunsofApprovals(otherNsApprovalTasks),
-        ).size;
+        const tasksByNamespace = otherNsApprovalTasks.reduce<
+          Record<string, ApprovalTaskKind[]>
+        >((acc, task) => {
+          const ns = task?.metadata?.namespace;
+          if (ns) {
+            acc[ns] = acc[ns] || [];
+            acc[ns].push(task);
+          }
+          return acc;
+        }, {});
 
-        if (uniquePipelineRuns > 0) {
-          toastID = addToast({
+        if (canAccessAllNamespace) {
+          const allNsPath = `${basePath}/all-namespaces/approvals?rowFilter-status=pending`;
+          const totalPipelineRuns = new Set(
+            getPipelineRunsofApprovals(otherNsApprovalTasks),
+          ).size;
+          const toastId = addToast({
             variant: AlertVariant.custom,
             title: t('Task approval required'),
             content: (
               <ApprovalToastContent
-                type="other"
-                uniquePipelineRuns={uniquePipelineRuns}
-                adminconsolePath={adminconsolePath}
+                type="admin"
+                uniquePipelineRuns={totalPipelineRuns}
+                path={allNsPath}
               />
             ),
             timeout: 25000,
             dismissible: true,
+          }) as any;
+          setCurrentToasts((toasts) => ({
+            ...toasts,
+            [`all-ns`]: { toastId: toastId },
+          }));
+        } else {
+          Object.entries(tasksByNamespace).forEach(([ns, tasks]) => {
+            const uniquePipelineRuns = new Set(
+              getPipelineRunsofApprovals(tasks),
+            ).size;
+
+            if (uniquePipelineRuns > 0) {
+              const nsPath = `${basePath}/ns/${ns}/approvals?rowFilter-status=pending`;
+              const toastID = addToast({
+                variant: AlertVariant.custom,
+                title: t('Task approval required'),
+                content: (
+                  <ApprovalToastContent
+                    type="other"
+                    uniquePipelineRuns={uniquePipelineRuns}
+                    path={nsPath}
+                    namespaceName={ns}
+                  />
+                ),
+                timeout: 25000,
+                dismissible: true,
+              }) as any;
+              setCurrentToasts((toasts) => ({
+                ...toasts,
+                [`other-${ns}`]: { toastId: toastID },
+              }));
+            }
           });
         }
-        setCurrentToasts((toasts) => ({
-          ...toasts,
-          other: { toastId: toastID },
-        }));
       }
     };
 
@@ -186,7 +253,9 @@ export const usePipelineApprovalToast = () => {
     namespace,
     t,
     addToast,
-    devconsolePath,
-    adminconsolePath,
+    basePath,
+    currentNsPath,
+    updateUserInfo,
+    canAccessAllNamespace,
   ]);
 };

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -200,3 +200,6 @@ export const PIPELINE_RUN_MANAGED_BY_KUEUE_LABEL = 'kueue.x-k8s.io/multikueue';
 export const PIPELINE_RUN_KUEUE_ORIGIN_LABEL =
   'kueue.x-k8s.io/multikueue-origin';
 export const KUEUE_LABEL_PREFIX = 'kueue.x-k8s.io';
+export const DASH = '-';
+export const ADMIN_PERSPECTIVE_BASE_PATH = '/pipelines';
+export const DEV_PERSPECTIVE_BASE_PATH = '/dev-pipelines';


### PR DESCRIPTION
## Description

[SRVKP-9451](https://redhat.atlassian.net/browse/SRVKP-9451) was investigated and found to be related to the **All Projects** view for non-admin users.

The root cause is addressed by the fix introduced in **[SRVKP-12147](https://redhat.atlassian.net/browse/SRVKP-12147)**, which prevents non-admin users from accessing the All Projects context. With this fix in place, the scenario that leads to missing PipelineRun names in the Approvals view no longer occurs.

This PR cherry-picks the [SRVKP-12147](https://redhat.atlassian.net/browse/SRVKP-12147) fix (PR #1093) from **master** to **main** so it can be backported to the supported release branches (1.21.x and 1.22.x).

## Screen Recording

https://github.com/user-attachments/assets/1279b421-2081-4063-8a1e-b62b123dc32c