### PR TITLE
SRVKP-12329: Add date range filter for TaskRuns list page

### DIFF
--- a/src/components/hooks/useDataViewFilter.ts
+++ b/src/components/hooks/useDataViewFilter.ts
@@ -122,7 +122,7 @@ const RESOURCE_FILTER_CONFIG: Record<ResourceType, ResourceFilterConfig> = {
     statusFilter: pipelineRunStatusFilter,
     statusReducer: pipelineRunFilterReducer,
     hasDataSourceFilter: true,
-    hasDateRangeFilter: false,
+    hasDateRangeFilter: true,
     defaultDataSourceValues: ['cluster-data'],
     getOptionLabel: (id) => ListFilterLabels[id],
   },

--- a/src/components/hooks/useTaskRuns.ts
+++ b/src/components/hooks/useTaskRuns.ts
@@ -71,6 +71,7 @@ export type UseTaskRunsOptions = {
   skipFetch?: boolean;
   name?: string /* used for fetching a single task run by metadata.name */;
   limit?: number /* used for fetching a limited number of task runs */;
+  dateRangeFilter?: string;
 };
 
 export const useTaskRuns = (
@@ -80,8 +81,14 @@ export const useTaskRuns = (
   pipelineRunUid?: string,
   options?: UseTaskRunsOptions,
 ): [TaskRunKind[], boolean, boolean, Error | undefined, boolean, boolean] => {
-  const { pipelineRunFinished, pipelineRunManagedBy, skipFetch, name, limit } =
-    options || {};
+  const {
+    pipelineRunFinished,
+    pipelineRunManagedBy,
+    skipFetch,
+    name,
+    limit,
+    dateRangeFilter,
+  } = options || {};
   const selector: Selector = useMemo(() => {
     if (pipelineRunName && pipelineRunUid) {
       return {
@@ -111,7 +118,7 @@ export const useTaskRuns = (
   ] = useRuns<TaskRunKind>(
     TASK_RUN_GVK,
     namespace,
-    { selector, skipFetch, name, limit },
+    { selector, skipFetch, name, limit, filter: dateRangeFilter },
     pipelineRunFinished,
     pipelineRunManagedBy,
   );

--- a/src/components/pipelines-tasks/TaskRunsList.tsx
+++ b/src/components/pipelines-tasks/TaskRunsList.tsx
@@ -49,6 +49,7 @@ import { useDataViewFilter } from '../hooks/useDataViewFilter';
 import { ComputedStatus, PipelineRunKind } from '../../types';
 import { pipelineRunFilterReducer } from '../utils/pipeline-filter-reducer';
 import './TasksNavigationPage.scss';
+import { useDateRangeFilter } from '../hooks/useDateRangeFilter';
 
 const taskRunModelRef = getReferenceForModel(TaskRunModel);
 
@@ -301,6 +302,8 @@ const TaskRunsList: FC<TaskRunsListPageProps> = ({
     selectedColumns: new Set(activeColumns.map((col) => col.id)),
   };
 
+  const { dateFilterCEL } = useDateRangeFilter('TaskRun');
+
   const [taskRuns, k8sLoaded, trLoaded, loadError] = useTaskRuns(
     ns,
     parentName,
@@ -309,6 +312,7 @@ const TaskRunsList: FC<TaskRunsListPageProps> = ({
     {
       pipelineRunFinished,
       pipelineRunManagedBy: pipelineRun?.spec?.managedBy,
+      dateRangeFilter: dateFilterCEL,
     },
   );
 

--- a/src/components/pipelines-tasks/__tests__/TaskRunsList.spec.tsx
+++ b/src/components/pipelines-tasks/__tests__/TaskRunsList.spec.tsx
@@ -1,0 +1,212 @@
+import { render, screen } from '@testing-library/react';
+import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
+import { ConsoleDataView } from '@openshift-console/dynamic-plugin-sdk-internal';
+import TaskRunsList from '../TaskRunsList';
+import { useTaskRuns } from '../../hooks/useTaskRuns';
+import { useDateRangeFilter } from '../../hooks/useDateRangeFilter';
+import type { TaskRunKind } from '../../../types';
+import type { DateRangeFilterResult } from '../../hooks/useDateRangeFilter';
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  useFlag: jest.fn(),
+  ListPageBody: ({ children }) => <div>{children}</div>,
+  ListPageCreateLink: ({ children }) => <div>{children}</div>,
+  getGroupVersionKindForModel: jest.fn((model) => ({
+    group: model?.apiGroup,
+    version: model?.apiVersion,
+    kind: model?.kind,
+  })),
+  useK8sWatchResource: jest.fn(() => [[], true, undefined]),
+  useActiveColumns: jest.fn(() => [[], jest.fn()]),
+  ResourceLink: () => null,
+  Timestamp: () => null,
+}));
+jest.mock('@openshift-console/dynamic-plugin-sdk-internal', () => ({
+  ConsoleDataView: jest.fn(() => null),
+  getNameCellProps: jest.fn(),
+  actionsCellProps: {},
+  cellIsStickyProps: {},
+  LazyActionMenu: () => null,
+}));
+jest.mock('react-router', () => ({
+  useParams: () => ({ ns: 'test-ns' }),
+  useSearchParams: () => [new URLSearchParams(), jest.fn()],
+}));
+jest.mock('@patternfly/react-icons', () => ({
+  ArchiveIcon: () => null,
+}));
+jest.mock('@patternfly/react-core', () => ({
+  Tooltip: ({ children }) => <div>{children}</div>,
+}));
+jest.mock('../../hooks/useTaskRuns');
+jest.mock('../../hooks/useDateRangeFilter');
+jest.mock('../../hooks/useDataViewFilter', () => ({
+  useDataViewFilter: ({ data }) => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { useDateRangeFilter } = require('../../hooks/useDateRangeFilter');
+    const { startDate, preferenceLoaded } = useDateRangeFilter('taskRun');
+    const filtered = startDate
+      ? data.filter((obj) => {
+          const st = obj.status?.startTime;
+          if (!st) return true;
+          return new Date(st).getTime() > startDate;
+        })
+      : data;
+    return {
+      filterValues: {},
+      onFilterChange: jest.fn(),
+      onClearAll: jest.fn(),
+      filteredData: filtered,
+      updatedCheckboxFilters: preferenceLoaded
+        ? [{ id: 'timeRange', singleSelect: true, options: [] }]
+        : [],
+      preferenceLoaded: preferenceLoaded ?? true,
+    };
+  },
+}));
+jest.mock('../../common/DataViewFilterToolbar', () => ({
+  DataViewFilterToolbar: ({ checkboxFilters }) => (
+    <div data-testid="filter-toolbar">
+      {checkboxFilters?.map((f) =>
+        f.singleSelect ? (
+          <span key={f.id} data-testid={`filter-${f.id}`} />
+        ) : null,
+      )}
+    </div>
+  ),
+}));
+jest.mock('../TaskRunStatus', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('../../utils/resource-link', () => ({
+  ResourceLinkWithIcon: () => null,
+}));
+jest.mock('../../utils/pipeline-augment', () => ({
+  getModelReferenceFromTaskKind: jest.fn(),
+}));
+jest.mock('../../utils/pipeline-utils', () => ({
+  pipelineRunDuration: jest.fn(() => '-'),
+}));
+jest.mock('../../pipelines-details/pipeline-step-utils', () => ({
+  sortPipelineAndTaskRunsByDuration: jest.fn(() => []),
+}));
+jest.mock('../../pipelines-overview/utils', () => ({
+  getReferenceForModel: jest.fn(() => 'tekton.dev~v1~TaskRun'),
+}));
+jest.mock('../../utils/pipeline-filter-reducer', () => ({
+  taskRunFilterReducer: jest.fn(() => 'Succeeded'),
+  pipelineRunFilterReducer: jest.fn(() => 'Succeeded'),
+}));
+
+const useFlagMock = useFlag as jest.Mock;
+const useTaskRunsMock = useTaskRuns as jest.Mock;
+const useDateRangeFilterMock = useDateRangeFilter as jest.Mock;
+const consoleDataViewMock = ConsoleDataView as jest.Mock;
+
+const ONE_DAY_MS = 86400000;
+
+const makeDateRange = (
+  overrides?: Partial<DateRangeFilterResult>,
+): DateRangeFilterResult => ({
+  timespan: 0,
+  setTimespanDateFilter: jest.fn(),
+  startDate: undefined,
+  dateFilterCEL: '',
+  preferenceLoaded: true,
+  ...overrides,
+});
+
+const makeTaskRun = (name: string, startTime?: string): TaskRunKind =>
+  ({
+    apiVersion: 'tekton.dev/v1',
+    kind: 'TaskRun',
+    metadata: { name, namespace: 'test-ns', uid: name },
+    spec: {},
+    status: startTime ? { startTime } : {},
+  }) as unknown as TaskRunKind;
+
+describe('TaskRunsList', () => {
+  beforeEach(() => {
+    useFlagMock.mockReturnValue(true);
+    consoleDataViewMock.mockReturnValue(null);
+    useDateRangeFilterMock.mockReturnValue(makeDateRange());
+    useTaskRunsMock.mockReturnValue([[], true, true, undefined, false, false]);
+  });
+
+  it('should pass dateFilterCEL to useTaskRuns via dateRangeFilter option', () => {
+    const cel =
+      'data.status.startTime > timestamp("2026-07-10T00:00:00.000Z")';
+    useDateRangeFilterMock.mockReturnValue(
+      makeDateRange({ dateFilterCEL: cel }),
+    );
+    render(<TaskRunsList />);
+    expect(useTaskRunsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined,
+      undefined,
+      undefined,
+      expect.objectContaining({ dateRangeFilter: cel }),
+    );
+  });
+
+  it('should filter out old runs client-side', () => {
+    const now = Date.now();
+    const recent = makeTaskRun('recent', new Date(now - 1000).toISOString());
+    const old = makeTaskRun(
+      'old',
+      new Date(now - 2 * ONE_DAY_MS).toISOString(),
+    );
+    useTaskRunsMock.mockReturnValue([
+      [recent, old],
+      true,
+      true,
+      undefined,
+      false,
+      false,
+    ]);
+    useDateRangeFilterMock.mockReturnValue(
+      makeDateRange({ timespan: ONE_DAY_MS, startDate: now - ONE_DAY_MS }),
+    );
+    render(<TaskRunsList />);
+    const dataArg = consoleDataViewMock.mock.calls[0][0].data;
+    expect(dataArg).not.toContainEqual(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ name: 'old' }),
+      }),
+    );
+  });
+
+  it('should keep runs without startTime (pending)', () => {
+    const now = Date.now();
+    const pending = makeTaskRun('pending');
+    useTaskRunsMock.mockReturnValue([
+      [pending],
+      true,
+      true,
+      undefined,
+      false,
+      false,
+    ]);
+    useDateRangeFilterMock.mockReturnValue(
+      makeDateRange({ timespan: ONE_DAY_MS, startDate: now - ONE_DAY_MS }),
+    );
+    render(<TaskRunsList />);
+    const dataArg = consoleDataViewMock.mock.calls[0][0].data;
+    expect(dataArg).toContainEqual(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ name: 'pending' }),
+      }),
+    );
+  });
+
+  it('should include time range as a singleSelect checkbox filter', () => {
+    render(<TaskRunsList />);
+    expect(screen.getByTestId('filter-timeRange')).toBeTruthy();
+  });
+
+  it('should hide filters when hideNameLabelFilters is true', () => {
+    render(<TaskRunsList hideNameLabelFilters />);
+    expect(screen.queryByTestId('filter-toolbar')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Migration
- [ ] CVE Fix

## Summary

Adds date range (time range) filter to the TaskRuns list page, allowing users to filter TaskRuns by time period (Last day, Last week, etc.) with server-side and client-side filtering. Selection is persisted to the user-settings ConfigMap.

## Changes

- `useDataViewFilter.ts`: Set hasDateRangeFilter: true for TaskRun in RESOURCE_FILTER_CONFIG
- `useTaskRuns.ts`: Add dateRangeFilter option to UseTaskRunsOptions, pass it as filter to useRuns
- `TaskRunsList.tsx`: Call useDateRangeFilter('TaskRun'), pass dateFilterCEL to useTaskRuns
- `TaskRunsList.spec.tsx`: Add unit tests for date range filter integration