### PR TITLE
SRVKP-11201: Fixes PipelineRuns/TaskRuns lingering in the list after delete when Tekton Results is enabled.

### DIFF
--- a/scripts/install-tekton-pruner.sh
+++ b/scripts/install-tekton-pruner.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Install Tekton Pruner and configure namespace-level pruning.
+#
+# Usage:
+#   ./scripts/install-tekton-pruner.sh
+#   USER_NS=my-team PRUNER_VERSION=v0.4.0 ./scripts/install-tekton-pruner.sh
+#
+# Requires: oc or kubectl, cluster-admin (for SCC on OpenShift)
+#
+set -euo pipefail
+
+PRUNER_VERSION="${PRUNER_VERSION:-v0.4.0}"
+PRUNER_NS="${PRUNER_NS:-tekton-pipelines}"
+USER_NS="${USER_NS:-osp-ui}"
+RELEASE_URL="https://infra.tekton.dev/tekton-releases/pruner/previous/${PRUNER_VERSION}/release.yaml"
+
+# Namespace-level retention defaults (override via env)
+TTL_SECONDS="${TTL_SECONDS:-60}"
+SUCCESSFUL_HISTORY_LIMIT="${SUCCESSFUL_HISTORY_LIMIT:-5}"
+FAILED_HISTORY_LIMIT="${FAILED_HISTORY_LIMIT:-5}"
+GLOBAL_TTL_SECONDS="${GLOBAL_TTL_SECONDS:-3600}"
+
+if command -v oc >/dev/null 2>&1; then
+  KCMD=oc
+  OPENSHIFT=true
+elif command -v kubectl >/dev/null 2>&1; then
+  KCMD=kubectl
+  OPENSHIFT=false
+else
+  echo "error: oc or kubectl is required" >&2
+  exit 1
+fi
+
+log() { echo "==> $*"; }
+
+wait_for_deployment() {
+  local ns=$1 name=$2 timeout=${3:-180}
+  log "Waiting for deployment/${name} in ${ns} (timeout ${timeout}s)..."
+  if ! "$KCMD" rollout status "deployment/${name}" -n "$ns" --timeout="${timeout}s"; then
+    echo "error: deployment/${name} did not become ready" >&2
+    "$KCMD" get pods -n "$ns" -l "app.kubernetes.io/part-of=tekton-pruner" 2>/dev/null || true
+    "$KCMD" get events -n "$ns" --field-selector type=Warning --sort-by=.metadata.creationTimestamp 2>/dev/null | tail -5 || true
+    exit 1
+  fi
+}
+
+patch_openshift_deployments() {
+  log "Applying OpenShift SCC and security context patches..."
+  "$KCMD" adm policy add-scc-to-user pipelines-scc \
+    -z tekton-pruner-controller -n "$PRUNER_NS" 2>/dev/null || true
+
+  for dep in tekton-pruner-controller tekton-pruner-webhook; do
+    if "$KCMD" get deployment "$dep" -n "$PRUNER_NS" >/dev/null 2>&1; then
+      # Remove hardcoded runAsUser:65532; OpenShift assigns UID from namespace range.
+      "$KCMD" patch deployment "$dep" -n "$PRUNER_NS" --type=json \
+        -p='[{"op":"remove","path":"/spec/template/spec/containers/0/securityContext/runAsUser"}]' \
+        2>/dev/null || true
+    fi
+  done
+
+  "$KCMD" rollout restart deployment/tekton-pruner-controller deployment/tekton-pruner-webhook \
+    -n "$PRUNER_NS" 2>/dev/null || true
+}
+
+log "Installing Tekton Pruner ${PRUNER_VERSION}..."
+
+log "Creating namespaces..."
+"$KCMD" create namespace "$PRUNER_NS" --dry-run=client -o yaml | "$KCMD" apply -f -
+"$KCMD" create namespace "$USER_NS" --dry-run=client -o yaml | "$KCMD" apply -f -
+
+log "Applying pruner release manifest..."
+# First apply may fail on ConfigMaps if the validating webhook is not ready yet.
+set +e
+"$KCMD" apply -f "$RELEASE_URL"
+apply_rc=$?
+set -e
+if [[ $apply_rc -ne 0 ]]; then
+  log "Initial apply returned errors (expected if webhook/configmaps failed); continuing..."
+fi
+
+if [[ "$OPENSHIFT" == "true" ]]; then
+  patch_openshift_deployments
+fi
+
+wait_for_deployment "$PRUNER_NS" tekton-pruner-webhook 180
+wait_for_deployment "$PRUNER_NS" tekton-pruner-controller 180
+
+log "Re-applying release to create validated ConfigMaps..."
+"$KCMD" apply -f "$RELEASE_URL"
+
+if [[ "$OPENSHIFT" == "true" ]]; then
+  # Re-apply may restore runAsUser; patch again if pods fail to schedule.
+  patch_openshift_deployments
+  wait_for_deployment "$PRUNER_NS" tekton-pruner-webhook 120
+  wait_for_deployment "$PRUNER_NS" tekton-pruner-controller 120
+fi
+
+log "Configuring global pruner policy (namespace-level enforcement)..."
+"$KCMD" apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-default-spec
+  namespace: ${PRUNER_NS}
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/config-type: global
+data:
+  global-config: |
+    enforcedConfigLevel: namespace
+    ttlSecondsAfterFinished: ${GLOBAL_TTL_SECONDS}
+    successfulHistoryLimit: 10
+    failedHistoryLimit: 10
+EOF
+
+log "Configuring namespace pruner policy for '${USER_NS}'..."
+"$KCMD" apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-namespace-spec
+  namespace: ${USER_NS}
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/config-type: namespace
+data:
+  ns-config: |
+    ttlSecondsAfterFinished: ${TTL_SECONDS}
+    successfulHistoryLimit: ${SUCCESSFUL_HISTORY_LIMIT}
+    failedHistoryLimit: ${FAILED_HISTORY_LIMIT}
+EOF
+
+log "Installation complete."
+echo
+echo "Pruner controller namespace : ${PRUNER_NS}"
+echo "Namespace config target     : ${USER_NS}"
+echo
+echo "Verify:"
+echo "  ${KCMD} get pods -n ${PRUNER_NS}"
+echo "  ${KCMD} get cm tekton-pruner-default-spec -n ${PRUNER_NS} -o jsonpath='{.data.global-config}'"
+echo "  ${KCMD} get cm tekton-pruner-namespace-spec -n ${USER_NS} -o jsonpath='{.data.ns-config}'"
+echo "  ${KCMD} logs -n ${PRUNER_NS} -l app.kubernetes.io/part-of=tekton-pruner --tail=20"

