### PR TITLE
fix(pipeline-augment): scope PipelineRun match to Pipeline namespace

### DIFF
--- a/src/components/utils/__tests__/pipeline-augment-test-data.ts
+++ b/src/components/utils/__tests__/pipeline-augment-test-data.ts
@@ -24,6 +24,7 @@ export const testData: PipelineAugmentData[] = [
         kind: 'PipelineRun',
         metadata: {
           name: 'apple-1-run1',
+          namespace: 'myproject',
           creationTimestamp: '21-05-2019',
           labels: { 'tekton.dev/pipeline': 'apple1' },
         },
@@ -40,13 +41,13 @@ export const testData: PipelineAugmentData[] = [
       {
         metadata: {
           name: 'apple1',
-          namespace: 'myproject',
+          namespace: 'tekton-pipelines',
         },
       },
       {
         metadata: {
           name: 'apple2',
-          namespace: 'myproject',
+          namespace: 'tekton-pipelines',
         },
       },
     ],
@@ -84,8 +85,42 @@ export const testData: PipelineAugmentData[] = [
         kind: 'PipelineRun',
         metadata: {
           name: 'apple-2-run1',
+          namespace: 'tekton-pipelines',
           creationTimestamp: '31-04-2019',
           labels: { 'tekton.dev/pipeline': 'apple2' },
+        },
+        spec: {},
+        status: {
+          pipelineSpec: { tasks: [] },
+          conditions: [{ type: 'Succeeded', status: 'True' }],
+        },
+      },
+    ],
+  },
+  {
+    pipelines: [
+      {
+        metadata: {
+          name: 'simple-pipeline',
+          namespace: 'ns-a',
+        },
+      },
+      {
+        metadata: {
+          name: 'simple-pipeline',
+          namespace: 'ns-b',
+        },
+      },
+    ],
+    pipelineruns: [
+      {
+        apiVersion: 'tekton.dev/v1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'simple-pipeline-run-1',
+          namespace: 'ns-a',
+          creationTimestamp: '2026-07-10T01:23:45Z',
+          labels: { 'tekton.dev/pipeline': 'simple-pipeline' },
         },
         spec: {},
         status: {

--- a/src/components/utils/__tests__/pipeline-augment.spec.ts
+++ b/src/components/utils/__tests__/pipeline-augment.spec.ts
@@ -54,6 +54,25 @@ describe('PipelineAugment test correct data is augmented', () => {
       testData[3].pipelineruns[0].metadata.name,
     );
   });
+
+  it('expect a PipelineRun to only be matched to the Pipeline in the same namespace', () => {
+    const newData = augmentRunsToData(
+      testData[4].pipelines,
+      testData[4].pipelineruns,
+    );
+    const pipelineWithRun = newData.find(
+      (p) => p.metadata.namespace === 'ns-a',
+    );
+    const pipelineWithoutRun = newData.find(
+      (p) => p.metadata.namespace === 'ns-b',
+    );
+
+    expect(pipelineWithRun.latestRun).toBeTruthy();
+    expect(pipelineWithRun.latestRun.metadata.name).toBe(
+      testData[4].pipelineruns[0].metadata.name,
+    );
+    expect(pipelineWithoutRun.latestRun).toBeFalsy();
+  });
 });
 
 describe('PipelineAugment test getRunStatusColor handles all ComputedStatus values', () => {

--- a/src/components/utils/pipeline-augment.ts
+++ b/src/components/utils/pipeline-augment.ts
@@ -102,6 +102,7 @@ export const augmentRunsToData = (
   return pipelines.map((pipeline) => {
     const prsForPipeline = pipelineruns.filter(
       (pr) =>
+        pr.metadata.namespace === pipeline.metadata.namespace &&
         pr.metadata.labels?.['tekton.dev/pipeline'] === pipeline.metadata.name,
     );
     pipeline.latestRun = getLatestRun(prsForPipeline, 'creationTimestamp');


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Migration
- [ ] CVE Fix

## Summary

`augmentRunsToData()` matched `PipelineRun`s to `Pipeline`s using only the `tekton.dev/pipeline` label, without checking that the `PipelineRun`'s namespace matches the `Pipeline`'s namespace.
In the Pipelines list "All Projects" view, this caused every `Pipeline` with the same name across different namespaces to show the same "Last run", even when the `PipelineRun` only existed in one of those namespaces.

Fixes #1168

Fix: added a namespace equality check to the existing label match in `augmentRunsToData`.

Test plan:
- Added a regression test in `pipeline-augment.spec.ts` reproducing the bug: two `Pipeline`s with the same name in different namespaces, only one of which has a matching `PipelineRun`. Confirmed it fails before the fix and passes after.
- Adjusted pre-existing test fixtures (`pipeline-augment-test-data.ts`) that had `Pipeline`/`PipelineRun` namespace mismatches, so they keep passing under the new namespace-aware matching.
- Ran the full test suite: all passing (1 pre-existing skip, unrelated to this change).
- `eslint` on changed files: no issues.

## Screen Recordings / Screenshot

### Before

Screen recordings for before/after.

**Before**: When a `create-table` Pipeline was run in only one namespace, every namespace that had a Pipeline with the same name showed that run — the `create-table-ixlmy2` PipelineRun appeared across all of them, all with the same timestamp (`Jul 10, 2026, 3:23 PM`).

<img width="1398" height="888" alt="image" src="https://github.com/user-attachments/assets/f46cf97e-d68b-40b8-9295-2b37991ca29d" />

**After** this fix, only the namespace where the Pipeline actually ran shows a result — each namespace now shows its own PipelineRun.

<img width="1398" height="559" alt="image" src="https://github.com/user-attachments/assets/4f4c76d2-c65f-4553-b002-1b813a27dbaa" />

