### PR TITLE
SRVKP-13054: Fix close option for the date range filter

### DIFF
--- a/src/components/hooks/useDataViewFilter.ts
+++ b/src/components/hooks/useDataViewFilter.ts
@@ -304,9 +304,10 @@ export const useDataViewFilter = <T extends K8sResourceCommon>({
   const onFilterChange = useCallback(
     (key: string, value: string | string[]) => {
       if (key === 'timeRange') {
+        const selected = Array.isArray(value) ? value[0] : value;
         setTimespanDateFilter(
-          value
-            ? parseDurationForDateRangeFiltering(value as string)
+          selected
+            ? parseDurationForDateRangeFiltering(selected)
             : NO_DATE_RANGE_FILTER,
         );
         resetPage();


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Migration
- [ ] CVE Fix

## Summary
The date range filter chip's close (X) button was not clearing the filter. When clicking X, deleteChip removes the value from the array producing [], then calls `onFilterChange('timeRange', [])`. Since empty arrays are truthy in JavaScript, the old code `value ? parseDurationForDateRangeFiltering(value as string) : NO_DATE_RANGE_FILTER` would enter the truthy branch and try to parse [] as a string instead of clearing the filter.
