### PR TITLE
SRVKP-12726: display child pipelineruns in a separate tab under PipelineRun Details page

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -723,6 +723,40 @@
         "kind": "PipelineRun"
       },
       "page": {
+        "name": "%plugin__pipelines-console-plugin~PipelineRuns%",
+        "href": "pipeline-runs"
+      },
+      "component": {
+        "$codeRef": "pipelineRunDetails.PipelineRunChildPipelineRunsList"
+      }
+    }
+  },
+  {
+    "type": "console.tab/horizontalNav",
+    "properties": {
+      "model": {
+        "group": "tekton.dev",
+        "version": "v1beta1",
+        "kind": "PipelineRun"
+      },
+      "page": {
+        "name": "%plugin__pipelines-console-plugin~PipelineRuns%",
+        "href": "pipeline-runs"
+      },
+      "component": {
+        "$codeRef": "pipelineRunDetails.PipelineRunChildPipelineRunsList"
+      }
+    }
+  },
+  {
+    "type": "console.tab/horizontalNav",
+    "properties": {
+      "model": {
+        "group": "tekton.dev",
+        "version": "v1",
+        "kind": "PipelineRun"
+      },
+      "page": {
         "name": "%plugin__pipelines-console-plugin~ApprovalTasks%",
         "href": "approval-tasks"
       },

--- a/locales/en/plugin__pipelines-console-plugin.json
+++ b/locales/en/plugin__pipelines-console-plugin.json
@@ -310,6 +310,7 @@
   "No {{resourceName}} results available due to failure": "No {{resourceName}} results available due to failure",
   "No {{resourceType}} resource": "No {{resourceType}} resource",
   "No approvers": "No approvers",
+  "No child pipeline runs found": "No child pipeline runs found",
   "No default StorageClass": "No default StorageClass",
   "No display name": "No display name",
   "No events": "No events",

--- a/src/components/pipelineRuns-details/PipelineRunChildPipelineRunsList.tsx
+++ b/src/components/pipelineRuns-details/PipelineRunChildPipelineRunsList.tsx
@@ -1,0 +1,86 @@
+import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  K8sResourceKind,
+  ListPageBody,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { ConsoleDataView } from '@openshift-console/dynamic-plugin-sdk-internal';
+import { EmptyState, EmptyStateBody } from '@patternfly/react-core';
+import { PipelineRunKind } from '../../types';
+import usePipelineRunsColumns from '../pipelineRuns-list/usePipelineRunsColumns';
+import { getPipelineRunsListDataViewRows } from '../pipelineRuns-list/PipelineRunsRow';
+import { useGetActiveUser } from '../hooks/hooks';
+import {
+  useChildPipelineRunReferences,
+  useChildPipelineRuns,
+} from '../hooks/useChildPipelineRuns';
+
+import '../multi-tab-list/MultiTabListPage.scss';
+import { DataViewFilterToolbar } from '../common/DataViewFilterToolbar';
+import { useDataViewFilter } from '../hooks/useDataViewFilter';
+
+type PipelineRunChildPipelineRunsListProps = {
+  ns?: string;
+  obj?: K8sResourceKind;
+};
+
+const PipelineRunChildPipelineRunsList: FC<
+  PipelineRunChildPipelineRunsListProps
+> = ({ obj }) => {
+  const { t } = useTranslation('plugin__pipelines-console-plugin');
+  const pipelineRun = obj as PipelineRunKind;
+  const namespace = pipelineRun?.metadata?.namespace;
+  const childPipelineRunRefs = useChildPipelineRunReferences(pipelineRun);
+  const [childPipelineRuns, allLoaded] = useChildPipelineRuns(
+    namespace,
+    childPipelineRunRefs,
+    { depth: 1 },
+  );
+  const currentUser = useGetActiveUser();
+  const columns = usePipelineRunsColumns(namespace);
+
+  const {
+    filterValues,
+    onFilterChange,
+    onClearAll,
+    filteredData,
+    updatedCheckboxFilters,
+  } = useDataViewFilter<PipelineRunKind>({
+    data: childPipelineRuns || [],
+    options: {
+      resourceType: 'PipelineRun',
+      defaultDataSourceValues: ['cluster-data'],
+    },
+  });
+
+  if (!childPipelineRunRefs?.length) {
+    return (
+      <EmptyState>
+        <EmptyStateBody>{t('No child pipeline runs found')}</EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  return (
+    <ListPageBody>
+      <DataViewFilterToolbar
+        filterValues={filterValues}
+        onFilterChange={onFilterChange}
+        onClearAll={onClearAll}
+        checkboxFilters={updatedCheckboxFilters}
+      />
+      <ConsoleDataView<PipelineRunKind>
+        label={t('PipelineRuns')}
+        columns={columns}
+        data={filteredData}
+        loaded={allLoaded}
+        getDataViewRows={getPipelineRunsListDataViewRows}
+        customRowData={{ currentUser }}
+        hideColumnManagement
+        hideNameLabelFilters
+      />
+    </ListPageBody>
+  );
+};
+
+export default PipelineRunChildPipelineRunsList;

--- a/src/components/pipelineRuns-details/index.ts
+++ b/src/components/pipelineRuns-details/index.ts
@@ -1,3 +1,4 @@
 export { LogURLRedirect } from './LogURLRedirect';
+export { default as PipelineRunChildPipelineRunsList } from './PipelineRunChildPipelineRunsList';
 export { default as PipelineRunDetails } from './PipelineRunDetails';
 export { default as PipelineRunDetailsPage } from './PipelineRunDetailsPage';

--- a/src/components/pipelineRuns-list/PipelineRunsList.tsx
+++ b/src/components/pipelineRuns-list/PipelineRunsList.tsx
@@ -14,6 +14,7 @@ import { DataViewFilterToolbar } from '../common/DataViewFilterToolbar';
 import { useDateRangeFilter } from '../hooks/useDateRangeFilter';
 
 import './PipelineRunsList.scss';
+import { isChildPipelineRun } from '../utils/pipeline-utils';
 
 type PipelineRunsListProps = {
   namespace?: string;
@@ -65,7 +66,7 @@ const PipelineRunsList: FC<PipelineRunsListProps> = ({
     filteredData,
     updatedCheckboxFilters,
   } = useDataViewFilter<PipelineRunKind>({
-    data: pipelineRuns || [],
+    data: (pipelineRuns || []).filter((r) => !isChildPipelineRun(r)),
     options: {
       resourceType: 'PipelineRun',
     },

--- a/src/components/utils/pipeline-utils.ts
+++ b/src/components/utils/pipeline-utils.ts
@@ -793,3 +793,8 @@ export const isPipelineInPipelineRun = (
     (child) => child.kind === 'PipelineRun',
   ) ||
   pipelineRun?.status?.pipelineSpec?.tasks?.some((item) => item.pipelineRef);
+
+export const isChildPipelineRun = (pipelineRun: K8sResourceKind): boolean =>
+  pipelineRun?.metadata?.ownerReferences?.some(
+    (ref) => ref.kind === 'PipelineRun',
+  ) ?? false;


### PR DESCRIPTION
## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Migration
- [ ] CVE Fix

## Summary

AI Generated PR summary in [comment](https://github.com/openshift-pipelines/console-plugin/pull/1179#issuecomment-4999232695)

## Screen Recordings / Screenshot

**Part 1 - ChildPipelineRuns listed in separate tab `PipelineRuns` in PipelineRun Details page and ChildPipelineRuns not displayed in the PipelineRuns List page**

https://github.com/user-attachments/assets/dfbc0707-d226-4157-ae22-bf04af45c2f1

**Part 2 - ChildPipelineRuns for a 3 level nested PinP**

https://github.com/user-attachments/assets/c6e530db-72a7-48cc-9637-521b5719ec6b

**Part 3 - PipelineRuns list tab under PipelineDetails page not having any child pipeline runs**

https://github.com/user-attachments/assets/6a18e65e-7bd9-40c8-bee0-e3ccfaaaa2bb


