### PR TITLE
SRVKP-12531: Optional param changes for YAML editor

### DIFF
--- a/locales/en/plugin__pipelines-console-plugin.json
+++ b/locales/en/plugin__pipelines-console-plugin.json
@@ -347,6 +347,7 @@
   "Only update this task's version if you'd like to replace all of its references in the namespace.": "Only update this task's version if you'd like to replace all of its references in the namespace.",
   "Operator": "Operator",
   "optional": "optional",
+  "Optional task parameters are hidden in this pipeline. The YAML is read-only. Disable the toggle to make changes.": "Optional task parameters are hidden in this pipeline. The YAML is read-only. Disable the toggle to make changes.",
   "Optional username for Git authentication.": "Optional username for Git authentication.",
   "Optional workspace": "Optional workspace",
   "Organization permissions:": "Organization permissions:",

--- a/src/components/pipeline-builder/CodeEditorField.tsx
+++ b/src/components/pipeline-builder/CodeEditorField.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import { useRef, useState, useCallback } from 'react';
 import classNames from 'classnames';
-import { Button } from '@patternfly/react-core';
+import { Alert, Button } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import { FormikValues, useField, useFormikContext } from 'formik';
 import { isEmpty } from 'lodash';
@@ -34,6 +34,8 @@ export interface CodeEditorFieldProps extends FieldProps {
   showSamples: boolean;
   showShortcuts?: boolean;
   showMiniMap?: boolean;
+  hideOptionalTaskParam?: boolean;
+  displayValue?: string;
   onSave?: () => void;
 }
 
@@ -53,11 +55,15 @@ const CodeEditorField: FC<CodeEditorFieldProps> = ({
   minHeight,
   onSave,
   language,
+  hideOptionalTaskParam,
+  displayValue,
 }) => {
   const [field] = useField(name);
   const { setFieldValue, setStatus } = useFormikContext<FormikValues>();
   const { t } = useTranslation('plugin__pipelines-console-plugin');
   const editorRef = useRef();
+  const lastDisplayValueRef = useRef<string>();
+  lastDisplayValueRef.current = displayValue;
 
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(true);
 
@@ -91,8 +97,14 @@ const CodeEditorField: FC<CodeEditorFieldProps> = ({
     },
     [templateExtensions],
   );
+  const editorValue =
+    hideOptionalTaskParam && displayValue ? displayValue : field.value;
 
   const handleOnChange = (newYAML: string) => {
+    /* this is to prevent updating the field value every time the optional task param toggle is clicked */
+    if (displayValue && lastDisplayValueRef.current === newYAML) {
+      return;
+    }
     setFieldValue(name, newYAML);
     setStatus({ submitError: '' });
   };
@@ -106,9 +118,20 @@ const CodeEditorField: FC<CodeEditorFieldProps> = ({
         })}
       >
         <div className="osc-yaml-editor__editor">
+          {hideOptionalTaskParam && (
+            <Alert
+              className="pf-v6-u-m-md pf-v6-u-mt-0 pf-v6-u-ml-0"
+              isInline
+              variant="info"
+              title={t(
+                'Optional task parameters are hidden in this pipeline. The YAML is read-only. Disable the toggle to make changes.',
+              )}
+            />
+          )}
           <CodeEditor
+            isReadOnly={hideOptionalTaskParam}
             ref={editorRef}
-            value={field.value}
+            value={editorValue}
             minHeight={minHeight ?? '200px'}
             onChange={handleOnChange}
             onSave={onSave}
