### PR TITLE
SRVKP-12524: Persist datasource filter selection for PipelineRuns

### DIFF
--- a/src/components/hooks/__tests__/useDatasourcePreference.spec.ts
+++ b/src/components/hooks/__tests__/useDatasourcePreference.spec.ts
@@ -1,0 +1,75 @@
+import { useUserPreference } from '@openshift-console/dynamic-plugin-sdk';
+import { testHook } from '../../../test-data/utils/hooks-utils';
+import {
+  DEFAULT_DATASOURCE_VALUES,
+  useDatasourcePreference,
+} from '../useDatasourcePreference';
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  useUserPreference: jest.fn(),
+}));
+
+const useUserPreferenceMock = useUserPreference as jest.Mock;
+
+describe('useDatasourcePreference', () => {
+  let setPreferenceMock: jest.Mock;
+
+  beforeEach(() => {
+    setPreferenceMock = jest.fn();
+    useUserPreferenceMock.mockReturnValue([
+      ['cluster-data'],
+      setPreferenceMock,
+      true,
+    ]);
+  });
+
+  it('should return the persisted preference', () => {
+    const { result } = testHook(() =>
+      useDatasourcePreference('pipelineRun', true),
+    );
+    expect(result.current.preference).toEqual(['cluster-data']);
+    expect(result.current.loaded).toBe(true);
+  });
+
+  it('should fall back to default when preference is undefined', () => {
+    useUserPreferenceMock.mockReturnValue([undefined, setPreferenceMock, true]);
+    const { result } = testHook(() =>
+      useDatasourcePreference('pipelineRun', true),
+    );
+    expect(result.current.preference).toEqual(DEFAULT_DATASOURCE_VALUES);
+  });
+
+  it('should persist value via setPreference', () => {
+    const { result } = testHook(() =>
+      useDatasourcePreference('pipelineRun', true),
+    );
+    result.current.setPreference(['archived-data']);
+    expect(setPreferenceMock).toHaveBeenCalledWith(['archived-data']);
+  });
+
+  it('should reset preference to default', () => {
+    const { result } = testHook(() =>
+      useDatasourcePreference('pipelineRun', true),
+    );
+    result.current.resetPreference();
+    expect(setPreferenceMock).toHaveBeenCalledWith(DEFAULT_DATASOURCE_VALUES);
+  });
+
+  it('should use the correct preference key for pipelineRun', () => {
+    testHook(() => useDatasourcePreference('pipelineRun', true));
+    expect(useUserPreferenceMock).toHaveBeenCalledWith(
+      'plugin__pipelines-console-plugin.dataSource.pipelineRun',
+      DEFAULT_DATASOURCE_VALUES,
+      true,
+    );
+  });
+
+  it('should pass undefined as default when persist is false', () => {
+    testHook(() => useDatasourcePreference('Pipeline', false));
+    expect(useUserPreferenceMock).toHaveBeenCalledWith(
+      'plugin__pipelines-console-plugin.dataSource.Pipeline',
+      undefined,
+      true,
+    );
+  });
+});

--- a/src/components/hooks/useDataViewFilter.ts
+++ b/src/components/hooks/useDataViewFilter.ts
@@ -15,6 +15,8 @@ import type {
   CheckboxFilterConfig,
   FilterValues,
 } from '../common/DataViewFilterToolbar';
