### PR TITLE
SRVKP-12291: Add Codecov coverage reporting with status checks

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -1,4 +1,4 @@
-name: Unit Tests
+name: Code Coverage
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   unit_tests:
-    name: Run unit tests
+    name: Run unit tests to track code coverage
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,27 @@
 codecov:
   branch: master
 
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5
+        flags:
+          - unit-tests
+        paths:
+          - "src"
+        if_ci_failed: error
+        informational: false
+    patch:
+      default:
+        target: auto
+        threshold: 0%
+        flags:
+          - unit-tests
+        paths:
+          - "src"
+
 flags:
   unit-tests:
     carryforward: true


### PR DESCRIPTION
## Summary

- Add Codecov coverage reporting for Jest unit tests via a new **Unit Tests** GitHub Actions workflow on push/PR to `master`.
- Replace `codecov/codecov-action@v5` with the **Codecov CLI** upload, since third-party actions are blocked in `openshift-pipelines/console-plugin`.
- Configure `codecov.yml` with project and patch status checks for the `unit-tests` flag under `src/`.

## Changes

### GitHub Actions (`.github/workflows/unit-tests.yaml`)
- Runs `yarn test --ci --maxWorkers=2` (Jest already emits `coverage/lcov.info`)
- Uploads coverage with the Codecov CLI (`upload-process`) using flag `unit-tests`
- Uses `CODECOV_TOKEN` from repository secrets
- Upload is non-fatal if it fails (e.g. missing token or no baseline on `master` yet)

### Codecov config (`codecov.yml`)
- Sets `master` as the default branch
- Defines `unit-tests` flag with carryforward
- Ignores test fixtures, generated types, mocks, and integration tests
- Adds status checks:
  - **`codecov/project`**: overall coverage in `src/`, auto target, 5% drop threshold
  - **`codecov/patch`**: coverage on changed lines in PRs, auto target, 0% threshold

## Prerequisites (one-time)

- [ ] Install the [Codecov GitHub App](https://github.com/apps/codecov) on `openshift-pipelines/console-plugin`
- [ ] Add `CODECOV_TOKEN` as a repository secret (from Codecov → repo → Configuration → General)
- [ ] Enable **Flag analytics** in Codecov after the first successful upload

## Notes

- `codecov/codecov-action@v5` cannot be used due to org policy; only GitHub-owned actions, `openshift-pipelines/*`, and `docker/login-action@*` / `docker/setup-buildx-action@*` are allowed.
- Codecov PR checks may not appear on the first PR until a baseline report exists on `master` (merge this PR first, then future PRs should report normally).
- OpenShift CI (`test-frontend.sh` via ci-operator) is unchanged; this adds parallel coverage reporting in GitHub Actions.

Assisted-by: Claude 4.5 medium