### PR TITLE
SRVKP-12826,SRVKP-12637,SRVKP-12856,SRVKP-12812: cve fix - adding resolution for js-yaml and lock file refresh for node tar, fast-uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
   "resolutions": {
     "webpack": "^5.100.0",
     "@types/d3-dispatch": "3.0.6",
-    "@types/d3-selection": "3.0.10"
+    "@types/d3-selection": "3.0.10",
+    "js-yaml@4.2.0": "4.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10301,14 +10301,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.2.0":
-  version: 4.2.0
-  resolution: "js-yaml@npm:4.2.0"
+"js-yaml@npm:4.3.0, js-yaml@npm:^4.1.0":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 
@@ -10321,17 +10321,6 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^4.1.0":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Migration
- [x] CVE Fix

## Summary
cve fix - adding resolution for js-yaml and lock file refresh for node tar, fast-uri
## Screen Recordings / Screenshot

**yarn why**
<img width="778" height="432" alt="SRVKP-12826-yarn-why" src="https://github.com/user-attachments/assets/f5b9ffba-a3ba-49e8-89a6-e62ded836c7b" />

**yarn test**
<img width="990" height="721" alt="SRVKP-12826-yarn-test" src="https://github.com/user-attachments/assets/6689dd6d-bb80-4cc7-a372-4a2b6063a6e0" />

**yarn build**
<img width="826" height="745" alt="Screenshot 2026-07-27 at 1 02 14 PM" src="https://github.com/user-attachments/assets/15f2f4a7-0f9b-43de-8f4a-2f70b7a1ba9b" />

**UI Sanity**

https://github.com/user-attachments/assets/8e2a23f7-464a-4f9b-b83c-2b14e0ebd565