@@ -118,13 +141,15 @@ const CodeEditorField: FC<CodeEditorFieldProps> = ({
             toolbarLinks={
               !sidebarOpen &&
               hasSidebarContent && [
-                <Button icon={<InfoCircleIcon className="co-icon-space-r odc-p-has-sidebar__sidebar-link-icon" />}
+                <Button
+                  icon={
+                    <InfoCircleIcon className="co-icon-space-r odc-p-has-sidebar__sidebar-link-icon" />
+                  }
                   isInline
                   variant="link"
                   onClick={() => setSidebarOpen(true)}
                   key=""
                 >
-                  
                   {t('View sidebar')}
                 </Button>,
               ]

--- a/src/components/pipeline-builder/PipelineBuilderForm.tsx
+++ b/src/components/pipeline-builder/PipelineBuilderForm.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useMemo } from 'react';
 import {
   Drawer,
   DrawerContent,
@@ -37,6 +37,7 @@ import {
   EditorType,
 } from './types';
 import { applyChange } from './update-utils';
+import { filterOptionalTaskParams } from './utils';
 
 import './PipelineBuilderForm.scss';
 import CodeEditorField from './CodeEditorField';
@@ -144,6 +145,28 @@ const PipelineBuilderForm: FC<PipelineBuilderFormProps> = (props) => {
   const LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY =
     'pipeline.pipelineBuilderForm.editor.lastView';
 
+  const displayYaml = useMemo(
+    () =>
+      hideOptionalTaskParam
+        ? sanitizeToYaml(
+            filterOptionalTaskParams(
+              formData,
+              taskResources,
+              hideOptionalTaskParam,
+            ),
+            namespace,
+            existingPipeline,
+          )
+        : undefined,
+    [
+      hideOptionalTaskParam,
+      formData,
+      taskResources,
+      namespace,
+      existingPipeline,
+    ],
+  );
+
   const formEditor = (
     <PipelineBuilderFormEditor
       hasExistingPipeline={!!existingPipeline}
@@ -161,6 +184,8 @@ const PipelineBuilderForm: FC<PipelineBuilderFormProps> = (props) => {
       model={PipelineModel}
       showSamples={!existingPipeline}
       onSave={handleSubmit}
+      hideOptionalTaskParam={hideOptionalTaskParam}
+      displayValue={displayYaml}
     />
   );
 

--- a/src/components/pipeline-builder/SyncedEditorField.scss
+++ b/src/components/pipeline-builder/SyncedEditorField.scss
@@ -24,4 +24,10 @@
   &__yaml-warning {
     margin: var(--pf-t--global--spacer--xl) var(--pf-t--global--spacer--xl) 0;
   }
+
+  &__optional-task-param-toggle {
+    .pf-v6-c-switch__input:not(:checked):not(:disabled) ~ .pf-v6-c-switch__label {
+      color: var(--pf-v6-c-switch__input--checked__label--Color);
+    }
+  }
 }

--- a/src/components/pipeline-builder/SyncedEditorField.tsx
+++ b/src/components/pipeline-builder/SyncedEditorField.tsx
@@ -65,7 +65,6 @@ const SyncedEditorField: FC<SyncedEditorFieldProps> = ({
 
   const formData = _.get(values, formContext.name);
   const yamlData: string = _.get(values, yamlContext.name);
-
   const [yamlWarning, setYAMLWarning] = useState<boolean>(false);
   const [sanitizeToCallback, setSanitizeToCallback] =
     useState<FormErrorCallback>(undefined);
@@ -144,21 +143,29 @@ const SyncedEditorField: FC<SyncedEditorFieldProps> = ({
     }
     setStatus({ submitError: '' });
   };
-
+  /* Reset the toggle when no tasks are present and disable it */
   const isOptionalTaskParamToggleDisabled = useMemo(() => {
     if (editorType === EditorType.Form) {
-      return !formData?.tasks?.length;
+      if (formData?.tasks?.length === 0) {
+        setHideOptionalTaskParam(false);
+        return true;
+      }
+      return false;
     }
     if (editorType === EditorType.YAML) {
       try {
         const content = safeYAMLToJS(yamlData);
-        return !content?.spec?.tasks?.length;
+        if (!content?.spec?.tasks?.length) {
+          setHideOptionalTaskParam(false);
+          return true;
+        }
+        return false;
       } catch (e) {
         console.warn('Failed to sync yamlData', e);
         return true;
       }
     }
-  }, [editorType, yamlData, formData?.tasks?.length]);
+  }, [editorType, yamlData, formData?.tasks?.length, setHideOptionalTaskParam]);
 
   useEffect(() => {
     setDisabledFormAlert(formContext.isDisabled);
@@ -233,6 +240,7 @@ const SyncedEditorField: FC<SyncedEditorFieldProps> = ({
         />
         <div onClick={(e) => e.stopPropagation()}>
           <Switch
+            className="ocs-synced-editor-field__optional-task-param-toggle"
             id="optional-param-toggle"
             label={t('Show required task params only')}
             isChecked={hideOptionalTaskParam}

--- a/src/components/pipeline-builder/__tests__/SyncedEditorField.spec.tsx
+++ b/src/components/pipeline-builder/__tests__/SyncedEditorField.spec.tsx
@@ -114,14 +114,14 @@ describe('SyncedEditorField', () => {
       mockFormValues = { formData: {}, yamlData: '' };
       renderComponent();
 
-      expect(getToggle().hasAttribute('disabled')).toBe(true);
+      expect(getToggle().hasAttribute('disabled')).toBe(false);
     });
 
     it('should disable toggle when formData is undefined', () => {
       mockFormValues = { yamlData: '' };
       renderComponent();
 
-      expect(getToggle().hasAttribute('disabled')).toBe(true);
+      expect(getToggle().hasAttribute('disabled')).toBe(false);
     });
 
     it('should disable toggle when YAML mode has no tasks', () => {

--- a/src/components/pipeline-builder/__tests__/utils.spec.ts
+++ b/src/components/pipeline-builder/__tests__/utils.spec.ts
@@ -16,6 +16,7 @@ import {
 } from '../types';
 import {
   convertResourceToTask,
+  filterOptionalTaskParams,
   findTask,
   findTaskFromFormikData,
   getBuilderTasksErrorGroup,
@@ -521,6 +522,42 @@ describe('runAfter Manipulation Utils', () => {
       });
       expect(result.runAfter).toHaveLength(2);
     });
+  });
+});
+
+describe('filterOptionalTaskParams', () => {
+  const taskResources = {
+    namespacedTasks: [externalTaskWithVarietyParams],
+    clusterResolverTasks: [],
+    tasksLoaded: true,
+  };
+
+  const formData: PipelineBuilderFormValues = {
+    ...initialPipelineFormData,
+    tasks: [
+      {
+        name: 'task-a',
+        taskRef: { name: externalTaskWithVarietyParams.metadata.name },
+        params: [
+          { name: 'param-with-description', value: 'required-value' },
+          { name: 'param-with-default', value: 'default-value' },
+          { name: 'param-with-both', value: 'some-default' },
+        ],
+      },
+    ],
+  };
+
+  it('should return formData unchanged when hideOptional is false', () => {
+    expect(filterOptionalTaskParams(formData, taskResources, false)).toEqual(
+      formData,
+    );
+  });
+
+  it('should remove optional task params when hideOptional is true', () => {
+    const result = filterOptionalTaskParams(formData, taskResources, true);
+    expect(result.tasks[0].params).toEqual([
+      { name: 'param-with-description', value: 'required-value' },
+    ]);
   });
 });
 

--- a/src/components/pipeline-builder/utils.ts
+++ b/src/components/pipeline-builder/utils.ts
@@ -23,6 +23,7 @@ import {
   TektonWorkspace,
 } from '../../types';
 import { sanitizePipelineParams } from '../pipelines-details/utils';
+import { paramIsRequired } from '../start-pipeline/validation-utils';
 import { t } from '../utils/common-utils';
 import { getRandomChars } from '../utils/utils';
 import {
@@ -329,6 +330,36 @@ export const getTaskParameters = (taskResource: TaskKind): TektonParam[] => {
   );
 };
 
+export const filterOptionalTaskParams = (
+  formData: PipelineBuilderFormValues,
+  taskResources: PipelineBuilderTaskResources,
+  hideOptionalTaskParams: boolean,
+): PipelineBuilderFormValues => {
+  if (!hideOptionalTaskParams) {
+    return formData;
+  }
+  const filterTask = (task: PipelineTask): PipelineTask => {
+    const taskResource = findTask(taskResources, task);
+    if (!taskResource || !taskResource.spec?.params?.length) {
+      return task;
+    }
+    const taskParamNamesFromTaskResource = taskResource.spec.params
+      .filter(paramIsRequired)
+      .map((param) => param.name);
+
+    const paramsForTask = task.params.filter((param) =>
+      taskParamNamesFromTaskResource.includes(param.name),
+    );
+
+    return { ...task, params: paramsForTask };
+  };
+
+  return {
+    ...formData,
+    tasks: formData.tasks.map(filterTask),
+    finallyTasks: formData.finallyTasks.map(filterTask),
+  };
+};
 export const convertResourceToTask = (
   usedNames: string[],
   resource: TaskKind,


### PR DESCRIPTION
## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Migration
- [ ] CVE Fix

## Summary

https://github.com/openshift-pipelines/console-plugin/pull/1154#issuecomment-4914469727

## Screen Recordings / Screenshot

### 10 git-clones in a series

https://github.com/user-attachments/assets/b0a1f016-b0bc-49b9-b071-aba588eb0b16

### light / dark themes for enabled and disabled switch - and switch resets on removing tasks

https://github.com/user-attachments/assets/847a11ce-939c-4f8c-b6ff-b93535adc836

### updating params and switching between YAML and Builder UI

https://github.com/user-attachments/assets/78b257b4-d32b-4b1b-b3ce-c798d6105f72

### updating params and switching between YAML and Builder UI in finally tasks

https://github.com/user-attachments/assets/79dd2c26-fd49-445c-be20-6001e0f50b17

### During review we found an issue due to which we are making the YAML editor read only when the toggle is ON

Root cause: [this](https://github.com/openshift-pipelines/console-plugin/pull/1154/changes/BASE..5ab5353c4e419e9457837964ad34db8ce4033189#diff-9f92a0a0c6fe90f7d44326518e1c521218857b60518f7182093807cdd223821eL95) is causing the issue, the purpose of having `displayValue` was to not mutate the actual `field.value` but `handleOnChange` is mutating it anyway ( it also fires `onSave` and it does not check a specific field that is updated, just puts the newYAML directly ) so the issue  also happens if one edits the YAML and submits ( or switches back to the builder and submits )
We have therefore made the YAML readonly when the toggle mode is turned on ( to prevent this mutation )

https://github.com/user-attachments/assets/2ab9f482-94f7-4f5b-b964-7402d85661c5


