### PR TITLE
SRVKP-12864, SRVKP-12640, SRVKP-12806, SRVKP-12824: cve fix - adding resolution for js-yaml and lock file refresh for node tar, fast-uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,6 +188,8 @@
     "webpack": "5.94.0",
     "@types/d3-dispatch": "3.0.6",
     "@types/d3-selection": "3.0.10",
-    "protobufjs": "^7.5.5"
+    "protobufjs": "^7.5.5",
+    "js-yaml@4.1.0": "4.3.0",
+    "js-yaml@4.2.0": "4.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1710,14 +1710,14 @@ __metadata:
   linkType: hard
 
 "@cucumber/query@npm:^16.0.0":
-  version: 16.0.1
-  resolution: "@cucumber/query@npm:16.0.1"
+  version: 16.1.0
+  resolution: "@cucumber/query@npm:16.1.0"
   dependencies:
     "@teppeis/multimaps": "npm:3.0.0"
     lodash.sortby: "npm:^4.7.0"
   peerDependencies:
     "@cucumber/messages": "*"
-  checksum: 10c0/e5546f97d812a378641b7b50bab9c5ed2cc0d415ab37193982eb627d947845413246f827269761dda7b5e9b18cebc23a15e7d1770e61d03bc894eda45f475a7d
+  checksum: 10c0/c19c2d0b2ac7f4ef9c5f4959bbe8d4e7a0ec2317b50912cd6ed0c3ca0fed72526040b0b841ddb126f5900b04a461a5530e09a22d35ec640f4f9d34cc73cf8597
   languageName: node
   linkType: hard
 
@@ -12290,25 +12290,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.1.0":
-  version: 4.1.0
-  resolution: "js-yaml@npm:4.1.0"
+"js-yaml@npm:4.3.0, js-yaml@npm:^4.1.0":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/184a24b4eaacfce40ad9074c64fd42ac83cf74d8c8cd137718d456ced75051229e5061b8633c3366b8aada17945a7a356b337828c19da92b51ae62126575018f
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:4.2.0":
-  version: 4.2.0
-  resolution: "js-yaml@npm:4.2.0"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 
@@ -12321,17 +12310,6 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^4.1.0":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Migration
- [x] CVE Fix

## Summary
cve fix - adding resolution for js-yaml
lock file refresh for node tar, fast-uri is done as part of [automated PR](https://github.com/openshift-pipelines/console-plugin/pull/1213)
## Screen Recordings / Screenshot
**yarn why**
<img width="686" height="476" alt="SRVKP-12864-yarn-why" src="https://github.com/user-attachments/assets/c45313bd-7479-41a9-abd2-6035497c1b81" />

**yarn test**
<img width="850" height="689" alt="SRVKP-12864-yarn-test" src="https://github.com/user-attachments/assets/198c1e16-53d1-43e8-93da-bf37154f0842" />

**yarn build**
<img width="1016" height="686" alt="SRVKP-12864-yarn-build" src="https://github.com/user-attachments/assets/0d4fcf28-cc1f-4461-a640-e3a6d325bccf" />

**UI sanity**

https://github.com/user-attachments/assets/5fc113f7-7377-4605-806e-500b61b8002a