--- a/src/components/hooks/useTaskRuns.ts
+++ b/src/components/hooks/useTaskRuns.ts
@@ -6,8 +6,8 @@ import {
   useFlag,
   useK8sWatchResource,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { differenceBy, uniqBy } from 'lodash-es';
-import { useMemo, useRef } from 'react';
+import { uniqBy } from 'lodash-es';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ApprovalFields,
   ApprovalLabels,
@@ -211,11 +211,11 @@ export const useRuns = <Kind extends K8sResourceKind>(
   pipelineRunFinished?: boolean,
   pipelineRunManagedBy?: string,
 ): [Kind[], boolean, boolean, Error | undefined, boolean, boolean] => {
-  const etcdRunsRef = useRef<Kind[]>([]);
   const optionsMemo = useDeepCompareMemoize(options);
   const isTektonResultEnabled = useFlag(FLAG_PIPELINE_TEKTON_RESULT_INSTALLED);
   const isList = !optionsMemo?.name;
   const limit = optionsMemo?.limit;
+  const prevEtcdLengthRef = useRef(0);
 
   // Hub cluster detection
   const { isResourceManagedByKueue } = useMultiClusterProxyService({
@@ -248,8 +248,7 @@ export const useRuns = <Kind extends K8sResourceKind>(
     if (optionsMemo?.skipFetch) {
       return null;
     }
-    // reset cached runs as the options have changed
-    etcdRunsRef.current = [];
+    prevEtcdLengthRef.current = 0; // we need to reset the previous length when options change to prevent unnecessary refetches - unfortunately this is an antipattern and should be avoided when possible
     return shouldUseMultiCluster
       ? null
       : {
@@ -289,40 +288,30 @@ export const useRuns = <Kind extends K8sResourceKind>(
   const effectiveLoaded = shouldUseMultiCluster ? mcLoaded : loaded;
   const effectiveError = shouldUseMultiCluster ? mcError : error;
 
-  const runs = useMemo(() => {
-    if (!etcdRuns) {
-      return etcdRuns;
-    }
-    let value = etcdRunsRef.current
-      ? [
-          ...etcdRuns,
-          // identify the runs that were removed
-          ...differenceBy(
-            etcdRunsRef.current,
-            etcdRuns,
-            (plr) => plr.metadata.name,
-          ),
-        ]
-      : [...etcdRuns];
-    value.sort((a, b) =>
-      b.metadata.creationTimestamp.localeCompare(a.metadata.creationTimestamp),
-    );
-    if (limit && limit < value?.length) {
-      value = value.slice(0, limit);
-    }
-    return value;
-  }, [etcdRuns, limit]);
+  // Detect deletions/pruning: if etcd returned fewer runs than before, re-fetch TR
+  const [trRefetchKey, setTrRefetchKey] = useState(0);
 
-  // cache the last set to identify removed runs
-  etcdRunsRef.current = runs;
+  useEffect(() => {
+    const prevLength = prevEtcdLengthRef.current;
+    prevEtcdLengthRef.current = etcdRuns?.length ?? 0;
+    if (
+      effectiveLoaded &&
+      !effectiveError &&
+      prevLength > 0 &&
+      etcdRuns.length < prevLength
+    ) {
+      setTrRefetchKey((k) => k + 1);
+    }
+  }, [etcdRuns?.length, effectiveLoaded, effectiveError]);
 
-  // Query tekton results if there's no limit or we received less items from etcd than the current limit
+  // Lists: always query TR. Details (limit + name): query TR only when etcd
+  // returned fewer items than limit (resource pruned/deleted) or etcd errored.
   const queryTr =
     isTektonResultEnabled &&
     (!limit ||
       (namespace &&
-        ((runs && effectiveLoaded && optionsMemo.limit > runs?.length) ||
-          effectiveError)));
+        effectiveLoaded &&
+        (limit > (etcdRuns?.length ?? 0) || !!effectiveError)));
 
   const trOptions: typeof optionsMemo = useMemo(() => {
     if (optionsMemo?.name) {
@@ -345,24 +334,29 @@ export const useRuns = <Kind extends K8sResourceKind>(
     trOptions,
     isTektonResultEnabled,
     optionsMemo?.skipFetch,
+    trRefetchKey,
   );
 
   // dedupe PLR by name since UIDs differ between hub and spoke clusters; for other cases(TR) dedupe by UID
+  const rResources: Kind[] = useMemo(() => {
+    const merged =
+      etcdRuns && trResources
+        ? !isTaskRunQuery
+          ? uniqBy([...etcdRuns, ...trResources], (r) => r.metadata.name)
+          : uniqBy([...etcdRuns, ...trResources], (r) => r.metadata.uid)
+        : etcdRuns || trResources;
+    return merged?.sort((a, b) =>
+      b.metadata.creationTimestamp.localeCompare(a.metadata.creationTimestamp),
+    ); // added the sort here, technically this was not necessary but did not want to risk breaking anything
+  }, [etcdRuns, trResources, isTaskRunQuery]);
 
-  const rResources: Kind[] =
-    runs && trResources
-      ? !isTaskRunQuery
-        ? uniqBy([...runs, ...trResources], (r) => r.metadata.name)
-        : uniqBy([...runs, ...trResources], (r) => r.metadata.uid)
-      : runs || trResources;
-
-  /* Refactoring the nesting as it is causing cognitive damage */
+  /* Refactored error */
   let resolvedError: Error | undefined = undefined;
 
   if (namespace) {
     if (queryTr) {
       if (isList) {
-        resolvedError = trError && effectiveError;
+        resolvedError = trError && effectiveError; // if TR is disabled and we use || instead of && then we won't be able to show the data from etcd if we propagate it as an error
       } else {
         // when searching by name, return an error if we have no result
         if (trError && trLoaded && !trResources?.length) {

--- a/src/components/hooks/useTektonResults.ts
+++ b/src/components/hooks/useTektonResults.ts
@@ -14,6 +14,7 @@ export const useTRRuns = <Kind extends K8sResourceCommon>(
   options?: TektonResultsOptions,
   isTektonResultEnabled?: boolean,
   skipFetch?: boolean,
+  refetchKey?: number,
 ): [Kind[], boolean, Error | undefined] => {
   const isDevConsoleProxyAvailable = useFlag(FLAGS.DEVCONSOLE_PROXY);
   const fetchedRef = useRef(false);
@@ -60,6 +61,7 @@ export const useTRRuns = <Kind extends K8sResourceCommon>(
     stableOptions,
     skipFetch,
     isTektonResultEnabled,
+    refetchKey, // the only purpose is to refetch data from TR after deletion / pruning
   ]);
   if (!isTektonResultEnabled) {
     return [[], true, undefined];


### PR DESCRIPTION
## Root cause

Two things were contributing:

1. **Stale cache in `useRuns`** — removed runs were being re-inserted via `differenceBy` / `etcdRunsRef`, so deleted resources could stay visible even after the k8s watch dropped them.

2. **Tekton Results annotation timing** — after delete, `resource.loaded.from.tektonResults` appears almost immediately on TR records, but `resource.deleted.in.k8s` is only added client-side in `decodeValueJson` when the TR record has `deletionTimestamp`. That only happens **after** the TR `/get` API runs on re-render. Until then, TR-sourced rows can be misclassified as `cluster-data` (because `isPipelineRunLoadedFromTektonResults` requires **both** annotations) and remain visible under the default cluster-data filter.

## How delete was tracked

The delete callback lives in **console** (via `useDeleteModal`) — we cannot hook into whether the user clicked Delete vs Cancel from the plugin.

Considered copying the delete modal into console-plugin to refetch TR on delete, but that would **not** cover **pruning** (server-side, no user action). So the fix is in the data layer instead.

## Solution

Updated `useRuns` to track `etcdRuns` count. When the count drops (delete or prune), we force a Tekton Results refetch via `trRefetchKey` in `useTRRuns`. In the screen recording you should see a TR `/get` after the delete API calls, which updates annotations and lets the data-source filter behave correctly.

Also removed the stale etcd cache logic and simplified merge/sort handling.

## Screen Recordings

#### Deleting PipelineRun 

https://github.com/user-attachments/assets/8b239b1d-c28a-4bb2-81f1-b38fe426e14c

#### Deleting TaskRun

https://github.com/user-attachments/assets/535adc9b-49ae-47f1-878e-45594371b638

#### Changes in `useRuns` are working when Pruner is enabled

https://github.com/user-attachments/assets/c52ac870-1ba7-4789-8d16-958a9d913f57
