### PR TITLE
Security: Fix CVE-2026-9277 (shell-quote) SRVKP-12136

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
   "resolutions": {
     "webpack": "5.94.0",
     "@types/d3-dispatch": "3.0.6",
-    "@types/d3-selection": "3.0.10"
+    "@types/d3-selection": "3.0.10",
+    "shell-quote": "1.8.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16479,13 +16479,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10c0/bee87c34e1e986cfb4c30846b8e6327d18874f10b535699866f368ade11ea4ee45433d97bf5eada22c4320c27df79c3a6a7eb1bf3ecfc47f2c997d9e5e2672fd
-  languageName: node
-  linkType: hard
-
 "shelljs@npm:^0.10.0":
   version: 0.10.0
   resolution: "shelljs@npm:0.10.0"


### PR DESCRIPTION
## Summary

This PR fixes **CVE-2026-9277** by adding `shell-quote@1.8.4` to yarn `resolutions` in `package.json`, pinning the transitive dependency to the patched version.

### CVE Details
- **CVE ID**: CVE-2026-9277
- **Package**: shell-quote
- **Vulnerable versions**: < 1.8.4
- **Fixed version**: 1.8.4
- **Jira Issues**: [SRVKP-12136](https://redhat.atlassian.net/browse/SRVKP-12136)

### Fix Approach
- Added `"shell-quote": "1.8.4"` to `resolutions` in `package.json`
- Removed stale yarn.lock entry for `shell-quote@1.8.3` — CI will regenerate with correct checksum for 1.8.4 on next `yarn install`

### ⚠️ Action Required Before Merge
Run the following after reviewing:
```sh
corepack enable && yarn install
git add yarn.lock && git commit --amend --no-edit
```

### Vulnerability Scan
- shell-quote 1.8.3 confirmed in yarn.lock on main branch
- Fixed version: 1.8.4

### Test Results
**Status**: ⚠️ No tests found — manual testing required
**Summary**: node_modules not installed (yarn 4.6.0 requires corepack, unavailable in CVE fixer env)

### Testing Checklist
- [x] Pre-PR automated tests attempted
- [ ] Run `yarn install` to regenerate yarn.lock with correct checksum
- [ ] Verify `yarn audit` shows no shell-quote vulnerability
- [ ] Test affected functionality manually

---
🤖 Generated by CVE Fixer Workflow

```release-note
Security fix: update shell-quote from 1.8.3 to 1.8.4 to address CVE-2026-9277
```