### PR TITLE
SRVKP-12917: Clear all filters should clear datasource instead of resetting to default

### DIFF
--- a/src/components/hooks/__tests__/useDatasourcePreference.spec.ts
+++ b/src/components/hooks/__tests__/useDatasourcePreference.spec.ts
@@ -47,12 +47,12 @@ describe('useDatasourcePreference', () => {
     expect(setPreferenceMock).toHaveBeenCalledWith(['archived-data']);
   });
 
-  it('should reset preference to default', () => {
+  it('should clear preference to empty array', () => {
     const { result } = testHook(() =>
       useDatasourcePreference('pipelineRun', true),
     );
-    result.current.resetPreference();
-    expect(setPreferenceMock).toHaveBeenCalledWith(DEFAULT_DATASOURCE_VALUES);
+    result.current.clearPreference();
+    expect(setPreferenceMock).toHaveBeenCalledWith([]);
   });
 
   it('should use the correct preference key for pipelineRun', () => {

--- a/src/components/hooks/useDataViewFilter.ts
+++ b/src/components/hooks/useDataViewFilter.ts
@@ -172,7 +172,7 @@ export const useDataViewFilter = <T extends K8sResourceCommon>({
   const {
     preference: datasourcePreference,
     setPreference: setDatasourcePreference,
-    resetPreference: resetDatasourcePreference,
+    clearPreference: clearDatasourcePreference,
   } = useDatasourcePreference(resourceType, shouldPersistDataSource);
   const allStatusIds = useMemo(() => Object.values(ListFilterId), []);
 
@@ -330,10 +330,10 @@ export const useDataViewFilter = <T extends K8sResourceCommon>({
       setTimespanDateFilter(NO_DATE_RANGE_FILTER);
     }
     if (config?.hasDataSourceFilter) {
-      resetDatasourcePreference();
+      clearDatasourcePreference();
     }
     resetPage();
-  }, [resetPage, setTimespanDateFilter, resetDatasourcePreference, config]);
+  }, [resetPage, setTimespanDateFilter, clearDatasourcePreference, config]);
 
   const labelSuggestions = useMemo(() => {
     if (!data) return [];

--- a/src/components/hooks/useDatasourcePreference.ts
+++ b/src/components/hooks/useDatasourcePreference.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { USER_PREFERENCE_PREFIX } from '../../consts';
 
 export const DEFAULT_DATASOURCE_VALUES = ['cluster-data'];
+const NO_DATASOURCE_FILTER = [];
 
 // When persist is false, no ConfigMap entry is auto-created; sync is enabled when resourceType is defined.
 export const useDatasourcePreference = (
@@ -15,14 +16,14 @@ export const useDatasourcePreference = (
     !!resourceType,
   );
 
-  const resetPreference = useCallback(() => {
-    setPreference(DEFAULT_DATASOURCE_VALUES);
+  const clearPreference = useCallback(() => {
+    setPreference(NO_DATASOURCE_FILTER);
   }, [setPreference]);
 
   return {
-    preference: preference ?? DEFAULT_DATASOURCE_VALUES,
+    preference: preference ?? (loaded ? DEFAULT_DATASOURCE_VALUES : NO_DATASOURCE_FILTER),
     setPreference,
-    resetPreference,
+    clearPreference,
     loaded,
   };
 };


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Migration
- [ ] CVE Fix

## Summary

"Clear all filters" on PipelineRuns and TaskRuns pages was not fully clearing the datasource filter. Instead of removing it, it was resetting to the default value ("Cluster"), leaving the filter chip visible and data still filtered by cluster source.

## Problem

- `onClearAll` called `resetDatasourcePreference() `which set the preference to ['cluster-data'] (default) instead of [] (no filter).
- After clearing and navigating away, returning to the page caused a brief flash of "1 filter applied" because the preference fallback returned ['cluster-data'] while the ConfigMap value was still loading.

## Fix

- Added `clearPreference` method that sets the datasource preference to [], removing the filter entirely.
- Removed unused `resetPreference` method.
- Updated `onClearAll` to use `clearPreference `instead of `resetPreference`.
- Deferred the default fallback (['cluster-data']) until the preference has finished loading, preventing the flash on navigation.

## Screen Recordings / Screenshot

https://github.com/user-attachments/assets/3add1a70-8571-4492-bf96-c65ed3611040