+import { formatPrometheusDuration } from '../pipelines-overview/dateTime';
+import { TimeRangeOptions } from '../pipelines-overview/utils';
 import { getApprovalStatusInfo } from '../utils/pipeline-approval-utils';
 import {
   isPipelineRunLoadedFromTektonResults,
@@ -25,13 +27,12 @@ import {
   pipelineStatusFilter,
 } from '../utils/pipeline-filter-reducer';
 import { ListFilterId, ListFilterLabels } from '../utils/pipeline-utils';
+import { useDatasourcePreference } from './useDatasourcePreference';
 import {
   NO_DATE_RANGE_FILTER,
   parseDurationForDateRangeFiltering,
   useDateRangeFilter,
 } from './useDateRangeFilter';
-import { formatPrometheusDuration } from '../pipelines-overview/dateTime';
-import { TimeRangeOptions } from '../pipelines-overview/utils';
 
 export type ResourceType =
   | 'Pipeline'
@@ -156,17 +157,24 @@ export const useDataViewFilter = <T extends K8sResourceCommon>({
     getLabels = defaultGetLabels,
     resourceType,
     defaultStatusValues,
-    defaultDataSourceValues,
     customData,
   } = options ?? {};
   const { t } = useTranslation('plugin__pipelines-console-plugin');
   const isTektonResultEnabled = useFlag(FLAG_PIPELINE_TEKTON_RESULT_INSTALLED);
-  const allStatusIds = useMemo(() => Object.values(ListFilterId), []);
-  const resetFilterState = { name: '', labels: [] };
 
   const config = resourceType
     ? RESOURCE_FILTER_CONFIG[resourceType]
     : undefined;
+
+  // true only for resource types with a datasource filter (PipelineRun, TaskRun)
+  const shouldPersistDataSource = !!config?.hasDataSourceFilter;
+
+  const {
+    preference: datasourcePreference,
+    setPreference: setDatasourcePreference,
+    resetPreference: resetDatasourcePreference,
+  } = useDatasourcePreference(resourceType, shouldPersistDataSource);
+  const allStatusIds = useMemo(() => Object.values(ListFilterId), []);
 
   // true only for resource types with a date range filter (PipelinRun, TaskRun)
   const shouldPersistDateRangeFilter = !!config?.hasDateRangeFilter;
@@ -204,8 +212,7 @@ export const useDataViewFilter = <T extends K8sResourceCommon>({
         id: 'dataSource',
         title: t('Data source'),
         placeholder: t('Filter by data source'),
-        defaultValues:
-          defaultDataSourceValues ?? config.defaultDataSourceValues,
+        defaultValues: datasourcePreference,
         options: [
           { value: 'cluster-data', label: t('Cluster'), count: 0 },
           { value: 'archived-data', label: t('Archived'), count: 0 },
@@ -232,7 +239,7 @@ export const useDataViewFilter = <T extends K8sResourceCommon>({
     isTektonResultEnabled,
     t,
     defaultStatusValues,
-    defaultDataSourceValues,
+    datasourcePreference,
     preferenceLoaded,
     timeRangeOptions,
   ]);
@@ -276,7 +283,14 @@ export const useDataViewFilter = <T extends K8sResourceCommon>({
     return values;
   }, [checkboxFilters]);
 
-  const [filterState, setFilterState] = useState<FilterValues>(initialValues);
+  const [filterOverrides, setFilterOverrides] = useState<Partial<FilterValues>>(
+    {},
+  );
+
+  const filterState = useMemo<FilterValues>(
+    () => ({ ...initialValues, ...filterOverrides }),
+    [initialValues, filterOverrides],
+  );
   const [, setSearchParams] = useSearchParams();
 
   const resetPage = useCallback(() => {
@@ -298,19 +312,27 @@ export const useDataViewFilter = <T extends K8sResourceCommon>({
         resetPage();
         return;
       }
-      setFilterState((prev) => ({ ...prev, [key]: value }));
+      if (key === 'dataSource') {
+        setDatasourcePreference(Array.isArray(value) ? value : [value]);
+        resetPage();
+        return;
+      }
+      setFilterOverrides((prev) => ({ ...prev, [key]: value }));
       resetPage();
     },
-    [resetPage, setTimespanDateFilter],
+    [resetPage, setTimespanDateFilter, setDatasourcePreference],
   );
 
   const onClearAll = useCallback(() => {
-    setFilterState(resetFilterState);
+    setFilterOverrides({ name: '', labels: [] });
     if (config?.hasDateRangeFilter) {
       setTimespanDateFilter(NO_DATE_RANGE_FILTER);
     }
+    if (config?.hasDataSourceFilter) {
+      resetDatasourcePreference();
+    }
     resetPage();
-  }, [resetPage, setTimespanDateFilter, config]);
+  }, [resetPage, setTimespanDateFilter, resetDatasourcePreference, config]);
 
   const labelSuggestions = useMemo(() => {
     if (!data) return [];

--- a/src/components/hooks/useDatasourcePreference.ts
+++ b/src/components/hooks/useDatasourcePreference.ts
@@ -1,0 +1,28 @@
+import { useUserPreference } from '@openshift-console/dynamic-plugin-sdk';
+import { useCallback } from 'react';
+import { USER_PREFERENCE_PREFIX } from '../../consts';
+
+export const DEFAULT_DATASOURCE_VALUES = ['cluster-data'];
+
+// When persist is false, no ConfigMap entry is auto-created; sync is enabled when resourceType is defined.
+export const useDatasourcePreference = (
+  resourceType: string | undefined,
+  persistPreference = false,
+) => {
+  const [preference, setPreference, loaded] = useUserPreference<string[]>(
+    `${USER_PREFERENCE_PREFIX}.dataSource.${resourceType}`,
+    persistPreference ? DEFAULT_DATASOURCE_VALUES : undefined,
+    !!resourceType,
+  );
+
+  const resetPreference = useCallback(() => {
+    setPreference(DEFAULT_DATASOURCE_VALUES);
+  }, [setPreference]);
+
+  return {
+    preference: preference ?? DEFAULT_DATASOURCE_VALUES,
+    setPreference,
+    resetPreference,
+    loaded,
+  };
+};

--- a/src/components/pipelineRuns-list/PipelineRunsList.tsx
+++ b/src/components/pipelineRuns-list/PipelineRunsList.tsx
@@ -68,7 +68,6 @@ const PipelineRunsList: FC<PipelineRunsListProps> = ({
     data: pipelineRuns || [],
     options: {
       resourceType: 'PipelineRun',
-      defaultDataSourceValues: ['cluster-data'],
     },
   });
 


### PR DESCRIPTION
## Summary

Implements RFE [SRVKP-12524](https://redhat.atlassian.net/browse/SRVKP-12524): Persist the user's datasource filter selection (Cluster / Archived)
across sessions on the PipelineRuns list page.

The selection is stored in the Console's per-user ConfigMap via `useUserPreference` from the
dynamic plugin SDK. On the next visit, the previously selected datasource filter is automatically
applied. Default selection is `Cluster`.

## Changes

- **New hook `useDatasourcePreference`**: Encapsulates `useUserPreference` for datasource filter
  persistence. Accepts a `pageType` (`pipelineRun` | `taskRun`) to allow reuse for TaskRuns
  in a follow-up.
- **PipelineRunsList.tsx**: Wraps `onFilterChange` to save datasource selection on change.
  Wraps `onClearAll` to reset preference to default.
- **consts.ts**: Adds `USER_PREFERENCE_PREFIX` for consistent preference key naming.

## Behavior

| Action | Result |
|---|---|
| User selects "Archived" | Preference saved, next visit shows "Archived" |
| User selects both | Preference saved, next visit shows both |
| Clear all filters | Chips removed, all data shown. Preference reset to "Cluster" |
| Next visit after clear | "Cluster" filter applied |
| Cross-device | Preference synced via ConfigMap |
| First-time user | Default "Cluster" applied (same as current behavior) |

## Test plan

- [ ] Verify datasource filter persists across page navigation
- [ ] Verify datasource filter persists across browser sessions
- [ ] Verify "Clear all filters" removes chips and resets preference
- [ ] Verify unit tests pass (`yarn test`)

## Screen Recordings / Screenshot

https://github.com/user-attachments/assets/8c60449e-389c-4317-94d7-463e2a757399